### PR TITLE
Plug Mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,11 @@
+pull_request_rules:
+  - name: automatic merge when CI passes on main
+    conditions:
+      - check-success=all-ci
+      - check-success=all-deploy
+      - label=automerge
+      - base=main
+    actions:
+      merge:
+        strict: true
+        method: squash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,11 @@ jobs:
       with:
         command: check --config .github/cargo-deny.toml ${{ matrix.checks }}
         arguments: --workspace --all-features
+
+  all-ci:
+    # This dummy job depends on all the mandatory checks. It succeeds if and only if CI is
+    # considered successful.
+    needs: [test, wasm-node-check, check-features, check-rustdoc-links, fmt, clippy, cargo-deny]
+    runs-on: ubuntu-latest
+    steps:
+     - run: echo Success

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,3 +95,11 @@ jobs:
         build_dir: target/doc
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  all-deploy:
+    # This dummy job depends on all the mandatory checks. It succeeds if and only if CI is
+    # considered successful.
+    needs: [build-push-docker-image, npm-publish, deploy-gh-pages]
+    runs-on: ubuntu-latest
+    steps:
+     - run: echo Success


### PR DESCRIPTION
I've added a new `automerge` label. When applied to a pull request, it should now, thanks to Mergify, automatically merge the pull request as soon as CI passes, essentially like bors does. The main point is of course to enforce a linear history.