### PR TITLE
Make maximum log level configuration from JS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2171,17 +2171,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65211b7b6fc3f14ff9fc7a2011a434e3e6880585bd2e9e9396315ae24cbf7852"
 
 [[package]]
-name = "simple_logger"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd57f17c093ead1d4a1499dc9acaafdd71240908d64775465543b8d9a9f1d198"
-dependencies = [
- "atty",
- "log",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,7 +2284,6 @@ dependencies = [
  "lru",
  "rand 0.8.3",
  "serde_json",
- "simple_logger",
  "smoldot",
 ]
 

--- a/bin/wasm-node/javascript/demo.js
+++ b/bin/wasm-node/javascript/demo.js
@@ -36,6 +36,7 @@ try {
 smoldot.start({
     chain_spec: JSON.stringify(westend_specs()),
     database_content: database_content,
+    max_log_level: 3,  // Can be increased for more verbosity
     json_rpc_callback: (resp) => {
         if (ws_connection) {
             ws_connection.sendUTF(resp);

--- a/bin/wasm-node/rust/Cargo.toml
+++ b/bin/wasm-node/rust/Cargo.toml
@@ -16,9 +16,8 @@ blake2-rfc = { version = "0.2.18", default-features = false }
 derive_more = "0.99.11"
 futures = "0.3.12"
 lazy_static = "1.4.0"
-log = "0.4.14"
+log = { version = "0.4.14", features = ["std"] }
 lru = "0.6.3"
 rand = "0.8.3"
 serde_json = "1.0.61"
-simple_logger = { version = "1.11.0", default-features = false }
 smoldot = { version = "0.1.0", path = "../../..", default-features = false }

--- a/bin/wasm-node/rust/src/ffi/bindings.rs
+++ b/bin/wasm-node/rust/src/ffi/bindings.rs
@@ -53,6 +53,15 @@ extern "C" {
     /// virtual machine at offset `ptr` and with length `len`.
     pub fn json_rpc_respond(ptr: u32, len: u32);
 
+    /// Client is emitting a log entry.
+    ///
+    /// Each log entry is made of a log level (1 = Error, 2 = Warn, 3 = Info, 4 = Debug,
+    /// 5 = Trace), a log target (e.g. "network"), and a log message.
+    ///
+    /// The log target and message is a UTF-8 string found in the memory of the WebAssembly
+    /// virtual machine at offset `ptr` and with length `len`.
+    pub fn log(level: u32, target_ptr: u32, target_len: u32, message_ptr: u32, message_len: u32);
+
     /// Must return the number of milliseconds that have passed since the UNIX epoch, ignoring
     /// leap seconds.
     ///
@@ -173,18 +182,23 @@ pub extern "C" fn alloc(len: u32) -> u32 {
 /// Write the chain specs and the database content in these two buffers.
 /// Then, pass the pointer and length of these two buffers to this function.
 /// Pass `0` for `database_content_ptr` and `database_content_len` if the database is empty.
+///
+/// The client will emit log messages by calling the [`log`] function, provided the log level is
+/// inferior or equal to the value of `max_log_level` passed here.
 #[no_mangle]
 pub extern "C" fn init(
     chain_specs_ptr: u32,
     chain_specs_len: u32,
     database_content_ptr: u32,
     database_content_len: u32,
+    max_log_level: u32,
 ) {
     super::init(
         chain_specs_ptr,
         chain_specs_len,
         database_content_ptr,
         database_content_len,
+        max_log_level,
     )
 }
 

--- a/bin/wasm-node/rust/src/ffi/bindings.rs
+++ b/bin/wasm-node/rust/src/ffi/bindings.rs
@@ -183,7 +183,7 @@ pub extern "C" fn alloc(len: u32) -> u32 {
 /// Then, pass the pointer and length of these two buffers to this function.
 /// Pass `0` for `database_content_ptr` and `database_content_len` if the database is empty.
 ///
-/// The client will emit log messages by calling the [`log`] function, provided the log level is
+/// The client will emit log messages by calling the [`log()`] function, provided the log level is
 /// inferior or equal to the value of `max_log_level` passed here.
 #[no_mangle]
 pub extern "C" fn init(

--- a/bin/wasm-node/rust/src/lib.rs
+++ b/bin/wasm-node/rust/src/lib.rs
@@ -128,13 +128,16 @@ watched and of the `:code` key.
 /// > **Note**: This function returns a `Result`. The return value according to the JavaScript
 /// >           function is what is in the `Ok`. If an `Err` is returned, a JavaScript exception
 /// >           is thrown.
-pub async fn start_client(chain_spec: String, database_content: Option<String>) {
+pub async fn start_client(
+    chain_spec: String,
+    database_content: Option<String>,
+    max_log_level: log::LevelFilter,
+) {
     // Try initialize the logging and the panic hook.
     // Note that `start_client` can theoretically be called multiple times, meaning that these
     // calls shouldn't panic if reached multiple times.
-    let _ = simple_logger::SimpleLogger::new()
-        .with_level(log::LevelFilter::Debug) // TODO: make log level configurable from JS?
-        .init();
+    let _ =
+        log::set_boxed_logger(Box::new(ffi::Logger)).map(|()| log::set_max_level(max_log_level));
     std::panic::set_hook(Box::new(|info| {
         ffi::throw(info.to_string());
     }));


### PR DESCRIPTION
Adds a `max_log_level` parameter to the configuration, configuring the logs verbosity.
Pass 0 to disable all logging. 1 = Error, 2 = Warn, 3 = Info, 4 = Debug, 5+ = Trace

Additionally, logs are now reported through a new ffi function called `log` that gets passed the level, target, and message. This allows additional filtering from the JS side, if needed.

Relates to https://github.com/paritytech/smoldot/issues/384