### PR TITLE
Improve API of the thread-safe read_write functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2212,6 +2212,7 @@ dependencies = [
  "num-traits",
  "parity-multiaddr",
  "parity-scale-codec",
+ "pin-project 1.0.4",
  "prost",
  "prost-build",
  "rand 0.8.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ num-bigint = { version = "0.3.1", default-features = false }
 num-rational = { version = "0.3.2", default-features = false, features = ["num-bigint"] }
 num-traits = { version = "0.2.14", default-features = false }
 parity-multiaddr = "0.9.6" # TODO: doesn't support no_std
+pin-project = "1.0.4"
 prost = { version = "0.7.0", default-features = false }
 rand = { version = "0.8.2", default-features = false, features = ["std", "std_rng"] }  # TODO: rand is used in hack-y ways at the moment ; these features should be removed
 rand_chacha = { version = "0.3.0", default-features = false }

--- a/bin/full-node/src/network_service.rs
+++ b/bin/full-node/src/network_service.rs
@@ -464,29 +464,9 @@ async fn connection_task(
 
         let now = Instant::now();
 
-        // TODO: hacky code
-        struct Waker(std::sync::Mutex<(bool, Option<std::task::Waker>)>);
-        impl futures::task::ArcWake for Waker {
-            fn wake_by_ref(arc_self: &Arc<Self>) {
-                let mut lock = arc_self.0.lock().unwrap();
-                lock.0 = true;
-                if let Some(w) = lock.1.take() {
-                    w.wake();
-                }
-            }
-        }
-
-        let waker = Arc::new(Waker(std::sync::Mutex::new((false, None))));
-
         let read_write = match network_service
             .network
-            .read_write(
-                id,
-                now,
-                read_buffer.map(|b| b.0),
-                write_buffer.unwrap(),
-                &mut std::task::Context::from_waker(&*futures::task::waker_ref(&waker)),
-            )
+            .read_write(id, now, read_buffer.map(|b| b.0), write_buffer.unwrap())
             .await
         {
             Ok(rw) => rw,
@@ -521,20 +501,19 @@ async fn connection_task(
             tracing::info!("write-closed");
         }
 
+        tcp_socket.advance(read_write.read_bytes, read_write.written_bytes);
+
         if let Some(wake_up) = read_write.wake_up_after {
             if wake_up > now {
                 let dur = wake_up - now;
                 poll_after = futures_timer::Delay::new(dur);
             } else {
-                poll_after = futures_timer::Delay::new(Duration::from_secs(0));
+                continue;
             }
         } else {
+            // TODO: hack
             poll_after = futures_timer::Delay::new(Duration::from_secs(3600));
         }
-
-        tcp_socket.advance(read_write.read_bytes, read_write.written_bytes);
-
-        // TODO: maybe optimize the code below so that multiple messages are pulled from `to_connection` at once
 
         futures::select! {
             _ = tcp_socket.as_mut().process().fuse() => {
@@ -543,17 +522,7 @@ async fn connection_task(
                     "socket-ready"
                 );
             },
-            _ = future::poll_fn(move |cx| {
-                let mut lock = waker.0.lock().unwrap();
-                if lock.0 {
-                    return std::task::Poll::Ready(());
-                }
-                match lock.1 {
-                    Some(ref w) if w.will_wake(cx.waker()) => {}
-                    _ => lock.1 = Some(cx.waker().clone()),
-                }
-                std::task::Poll::Pending
-            }).fuse() => {}
+            _ = read_write.wake_up_future.fuse() => {},
             _ = (&mut poll_after).fuse() => { // TODO: no, ref mut + fuse() = probably panic
                 // Nothing to do, but guarantees that we loop again.
                 tracing::event!(

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -645,16 +645,16 @@ where
         now: TNow,
         incoming_buffer: Option<&[u8]>,
         outgoing_buffer: (&'a mut [u8], &'a mut [u8]),
-        cx: &mut Context<'_>,
     ) -> Result<ReadWrite<TNow>, libp2p::ConnectionError> {
         let inner = self
             .libp2p
-            .read_write(connection_id.0, now, incoming_buffer, outgoing_buffer, cx)
+            .read_write(connection_id.0, now, incoming_buffer, outgoing_buffer)
             .await?;
         Ok(ReadWrite {
             read_bytes: inner.read_bytes,
             written_bytes: inner.written_bytes,
             wake_up_after: inner.wake_up_after,
+            wake_up_future: inner.wake_up_future,
             write_close: inner.write_close,
         })
     }
@@ -803,6 +803,10 @@ pub struct ReadWrite<TNow> {
     /// If `Some`, [`ChainNetwork::read_write`] should be called again when the point in time
     /// reaches the value in the `Option`.
     pub wake_up_after: Option<TNow>,
+
+    /// [`ChainNetwork::read_write`] should be called again when this [`ConnectionReadyFuture`]
+    /// returns `Ready`.
+    pub wake_up_future: libp2p::ConnectionReadyFuture,
 
     /// If `true`, the writing side the connection must be closed. Will always remain to `true`
     /// after it has been set.

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -804,8 +804,8 @@ pub struct ReadWrite<TNow> {
     /// reaches the value in the `Option`.
     pub wake_up_after: Option<TNow>,
 
-    /// [`ChainNetwork::read_write`] should be called again when this [`ConnectionReadyFuture`]
-    /// returns `Ready`.
+    /// [`ChainNetwork::read_write`] should be called again when this
+    /// [`libp2p::ConnectionReadyFuture`] returns `Ready`.
     pub wake_up_future: libp2p::ConnectionReadyFuture,
 
     /// If `true`, the writing side the connection must be closed. Will always remain to `true`

--- a/src/util.rs
+++ b/src/util.rs
@@ -121,14 +121,3 @@ pub(crate) fn encode_scale_compact_usize(mut value: usize) -> impl AsRef<[u8]> +
 
     array
 }
-
-///
-pub(crate) struct ReadySwitch {}
-
-impl ReadySwitch {
-    pub(crate) fn set_ready(&self) {}
-
-    pub(crate) async fn wait(&self) {}
-
-    pub(crate) fn reset(&self) {}
-}

--- a/src/util.rs
+++ b/src/util.rs
@@ -121,3 +121,14 @@ pub(crate) fn encode_scale_compact_usize(mut value: usize) -> impl AsRef<[u8]> +
 
     array
 }
+
+///
+pub(crate) struct ReadySwitch {}
+
+impl ReadySwitch {
+    pub(crate) fn set_ready(&self) {}
+
+    pub(crate) async fn wait(&self) {}
+
+    pub(crate) fn reset(&self) {}
+}


### PR DESCRIPTION
Replaces the manual `Context` usage with a `futures::oneshot::channel()`.
This is not the most optimal way to implement this future, but right now I'm trying to reduce the complexity of `libp2p.rs` until a proper design is found.

cc #288 