### PR TITLE
Allow passing a relay chain spec from the JS side

### DIFF
--- a/bin/wasm-node/javascript/index.d.ts
+++ b/bin/wasm-node/javascript/index.d.ts
@@ -31,6 +31,7 @@ export interface SmoldotOptions {
   json_rpc_callback: SmoldotJsonRpcCallback;
   database_save_callback: SmoldotDatabaseSaveCallback;
   database_content?: string;
+  relay_chain_spec?: string;
 }
 
 export interface Smoldot {

--- a/bin/wasm-node/javascript/index.js
+++ b/bin/wasm-node/javascript/index.js
@@ -33,6 +33,7 @@ export async function start(config) {
 
   const chain_spec = config.chain_spec;
   const database_content = config.database_content;
+  const relay_chain_spec = config.relay_chain_spec;
   const json_rpc_callback = config.json_rpc_callback;
   const database_save_callback = config.database_save_callback;
   // Maximum level of log entries sent by the client.
@@ -339,7 +340,19 @@ export async function start(config) {
       .write(database_content, database_ptr);
   }
 
-  module.exports.init(chain_spec_ptr, chain_spec_len, database_ptr, database_len, max_log_level);
+  let relay_chain_spec_len = relay_chain_spec ? Buffer.byteLength(relay_chain_spec, 'utf8') : 0;
+  let relay_chain_spec_ptr = (relay_chain_spec_len != 0) ? module.exports.alloc(relay_chain_spec_len) : 0;
+  if (relay_chain_spec_len != 0) {
+    Buffer.from(module.exports.memory.buffer)
+      .write(relay_chain_spec, relay_chain_spec_ptr);
+  }
+
+  module.exports.init(
+    chain_spec_ptr, chain_spec_len,
+    database_ptr, database_len,
+    relay_chain_spec_ptr, relay_chain_spec_len,
+    max_log_level
+  );
 
   return {
     send_json_rpc: (request) => {

--- a/bin/wasm-node/javascript/index.test-d.ts
+++ b/bin/wasm-node/javascript/index.test-d.ts
@@ -6,6 +6,7 @@ smoldot.start({
   max_log_level: 3,
   chain_spec: '',
   database_content: '',
+  relay_chain_spec: '',
   json_rpc_callback: (resp) => {},
   database_save_callback: (content) => {},
 });

--- a/bin/wasm-node/rust/src/ffi.rs
+++ b/bin/wasm-node/rust/src/ffi.rs
@@ -439,12 +439,16 @@ fn init(
     chain_specs_len: u32,
     database_content_ptr: u32,
     database_content_len: u32,
+    relay_chain_specs_ptr: u32,
+    relay_chain_specs_len: u32,
     max_log_level: u32,
 ) {
     let chain_specs_ptr = usize::try_from(chain_specs_ptr).unwrap();
     let chain_specs_len = usize::try_from(chain_specs_len).unwrap();
     let database_content_ptr = usize::try_from(database_content_ptr).unwrap();
     let database_content_len = usize::try_from(database_content_len).unwrap();
+    let relay_chain_specs_ptr = usize::try_from(relay_chain_specs_ptr).unwrap();
+    let relay_chain_specs_len = usize::try_from(relay_chain_specs_len).unwrap();
 
     let chain_specs: Box<[u8]> = unsafe {
         Box::from_raw(slice::from_raw_parts_mut(
@@ -467,6 +471,18 @@ fn init(
         None
     };
 
+    let relay_chain_specs = if relay_chain_specs_ptr != 0 {
+        let data: Box<[u8]> = unsafe {
+            Box::from_raw(slice::from_raw_parts_mut(
+                relay_chain_specs_ptr as *mut u8,
+                relay_chain_specs_len,
+            ))
+        };
+        Some(String::from_utf8(Vec::from(data)).expect("non-utf8 relay chain specs"))
+    } else {
+        None
+    };
+
     let max_log_level = match max_log_level {
         0 => log::LevelFilter::Off,
         1 => log::LevelFilter::Error,
@@ -480,7 +496,15 @@ fn init(
         iter::once(super::ChainConfig {
             specification: chain_specs,
             database_content,
-        }),
+        })
+        .chain(
+            relay_chain_specs
+                .into_iter()
+                .map(|specification| super::ChainConfig {
+                    specification,
+                    database_content: None,
+                }),
+        ),
         max_log_level,
     ));
 }

--- a/bin/wasm-node/rust/src/ffi/bindings.rs
+++ b/bin/wasm-node/rust/src/ffi/bindings.rs
@@ -196,14 +196,17 @@ pub extern "C" fn alloc(len: u32) -> u32 {
 
 /// Initializes the client.
 ///
-/// Use [`alloc`] to allocate either one or two buffers: one for the chain specs, and an optional
-/// one for the database content.
+/// Use [`alloc`] to allocate either one to three buffers: one for the chain specs, an optional
+/// one for the database content, and an optional one for the chain specs of the relay chain if
+/// the chain is a parachain.
 /// The buffers **must** have been allocated with [`alloc`]. They are freed when this function is
 /// called.
 ///
-/// Write the chain specs and the database content in these two buffers.
-/// Then, pass the pointer and length of these two buffers to this function.
+/// Write the chain specs, the database content, and the relay chain specs in these three buffers.
+/// Then, pass the pointer and length of these buffers to this function.
 /// Pass `0` for `database_content_ptr` and `database_content_len` if the database is empty.
+/// Pass `0` for `relay_chain_specs_ptr` and `relay_chain_specs_len` if the chain is not a
+/// parachain.
 ///
 /// The client will emit log messages by calling the [`log()`] function, provided the log level is
 /// inferior or equal to the value of `max_log_level` passed here.
@@ -213,6 +216,8 @@ pub extern "C" fn init(
     chain_specs_len: u32,
     database_content_ptr: u32,
     database_content_len: u32,
+    relay_chain_specs_ptr: u32,
+    relay_chain_specs_len: u32,
     max_log_level: u32,
 ) {
     super::init(
@@ -220,6 +225,8 @@ pub extern "C" fn init(
         chain_specs_len,
         database_content_ptr,
         database_content_len,
+        relay_chain_specs_ptr,
+        relay_chain_specs_len,
         max_log_level,
     )
 }


### PR DESCRIPTION
cc @raoulmillais 
I've added a new `relay_chain_spec` field.

For example, if you want to connect to Tick, you need to pass the Tick chain specs in the `chain_spec` field, and the Rococo chain spec in the `relay_chain_spec` field.
At the moment smoldot isn't capable of understanding the relationship between Tick and Rococo and just treats them as two individual chains. But eventually, you'll get an error if the content of `relay_chain_spec` doesn't match the relay chain expected by `chain_spec` or if `relay_chain_spec` is empty and `chain_spec` is a parachain.

I went for adding a new `relay_chain_spec` field so that `database_content` and the JSON-RPC calls still always refer to the the chain passed through `chain_spec`. In the long term this will change again with #501.