### PR TITLE
Fix RuntimeVersion not sent back correctly

### DIFF
--- a/bin/wasm-node/rust/src/lib.rs
+++ b/bin/wasm-node/rust/src/lib.rs
@@ -677,7 +677,8 @@ async fn handle_rpc(rpc: &str, client: &mut Client) -> (String, Option<String>) 
                     impl_version: u64::from(runtime_specs.impl_version),
                     transaction_version: u64::from(runtime_specs.transaction_version),
                     apis: runtime_specs.apis,
-                }).unwrap(),
+                })
+                .unwrap(),
             );
             (response, Some(response2))
         }

--- a/bin/wasm-node/rust/src/lib.rs
+++ b/bin/wasm-node/rust/src/lib.rs
@@ -673,6 +673,7 @@ async fn handle_rpc(rpc: &str, client: &mut Client) -> (String, Option<String>) 
                 spec_version: u64::from(runtime_specs.spec_version),
                 impl_version: u64::from(runtime_specs.impl_version),
                 transaction_version: u64::from(runtime_specs.transaction_version),
+                apis: runtime_specs.apis,
             })
             .to_json_response(request_id);
             (response, Some(response2))
@@ -740,6 +741,7 @@ async fn handle_rpc(rpc: &str, client: &mut Client) -> (String, Option<String>) 
                 spec_version: u64::from(runtime_specs.spec_version),
                 impl_version: u64::from(runtime_specs.impl_version),
                 transaction_version: u64::from(runtime_specs.transaction_version),
+                apis: runtime_specs.apis,
             })
             .to_json_response(request_id);
             (response, None)

--- a/bin/wasm-node/rust/src/lib.rs
+++ b/bin/wasm-node/rust/src/lib.rs
@@ -666,16 +666,19 @@ async fn handle_rpc(rpc: &str, client: &mut Client) -> (String, Option<String>) 
             .unwrap();
             let (runtime_specs, _) = executor::core_version(vm).unwrap();
 
-            let response2 = methods::Response::state_getRuntimeVersion(methods::RuntimeVersion {
-                spec_name: runtime_specs.spec_name,
-                impl_name: runtime_specs.impl_name,
-                authoring_version: u64::from(runtime_specs.authoring_version),
-                spec_version: u64::from(runtime_specs.spec_version),
-                impl_version: u64::from(runtime_specs.impl_version),
-                transaction_version: u64::from(runtime_specs.transaction_version),
-                apis: runtime_specs.apis,
-            })
-            .to_json_response(request_id);
+            let response2 = smoldot::json_rpc::parse::build_subscription_event(
+                "state_runtimeVersion",
+                &subscription,
+                &serde_json::to_string(&methods::RuntimeVersion {
+                    spec_name: runtime_specs.spec_name,
+                    impl_name: runtime_specs.impl_name,
+                    authoring_version: u64::from(runtime_specs.authoring_version),
+                    spec_version: u64::from(runtime_specs.spec_version),
+                    impl_version: u64::from(runtime_specs.impl_version),
+                    transaction_version: u64::from(runtime_specs.transaction_version),
+                    apis: runtime_specs.apis,
+                }).unwrap(),
+            );
             (response, Some(response2))
         }
         methods::MethodCall::state_subscribeStorage { list } => {

--- a/src/json_rpc/methods.rs
+++ b/src/json_rpc/methods.rs
@@ -302,7 +302,7 @@ pub struct RuntimeVersion {
     pub spec_version: u64,
     pub impl_version: u64,
     pub transaction_version: u64,
-    // TODO: apis missing
+    pub apis: Vec<([u8; 8], u32)>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -371,15 +371,22 @@ impl serde::Serialize for RuntimeVersion {
     where
         S: serde::Serializer,
     {
-        // TODO: not sure about the camelCasing
         #[derive(serde::Serialize)]
         struct SerdeRuntimeVersion<'a> {
+            #[serde(rename = "specName")]
             spec_name: &'a str,
+            #[serde(rename = "implName")]
             impl_name: &'a str,
+            #[serde(rename = "authoringVersion")]
             authoring_version: u64,
+            #[serde(rename = "specVersion")]
             spec_version: u64,
+            #[serde(rename = "implVersion")]
             impl_version: u64,
+            #[serde(rename = "transactionVersion")]
             transaction_version: u64,
+            // TODO: optimize?
+            apis: Vec<(HexString, u32)>,
         }
 
         SerdeRuntimeVersion {
@@ -389,6 +396,12 @@ impl serde::Serialize for RuntimeVersion {
             spec_version: self.spec_version,
             impl_version: self.impl_version,
             transaction_version: self.transaction_version,
+            // TODO: optimize?
+            apis: self
+                .apis
+                .iter()
+                .map(|(name, version)| (HexString(name.to_vec()), *version))
+                .collect(),
         }
         .serialize(serializer)
     }


### PR DESCRIPTION
After this PR:

> {"jsonrpc":"2.0","method":"state_runtimeVersion","params":{"subscription":"0","result":{"specName":"westend","implName":"parity-westend","authoringVersion":2,"specVersion":47,"implVersion":0,"transactionVersion":3,"apis":[["0xdf6acb689907609b",3],["0x37e397fc7c91f5e4",1],["0x40fe3ad401f8959a",4],["0xd2bc9897eed08f15",2],["0xf78b278be53f454c",2],["0xaf2c0297a23e6d3d",1],["0xed99c5acb25eedf5",2],["0xcbca25e39f142387",2],["0x687ad44ad37f03c2",1],["0xab3c0572291feb8b",1],["0xbc9d89904f5b923f",1],["0x37c8bb1350a9a2a8",1]]}}}

Comparing with official Westend node:

> {"jsonrpc":"2.0","method":"state_runtimeVersion","params":{"result":{"apis":[["0xdf6acb689907609b",3],["0x37e397fc7c91f5e4",1],["0x40fe3ad401f8959a",4],["0xd2bc9897eed08f15",2],["0xf78b278be53f454c",2],["0xaf2c0297a23e6d3d",1],["0xed99c5acb25eedf5",2],["0xcbca25e39f142387",2],["0x687ad44ad37f03c2",1],["0xab3c0572291feb8b",1],["0xbc9d89904f5b923f",1],["0x37c8bb1350a9a2a8",1]],"authoringVersion":2,"implName":"parity-westend","implVersion":0,"specName":"westend","specVersion":47,"transactionVersion":3},"subscription":"AkCt89rUF82DNNgF"}}