### PR TITLE
Fix bad next key storage retreival

### DIFF
--- a/src/chain/blocks_tree.rs
+++ b/src/chain/blocks_tree.rs
@@ -1353,6 +1353,11 @@ impl<T> StorageNextKey<T> {
     }
 
     /// Injects the key.
+    ///
+    /// # Panic
+    ///
+    /// Panics if the key passed as parameter isn't strictly superior to the requested key.
+    ///
     pub fn inject_key(self, key: Option<impl AsRef<[u8]>>) -> BodyVerifyStep2<T> {
         let inner = self.inner.inject_key(key);
         BodyVerifyStep2::from_inner(inner, self.chain)

--- a/src/chain/sync/full_optimistic.rs
+++ b/src/chain/sync/full_optimistic.rs
@@ -755,6 +755,11 @@ impl<TRq, TBl> StorageNextKey<TRq, TBl> {
     }
 
     /// Injects the key.
+    ///
+    /// # Panic
+    ///
+    /// Panics if the key passed as parameter isn't strictly superior to the requested key.
+    ///
     pub fn inject_key(self, key: Option<impl AsRef<[u8]>>) -> ProcessOne<TRq, TBl> {
         let key = key.as_ref().map(|k| k.as_ref());
 
@@ -768,6 +773,10 @@ impl<TRq, TBl> StorageNextKey<TRq, TBl> {
         } else {
             self.inner.key()
         };
+
+        if let Some(key) = key {
+            assert!(key > requested_key);
+        }
 
         let in_diff = self
             .shared

--- a/src/verify/execute_block.rs
+++ b/src/verify/execute_block.rs
@@ -367,6 +367,11 @@ impl NextKey {
     }
 
     /// Injects the key.
+    ///
+    /// # Panic
+    ///
+    /// Panics if the key passed as parameter isn't strictly superior to the requested key.
+    ///
     pub fn inject_key(mut self, key: Option<impl AsRef<[u8]>>) -> Verify {
         let key = key.as_ref().map(|k| k.as_ref());
 
@@ -377,6 +382,10 @@ impl NextKey {
                 } else {
                     req.key()
                 };
+
+                if let Some(key) = key {
+                    assert!(key > requested_key);
+                }
 
                 // The next key can be either the one passed by the user or one key in the current
                 // pending storage changes that has been inserted during the verification.

--- a/src/verify/header_body.rs
+++ b/src/verify/header_body.rs
@@ -332,6 +332,11 @@ impl StorageNextKey {
     }
 
     /// Injects the key.
+    ///
+    /// # Panic
+    ///
+    /// Panics if the key passed as parameter isn't strictly superior to the requested key.
+    ///
     pub fn inject_key(self, key: Option<impl AsRef<[u8]>>) -> Verify {
         VerifyInner::Unsealed {
             inner: self.inner.inject_key(key),


### PR DESCRIPTION
This wasn't completely implemented.

Fixes the state root mismatch error happening around Polkadot block 10500
