### PR TITLE
Allow passing multiple chains to start

### DIFF
--- a/bin/wasm-node/rust/src/ffi.rs
+++ b/bin/wasm-node/rust/src/ffi.rs
@@ -22,7 +22,7 @@ use core::{
     convert::TryFrom as _,
     fmt,
     future::Future,
-    marker,
+    iter, marker,
     ops::{Add, Sub},
     pin::Pin,
     slice,
@@ -477,8 +477,10 @@ fn init(
     };
 
     spawn_task(super::start_client(
-        chain_specs,
-        database_content,
+        iter::once(super::ChainConfig {
+            specification: chain_specs,
+            database_content,
+        }),
         max_log_level,
     ));
 }


### PR DESCRIPTION
Changes can be summarized by three things:

- Changes the network service to allow connecting to multiple chains at the same time.
- The JSON-RPC service and sync service now have an extra "chain index" being passed in order to identify which chain to use when it interacts with the network service.
- The lib.rs file now accepts multiple chains and will spawn the sync service multiple times.

This lays down some foundation for later work.
