### PR TITLE
Enable #![no_std]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
 default = ["database-sled", "std"]
 database-sled = [
     "sled",
+    "std"   # A database stored on the filesystem can't reasonably work without a filesystem.
 ]
 std = [
     "async-std",

--- a/src/author/runtime.rs
+++ b/src/author/runtime.rs
@@ -54,7 +54,7 @@ use crate::{
     util,
 };
 
-use alloc::{string::String, vec::Vec};
+use alloc::{borrow::ToOwned as _, string::String, vec::Vec};
 use core::{iter, mem};
 use hashbrown::HashMap;
 

--- a/src/chain/chain_information.rs
+++ b/src/chain/chain_information.rs
@@ -40,7 +40,7 @@
 
 use crate::{finality::grandpa, header};
 
-use alloc::vec::Vec;
+use alloc::{borrow::ToOwned as _, vec::Vec};
 use core::num::NonZeroU64;
 
 pub mod aura_config;

--- a/src/chain/sync/all_forks.rs
+++ b/src/chain/sync/all_forks.rs
@@ -87,7 +87,7 @@ use crate::{
     header, verify,
 };
 
-use alloc::collections::VecDeque;
+use alloc::{collections::VecDeque, vec::Vec};
 use core::{
     iter, mem,
     num::{NonZeroU32, NonZeroU64},

--- a/src/chain/sync/all_forks/pending_blocks.rs
+++ b/src/chain/sync/all_forks/pending_blocks.rs
@@ -61,7 +61,10 @@
 
 use crate::header;
 
-use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    vec::Vec,
+};
 use core::{
     convert::TryFrom as _,
     num::{NonZeroU32, NonZeroU64},

--- a/src/chain/sync/all_forks/sources.rs
+++ b/src/chain/sync/all_forks/sources.rs
@@ -25,7 +25,7 @@
 //! - An opaque user data, of type `TSrc`.
 //!
 
-use alloc::collections::BTreeSet;
+use alloc::{collections::BTreeSet, vec::Vec};
 use core::fmt;
 
 /// Identifier for a source in the [`AllForksSources`].

--- a/src/chain/sync/grandpa_warp_sync.rs
+++ b/src/chain/sync/grandpa_warp_sync.rs
@@ -31,6 +31,8 @@ use crate::{
     network::protocol::GrandpaWarpSyncResponse,
 };
 
+use alloc::vec::Vec;
+
 /// Problem encountered during a call to [`grandpa_warp_sync`].
 #[derive(Debug, derive_more::Display)]
 pub enum Error {

--- a/src/chain/sync/optimistic.rs
+++ b/src/chain/sync/optimistic.rs
@@ -54,6 +54,7 @@ use crate::{
 };
 
 use alloc::{
+    borrow::ToOwned as _,
     collections::{BTreeMap, VecDeque},
     vec::Vec,
 };

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -37,7 +37,7 @@
 use crate::chain::chain_information::{
     BabeEpochInformation, ChainInformation, ChainInformationConsensus, ChainInformationFinality,
 };
-use alloc::string::String;
+use alloc::{string::String, vec::Vec};
 use core::num::NonZeroU64;
 
 mod light_sync_state;

--- a/src/chain_spec/light_sync_state.rs
+++ b/src/chain_spec/light_sync_state.rs
@@ -17,7 +17,7 @@
 
 use crate::header::BabeNextConfig;
 
-use alloc::{collections::BTreeMap, vec::Vec};
+use alloc::{collections::BTreeMap, format, string::String, vec::Vec};
 use parity_scale_codec::{Decode, DecodeAll as _, Encode};
 use serde::{Deserialize, Serialize};
 

--- a/src/chain_spec/structs.rs
+++ b/src/chain_spec/structs.rs
@@ -22,7 +22,7 @@
 
 use super::light_sync_state::LightSyncState;
 
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, format, string::String, vec::Vec};
 use fnv::FnvBuildHasher;
 use hashbrown::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};

--- a/src/database/finalized_serialize.rs
+++ b/src/database/finalized_serialize.rs
@@ -31,6 +31,7 @@
 
 use crate::chain::chain_information;
 
+use alloc::{string::String, vec::Vec};
 use core::iter;
 use hashbrown::HashMap;
 

--- a/src/executor/read_only_runtime_host.rs
+++ b/src/executor/read_only_runtime_host.rs
@@ -21,7 +21,10 @@
 
 use crate::executor::{self, host, vm};
 
-use alloc::{string::String, vec::Vec};
+use alloc::{
+    string::{String, ToString as _},
+    vec::Vec,
+};
 use core::{fmt, iter};
 
 /// Configuration for [`run`].

--- a/src/executor/runtime_host.rs
+++ b/src/executor/runtime_host.rs
@@ -42,7 +42,10 @@ use crate::{
     trie::calculate_root,
 };
 
-use alloc::{string::String, vec::Vec};
+use alloc::{
+    string::{String, ToString as _},
+    vec::Vec,
+};
 use core::{fmt, iter, slice};
 use hashbrown::{HashMap, HashSet};
 

--- a/src/executor/vm.rs
+++ b/src/executor/vm.rs
@@ -93,7 +93,7 @@ mod interpreter;
 #[cfg(all(target_arch = "x86_64", feature = "std"))]
 mod jit;
 
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 use core::{convert::TryFrom, fmt};
 use smallvec::SmallVec;
 

--- a/src/executor/vm/interpreter.rs
+++ b/src/executor/vm/interpreter.rs
@@ -22,7 +22,7 @@ use super::{
     Signature, StartErr, Trap, ValueType, WasmValue,
 };
 
-use alloc::{borrow::ToOwned as _, boxed::Box, format, sync::Arc, vec::Vec};
+use alloc::{borrow::ToOwned as _, boxed::Box, format, string::ToString as _, sync::Arc, vec::Vec};
 use core::{
     cell::RefCell,
     convert::{TryFrom, TryInto as _},

--- a/src/finality/grandpa/chain_config.rs
+++ b/src/finality/grandpa/chain_config.rs
@@ -20,7 +20,7 @@ use crate::{
     header,
 };
 
-use alloc::vec::Vec;
+use alloc::{borrow::ToOwned as _, vec::Vec};
 use core::num::NonZeroU64;
 use parity_scale_codec::DecodeAll as _;
 

--- a/src/finality/grandpa/warp_sync.rs
+++ b/src/finality/grandpa/warp_sync.rs
@@ -22,6 +22,8 @@ use crate::finality::justification::verify::{
 use crate::header::{DigestItemRef, GrandpaConsensusLogRef, Header};
 use crate::network::protocol::GrandpaWarpSyncResponseFragment;
 
+use alloc::vec::Vec;
+
 #[derive(Debug, derive_more::Display)]
 pub enum Error {
     #[display(fmt = "{}", _0)]

--- a/src/finality/justification/decode.rs
+++ b/src/finality/justification/decode.rs
@@ -133,7 +133,7 @@ pub struct PrecommitsRefIter<'a> {
 }
 
 enum PrecommitsRefIterInner<'a> {
-    Decoded(std::slice::Iter<'a, Precommit>),
+    Decoded(core::slice::Iter<'a, Precommit>),
     Undecoded {
         remaining_len: usize,
         pointer: &'a [u8],

--- a/src/json_rpc/methods.rs
+++ b/src/json_rpc/methods.rs
@@ -19,7 +19,14 @@
 
 use super::parse;
 use crate::util;
-use alloc::{format, string::String, vec::Vec};
+
+use alloc::{
+    borrow::ToOwned as _,
+    boxed::Box,
+    format,
+    string::{String, ToString as _},
+    vec::Vec,
+};
 use core::convert::TryFrom as _;
 
 /// Parses a JSON call (usually received from a JSON-RPC server).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,8 +184,7 @@
 //! - TODO: telemetry
 //!
 
-// TODO: for `no_std`, fix all the compilation errors caused by the copy-pasted code
-//#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![deny(broken_intra_doc_links)]
 #![deny(unused_crate_dependencies)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,8 @@
 //! - TODO: telemetry
 //!
 
+// The library part of `smoldot` should as pure as possible and shouldn't rely on any environment
+// such as a file system, environment variables, time, randomness, etc.
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![deny(broken_intra_doc_links)]
 #![deny(unused_crate_dependencies)]

--- a/src/libp2p.rs
+++ b/src/libp2p.rs
@@ -94,7 +94,7 @@
 // the substream which is thought to be the old one but is actually the new one.
 //
 
-use alloc::sync::Arc;
+use alloc::{string::String, sync::Arc, vec::Vec};
 use connection::established;
 use core::{
     iter, mem,

--- a/src/libp2p/connection/established.rs
+++ b/src/libp2p/connection/established.rs
@@ -52,7 +52,10 @@ use crate::util::leb128;
 
 use super::{multistream_select, noise, yamux};
 
-use alloc::vec::{self, Vec};
+use alloc::{
+    string::String,
+    vec::{self, Vec},
+};
 use core::{
     cmp, fmt, iter, mem,
     ops::{Add, Sub},

--- a/src/libp2p/connection/handshake.rs
+++ b/src/libp2p/connection/handshake.rs
@@ -39,7 +39,7 @@ use super::{
     yamux,
 };
 
-use alloc::vec;
+use alloc::{boxed::Box, vec};
 use core::{fmt, iter};
 
 mod tests;

--- a/src/metadata/query.rs
+++ b/src/metadata/query.rs
@@ -57,7 +57,7 @@
 
 use crate::executor::{host, read_only_runtime_host};
 
-use alloc::vec::Vec;
+use alloc::{borrow::ToOwned as _, vec::Vec};
 
 /// Retrieves the SCALE-encoded metadata from the given virtual machine prototype.
 ///

--- a/src/network/protocol/identify.rs
+++ b/src/network/protocol/identify.rs
@@ -18,7 +18,7 @@
 use super::schema;
 use crate::libp2p::{peer_id::PublicKey, Multiaddr};
 
-use alloc::vec::Vec;
+use alloc::{borrow::ToOwned as _, vec::Vec};
 use core::iter;
 use prost::Message as _;
 

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -20,6 +20,12 @@ use crate::libp2p::{
 };
 use crate::network::protocol;
 use crate::util;
+
+use alloc::{
+    format,
+    string::{String, ToString as _},
+    vec::Vec,
+};
 use core::{
     fmt, iter,
     num::NonZeroUsize,

--- a/src/trie/trie_structure.rs
+++ b/src/trie/trie_structure.rs
@@ -22,7 +22,7 @@
 
 use super::nibble::Nibble;
 
-use alloc::vec::Vec;
+use alloc::{borrow::ToOwned as _, vec::Vec};
 use core::{convert::TryFrom as _, fmt, iter};
 use either::Either;
 use slab::Slab;


### PR DESCRIPTION
cc #106 

Adds `#![no_std]` in `lib.rs` and fixes the resulting compilation errors.
