### PR TITLE
Remove blake2 in favour of blake2_rfc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,18 +361,6 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
-dependencies = [
- "byte-tools",
- "crypto-mac 0.7.0",
- "digest 0.8.1",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "blake2"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84ce5b6108f8e154604bd4eb76a2f726066c3464d5a552a4229262a18c9bb471"
@@ -2993,7 +2981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32bf8474159a95551661246cda4976e89356999e3cbfef36f493dacc3fae1e8e"
 dependencies = [
  "aes-gcm",
- "blake2 0.9.0",
+ "blake2",
  "chacha20poly1305",
  "rand",
  "rand_core",
@@ -3123,7 +3111,6 @@ dependencies = [
  "async-trait",
  "atomic",
  "bitflags",
- "blake2 0.8.1",
  "blake2-rfc",
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,6 @@ web-sys = { version = "0.3.44", optional = true, features = ["DomException", "St
 # TODO:
 anyhow = "1.0.31"  # TODO: wasmtime returns these errors for some reason
 bitflags = "1.2.1"  # TODO: I hate bitflags
-blake2 = "0.8.1"  # TODO: should be merged with blake2-rfc
 bytes = "0.5.0"  # TODO: I hate bytes
 impl-serde = "0.2.3"  # TODO: that looks like a hack
 parity-scale-codec = { version = "1.0.0", features = ["derive"] } # TODO: a lot of unnecessary overhead in terms of memory allocations

--- a/bin/browser-node/src/lib.rs
+++ b/bin/browser-node/src/lib.rs
@@ -23,7 +23,10 @@ use futures::{
     prelude::*,
 };
 use libp2p::wasm_ext::{ffi, ExtTransport};
-use std::{collections::HashMap, num::{NonZeroU32, NonZeroU64}};
+use std::{
+    collections::HashMap,
+    num::{NonZeroU32, NonZeroU64},
+};
 use substrate_lite::{
     chain, chain::sync::headers_optimistic, chain_spec, database, header, json_rpc, network,
     verify::babe,
@@ -345,8 +348,10 @@ async fn start_network(
             known_addresses,
             chain_spec_protocol_id: chain_spec.protocol_id().as_bytes().to_vec(),
             tasks_executor: Box::new(|fut| wasm_bindgen_futures::spawn_local(fut)),
-            local_genesis_hash: substrate_lite::calculate_genesis_block_header(chain_spec.genesis_storage())
-                .hash(),
+            local_genesis_hash: substrate_lite::calculate_genesis_block_header(
+                chain_spec.genesis_storage(),
+            )
+            .hash(),
             wasm_external_transport: Some(ExtTransport::new(ffi::websocket_transport())),
         })
         .await


### PR DESCRIPTION
We were using both. This removes a dependency.