### PR TITLE
Remove memory copies when reading Wasmi memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,9 +1255,9 @@ checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "libm"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
+checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libsecp256k1"
@@ -2780,8 +2780,7 @@ checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
 [[package]]
 name = "wasmi"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6825d9b2147105789adb4c2d84b9b568719713f3ac39618b637b4dafc86c4"
+source = "git+https://github.com/paritytech/wasmi?rev=8871f9d6b235d37b73e946978d8dac535fe3c2fa#8871f9d6b235d37b73e946978d8dac535fe3c2fa"
 dependencies = [
  "downcast-rs",
  "libm",
@@ -2795,8 +2794,7 @@ dependencies = [
 [[package]]
 name = "wasmi-validation"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea78c597064ba73596099281e2f4cfc019075122a65cdda3205af94f0b264d93"
+source = "git+https://github.com/paritytech/wasmi?rev=8871f9d6b235d37b73e946978d8dac535fe3c2fa#8871f9d6b235d37b73e946978d8dac535fe3c2fa"
 dependencies = [
  "parity-wasm",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ smallvec = "1.6.1"
 snow = { version = "0.7.2", default-features = false, features = ["default-resolver"] }
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 twox-hash = "1.6.0"
-wasmi = { version = "0.7.0", default-features = false, features = ["core"] }  # TODO: having to add `core` is sketchy; maybe report this
+wasmi = { git = "https://github.com/paritytech/wasmi", rev = "8871f9d6b235d37b73e946978d8dac535fe3c2fa", default-features = false, features = ["core"] }  # TODO: having to add `core` is sketchy; maybe report this
 
 # `database-sled` feature
 sled = { version = "0.34.6", optional = true, features = ["compression"] }


### PR DESCRIPTION
Integrates https://github.com/paritytech/wasmi/pull/246

This switches a dependency from crates.io to git, but I don't think it'd be a problem to ask for a new version if we want to publish smoldot.
