### PR TITLE
Add logging to the Wasm node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
 ]
@@ -2158,6 +2158,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65211b7b6fc3f14ff9fc7a2011a434e3e6880585bd2e9e9396315ae24cbf7852"
 
 [[package]]
+name = "simple_logger"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd57f17c093ead1d4a1499dc9acaafdd71240908d64775465543b8d9a9f1d198"
+dependencies = [
+ "atty",
+ "log",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2266,9 +2277,11 @@ dependencies = [
  "derive_more",
  "futures",
  "lazy_static",
+ "log",
  "lru",
  "rand 0.8.2",
  "serde_json",
+ "simple_logger",
  "slab",
  "smoldot",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ futures = "0.3.12"   # TODO: no-std-ize
 hashbrown = { version = "0.9.1", default-features = false, features = ["serde"] }   # TODO: remove serde feature
 hex = { version = "0.4.2", default-features = false }
 libsecp256k1 = { version = "0.3.5", default-features = false }
+# Reminder: `log` is forbidden
 merlin = { version = "2.0", default-features = false }
 multihash = "0.11.4"  # TODO: waiting for a crates.io publication of https://github.com/multiformats/rust-multihash/pull/82 that adds no_std support
 nom = { version = "6.1.0", default-features = false, features = ["alloc"] }

--- a/bin/wasm-node/javascript/demo.js
+++ b/bin/wasm-node/javascript/demo.js
@@ -38,12 +38,10 @@ smoldot.start({
     database_content: database_content,
     json_rpc_callback: (resp) => {
         if (ws_connection) {
-            console.log("Sending back:", resp.slice(0, 100) + (resp.length > 100 ? '…' : ''));
             ws_connection.sendUTF(resp);
         }
     },
     database_save_callback: (db_content) => {
-        console.log("Saving database");
         fs.writeFileSync(database_path, db_content);
     }
 })
@@ -54,7 +52,6 @@ smoldot.start({
     })
 
 let server = http.createServer(function (request, response) {
-    console.log((new Date()) + ' Received request for ' + request.url);
     response.writeHead(404);
     response.end();
 });
@@ -76,7 +73,6 @@ wsServer.on('request', function (request) {
 
     connection.on('message', function (message) {
         if (message.type === 'utf8') {
-            console.log('Received Message:', message.utf8Data.slice(0, 100) + (message.utf8Data.length > 100 ? '…' : ''));
             if (client) {
                 client.send_json_rpc(message.utf8Data);
             } else {

--- a/bin/wasm-node/javascript/index.js
+++ b/bin/wasm-node/javascript/index.js
@@ -186,7 +186,7 @@ export async function start(config) {
           total_length += buf_len;
         }
 
-        let log_if_necessary = (string) => {
+        let flush_buffer = (string) => {
           // As documented in the documentation of `println!`, lines are always split by a single
           // `\n` in Rust.
           let index = string.indexOf('\n');
@@ -204,10 +204,10 @@ export async function start(config) {
         // their content if necessary.
         if (fd == 1) {
           stdout_buffer += to_write;
-          stdout_buffer = log_if_necessary(stdout_buffer);
+          stdout_buffer = flush_buffer(stdout_buffer);
         } else if (fd == 2) {
           stderr_buffer += to_write;
-          stderr_buffer = log_if_necessary(stderr_buffer);
+          stderr_buffer = flush_buffer(stderr_buffer);
         }
 
         // Need to write in `out_ptr` how much data was "written".

--- a/bin/wasm-node/javascript/index.js
+++ b/bin/wasm-node/javascript/index.js
@@ -46,6 +46,11 @@ export async function start(config) {
   // cross-platform cross-bundler approach.
   let wasm_bytecode = new Uint8Array(Buffer.from(wasm_base64, 'base64'));
 
+  // Buffers holding temporary data being written by the Rust code to respectively stdout and
+  // stderr.
+  let stdout_buffer = new String();
+  let stderr_buffer = new String();
+
   // Start the Wasm virtual machine.
   // The Rust code defines a list of imports that must be fulfilled by the environment. The second
   // parameter provides their implementations.
@@ -181,12 +186,29 @@ export async function start(config) {
           total_length += buf_len;
         }
 
-        // Note that it is questionnable to use `console.log` from within a library. However this
-        // simply reflects the usage of `println!` in the Rust code. In other words, it is
-        // `println!` that shouldn't be used in the first place. The harm of not showing text
-        // printed with `println!` at all is greater than the harm possibly caused by accidentally
-        // leaving a `println!` in the code.
-        console.log(to_write);
+        let log_if_necessary = (string) => {
+          // As documented in the documentation of `println!`, lines are always split by a single
+          // `\n` in Rust.
+          let index = string.indexOf('\n');
+          if (index != -1) {
+            // TODO: it is questionnable to use `console.log` from within a library ; see https://github.com/paritytech/smoldot/issues/384
+            //       we might also consider making the logging of the node configurable
+            console.log(string.substring(0, index));
+            return string.substring(index + 1);
+          } else {
+            return string;
+          }
+        };
+
+        // Append the newly-written data to either `stdout_buffer` or `stderr_buffer`, and print
+        // their content if necessary.
+        if (fd == 1) {
+          stdout_buffer += to_write;
+          stdout_buffer = log_if_necessary(stdout_buffer);
+        } else if (fd == 2) {
+          stderr_buffer += to_write;
+          stderr_buffer = log_if_necessary(stderr_buffer);
+        }
 
         // Need to write in `out_ptr` how much data was "written".
         mem.writeUInt32LE(total_length, out_ptr);

--- a/bin/wasm-node/rust/Cargo.toml
+++ b/bin/wasm-node/rust/Cargo.toml
@@ -15,8 +15,10 @@ crate-type = ["cdylib", "rlib"]
 derive_more = "0.99.11"
 futures = "0.3.12"
 lazy_static = "1.4.0"
+log = "0.4.13"
 lru = "0.6.3"
 rand = "0.8.2"
 serde_json = "1.0.61"
+simple_logger = { version = "1.11.0", default-features = false }
 slab = "0.4.2"
 smoldot = { version = "0.1.0", path = "../../..", default-features = false }

--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -20,7 +20,7 @@ use futures::{
     lock::Mutex,
     prelude::*,
 };
-use smoldot::{chain, chain::sync::optimistic, libp2p, network};
+use smoldot::{chain, chain::sync::optimistic, informant::HashDisplay, libp2p, network};
 use std::{collections::HashMap, num::NonZeroU32, pin::Pin};
 
 /// Configuration for a [`SyncService`].
@@ -286,9 +286,52 @@ async fn start_sync(
                         sync = s;
                         break;
                     }
-                    optimistic::ProcessOne::NewBest { sync: s, .. }
-                    | optimistic::ProcessOne::Reset { sync: s, .. } => {
+
+                    optimistic::ProcessOne::NewBest {
+                        sync: s,
+                        new_best_number,
+                        new_best_hash,
+                    } => {
                         sync = s;
+
+                        log::debug!(
+                            target: "sync-verify",
+                            "New best block: #{} ({})",
+                            new_best_number,
+                            HashDisplay(&new_best_hash),
+                        );
+
+                        let scale_encoded_header = sync.best_block_header().scale_encoding().fold(
+                            Vec::new(),
+                            |mut a, b| {
+                                a.extend_from_slice(b.as_ref());
+                                a
+                            },
+                        );
+                        if to_foreground
+                            .send(FromBackground::NewBest {
+                                scale_encoded_header,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
+
+                    optimistic::ProcessOne::Reset {
+                        sync: s,
+                        reason,
+                        previous_best_height,
+                    } => {
+                        sync = s;
+
+                        log::warn!(
+                            target: "sync-verify",
+                            "Failed to verify block #{}: {}",
+                            previous_best_height + 1,
+                            reason
+                        );
 
                         let scale_encoded_header = sync.best_block_header().scale_encoding().fold(
                             Vec::new(),
@@ -315,6 +358,12 @@ async fn start_sync(
                     } => {
                         sync = s;
                         verified_blocks += 1;
+
+                        log::debug!(
+                            target: "sync-verify",
+                            "Finalized {} block",
+                            finalized_blocks.len()
+                        );
 
                         let scale_encoded_header = finalized_blocks
                             .last()

--- a/src/informant.rs
+++ b/src/informant.rs
@@ -190,7 +190,7 @@ impl<'a> fmt::Display for InformantLine<'a> {
 }
 
 /// Implements `fmt::Display` and displays hashes in a nice way.
-struct HashDisplay<'a>(&'a [u8]);
+pub struct HashDisplay<'a>(pub &'a [u8]);
 
 impl<'a> fmt::Display for HashDisplay<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
This adds a lot of logging to the code of the Wasm node, which should hopefully make it easier to figure out where issues come from.

I've also fixed `index.js` to properly buffer the stdout/stderr output and split them by `\n`. This removes a lot of extra accidental new lines.

Relates to #384 
