### PR TITLE
Fix Kusama syncing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ pin-project = "0.4"
 prost = "0.6.1"
 rand = "0.7.0"
 rand_chacha = "0.2.2"
-schnorrkel = { version = "0.9.1", default-features = false }
+schnorrkel = { version = "0.9.1", default-features = false, features = ["preaudit_deprecated"] }
 send_wrapper = "0.4.0"
 serde = { version = "1.0.101", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0.57", default-features = false, features = ["alloc", "raw_value"] }

--- a/src/executor/externals.rs
+++ b/src/executor/externals.rs
@@ -364,6 +364,7 @@ impl ReadyToRun {
                 Externality::ext_crypto_sr25519_public_keys_version_1 => todo!(),
                 Externality::ext_crypto_sr25519_generate_version_1 => todo!(),
                 Externality::ext_crypto_sr25519_sign_version_1 => todo!(),
+                Externality::ext_crypto_sr25519_verify_version_1 => 3,
                 Externality::ext_crypto_sr25519_verify_version_2 => 3,
                 Externality::ext_crypto_secp256k1_ecdsa_recover_version_1 => 2,
                 Externality::ext_crypto_secp256k1_ecdsa_recover_compressed_version_1 => todo!(),
@@ -669,6 +670,24 @@ impl ReadyToRun {
                 Externality::ext_crypto_sr25519_public_keys_version_1 => todo!(),
                 Externality::ext_crypto_sr25519_generate_version_1 => todo!(),
                 Externality::ext_crypto_sr25519_sign_version_1 => todo!(),
+                Externality::ext_crypto_sr25519_verify_version_1 => {
+                    let sig = expect_pointer_constant_size!(0, 64);
+                    let message = expect_pointer_size!(1);
+                    let pubkey = expect_pointer_constant_size!(2, 32);
+
+                    // The `unwrap()` below can only panic if the input is the wrong length, which
+                    // we know can't happen.
+                    // TODO: copy overhead?
+                    let signing_public_key = schnorrkel::PublicKey::from_bytes(&pubkey).unwrap();
+                    let success = signing_public_key
+                        .verify_simple_preaudit_deprecated(b"substrate", &message, &sig)
+                        .is_ok();
+
+                    self = ReadyToRun {
+                        resume_value: Some(vm::WasmValue::I32(if success { 1 } else { 0 })),
+                        inner: self.inner,
+                    };
+                }
                 Externality::ext_crypto_sr25519_verify_version_2 => {
                     let sig = expect_pointer_constant_size!(0, 64);
                     let message = expect_pointer_size!(1);
@@ -1983,6 +2002,7 @@ externalities! {
     ext_crypto_sr25519_public_keys_version_1,
     ext_crypto_sr25519_generate_version_1,
     ext_crypto_sr25519_sign_version_1,
+    ext_crypto_sr25519_verify_version_1,
     ext_crypto_sr25519_verify_version_2,
     ext_crypto_secp256k1_ecdsa_recover_version_1,
     ext_crypto_secp256k1_ecdsa_recover_compressed_version_1,


### PR DESCRIPTION
Kusama still uses the deprecated sr25519 signature verification function, and I thus accidentally broke it in #75.