### PR TITLE
Properly return the prototype in case of error

### DIFF
--- a/src/author/runtime.rs
+++ b/src/author/runtime.rs
@@ -119,7 +119,7 @@ pub enum Error {
     WasmVm(runtime_host::Error),
     /// Error while initializing the Wasm virtual machine.
     #[display(fmt = "{}", _0)]
-    VmInit(host::StartErr),
+    VmInit(host::StartErr, host::HostVmPrototype),
     /// Overflow when incrementing block height.
     BlockHeightOverflow,
     /// `Core_initialize_block` has returned a non-empty output.
@@ -185,7 +185,7 @@ pub fn build_block(config: Config) -> BlockBuild {
 
     let vm = match init_result {
         Ok(vm) => vm,
-        Err(err) => return BlockBuild::Finished(Err(Error::VmInit(err))),
+        Err((err, proto)) => return BlockBuild::Finished(Err(Error::VmInit(err, proto))),
     };
 
     let shared = Shared {
@@ -329,7 +329,9 @@ impl BlockBuild {
 
                     inner = Inner::Runtime(match init_result {
                         Ok(vm) => vm,
-                        Err(err) => return BlockBuild::Finished(Err(Error::VmInit(err))),
+                        Err((err, proto)) => {
+                            return BlockBuild::Finished(Err(Error::VmInit(err, proto)))
+                        }
                     });
                 }
 
@@ -533,7 +535,7 @@ impl InherentExtrinsics {
 
         let vm = match init_result {
             Ok(vm) => vm,
-            Err(err) => return BlockBuild::Finished(Err(Error::VmInit(err))),
+            Err((err, proto)) => return BlockBuild::Finished(Err(Error::VmInit(err, proto))),
         };
 
         BlockBuild::from_inner(vm, self.shared)
@@ -625,7 +627,7 @@ impl ApplyExtrinsic {
 
         let vm = match init_result {
             Ok(vm) => vm,
-            Err(err) => return BlockBuild::Finished(Err(Error::VmInit(err))),
+            Err((err, proto)) => return BlockBuild::Finished(Err(Error::VmInit(err, proto))),
         };
 
         BlockBuild::from_inner(vm, self.shared)
@@ -646,7 +648,7 @@ impl ApplyExtrinsic {
 
         let vm = match init_result {
             Ok(vm) => vm,
-            Err(err) => return BlockBuild::Finished(Err(Error::VmInit(err))),
+            Err((err, proto)) => return BlockBuild::Finished(Err(Error::VmInit(err, proto))),
         };
 
         BlockBuild::from_inner(vm, self.shared)

--- a/src/chain/blocks_tree/verify.rs
+++ b/src/chain/blocks_tree/verify.rs
@@ -449,12 +449,15 @@ impl<T> VerifyContext<T> {
                     },
                 }
             }
-            verify::header_body::Verify::Finished(Err(error)) => BodyVerifyStep2::Error {
-                chain: NonFinalizedTree {
-                    inner: Some(self.chain),
-                },
-                error,
-            },
+            verify::header_body::Verify::Finished(Err((error, parent_runtime))) => {
+                BodyVerifyStep2::Error {
+                    chain: NonFinalizedTree {
+                        inner: Some(self.chain),
+                    },
+                    error,
+                    parent_runtime,
+                }
+            }
             verify::header_body::Verify::StorageGet(inner) => {
                 BodyVerifyStep2::StorageGet(StorageGet {
                     context: self,
@@ -694,6 +697,8 @@ pub enum BodyVerifyStep2<T> {
         chain: NonFinalizedTree<T>,
         /// Error that happened during the verification.
         error: verify::header_body::Error, // TODO: BodyVerifyError, or rename the error to be common
+        /// Value that was passed to [`BodyVerifyRuntimeRequired::resume`].
+        parent_runtime: host::HostVmPrototype,
     },
     /// Loading a storage value is required in order to continue.
     StorageGet(StorageGet<T>),

--- a/src/chain/chain_information/babe_fetch_epoch.rs
+++ b/src/chain/chain_information/babe_fetch_epoch.rs
@@ -41,11 +41,11 @@ pub struct Config {
 }
 
 /// Problem encountered during a call to [`babe_fetch_epoch`].
-#[derive(Debug, Clone, derive_more::Display)]
+#[derive(Debug, derive_more::Display)]
 pub enum Error {
     /// Error while starting the Wasm virtual machine.
     #[display(fmt = "{}", _0)]
-    WasmStart(host::StartErr),
+    WasmStart(host::StartErr, host::HostVmPrototype),
     /// Error while running the Wasm virtual machine.
     #[display(fmt = "{}", _0)]
     WasmVm(read_only_runtime_host::Error),
@@ -70,7 +70,7 @@ pub fn babe_fetch_epoch(config: Config) -> Query {
 
     match vm {
         Ok(vm) => Query::from_inner(vm),
-        Err(err) => Query::Finished(Err(Error::WasmStart(err))),
+        Err((err, proto)) => Query::Finished(Err(Error::WasmStart(err, proto))),
     }
 }
 

--- a/src/executor/read_only_runtime_host.rs
+++ b/src/executor/read_only_runtime_host.rs
@@ -43,7 +43,7 @@ pub struct Config<'a, TParams> {
 /// Start running the WebAssembly virtual machine.
 pub fn run(
     config: Config<impl Iterator<Item = impl AsRef<[u8]>> + Clone>,
-) -> Result<RuntimeHostVm, host::StartErr> {
+) -> Result<RuntimeHostVm, (host::StartErr, host::HostVmPrototype)> {
     Ok(Inner {
         vm: config
             .virtual_machine
@@ -86,8 +86,18 @@ impl fmt::Debug for SuccessVirtualMachine {
 }
 
 /// Error that can happen during the execution.
+#[derive(Debug, derive_more::Display)]
+#[display(fmt = "{}", detail)]
+pub struct Error {
+    /// Exact error that happened.
+    pub detail: ErrorDetail,
+    /// Prototype of the virtual machine that was passed through [`Config::virtual_machine`].
+    pub prototype: host::HostVmPrototype,
+}
+
+/// See [`Error::detail`].
 #[derive(Debug, Clone, derive_more::Display)]
-pub enum Error {
+pub enum ErrorDetail {
     /// Error while executing the Wasm virtual machine.
     #[display(fmt = "Error while executing Wasm VM: {}\n{:?}", error, logs)]
     WasmVm {
@@ -110,6 +120,18 @@ pub enum RuntimeHostVm {
     StorageGet(StorageGet),
     /// Fetching the key that follows a given one is required in order to continue.
     NextKey(NextKey),
+}
+
+impl RuntimeHostVm {
+    /// Cancels execution of the virtual machine and returns back the prototype.
+    pub fn into_prototype(self) -> host::HostVmPrototype {
+        match self {
+            RuntimeHostVm::Finished(Ok(inner)) => inner.virtual_machine.into_prototype(),
+            RuntimeHostVm::Finished(Err(inner)) => inner.prototype,
+            RuntimeHostVm::StorageGet(inner) => inner.inner.vm.into_prototype(),
+            RuntimeHostVm::NextKey(inner) => inner.inner.vm.into_prototype(),
+        }
+    }
 }
 
 /// Loading a storage value is required in order to continue.
@@ -219,10 +241,13 @@ impl Inner {
             match self.vm {
                 host::HostVm::ReadyToRun(r) => self.vm = r.run(),
 
-                host::HostVm::Error { error, .. } => {
-                    return RuntimeHostVm::Finished(Err(Error::WasmVm {
-                        error,
-                        logs: self.logs,
+                host::HostVm::Error { error, prototype } => {
+                    return RuntimeHostVm::Finished(Err(Error {
+                        detail: ErrorDetail::WasmVm {
+                            error,
+                            logs: self.logs,
+                        },
+                        prototype,
                     }));
                 }
 
@@ -283,14 +308,22 @@ impl Inner {
                     // TODO: optimize somehow? don't create an intermediary String?
                     let message = req.to_string();
                     if self.logs.len().saturating_add(message.len()) >= 1024 * 1024 {
-                        return RuntimeHostVm::Finished(Err(Error::LogsTooLong));
+                        return RuntimeHostVm::Finished(Err(Error {
+                            detail: ErrorDetail::LogsTooLong,
+                            prototype: host::HostVm::LogEmit(req).into_prototype(),
+                        }));
                     }
 
                     self.logs.push_str(&message);
                     self.vm = req.resume();
                 }
 
-                _ => return RuntimeHostVm::Finished(Err(Error::ForbiddenHostCall)),
+                other => {
+                    return RuntimeHostVm::Finished(Err(Error {
+                        detail: ErrorDetail::ForbiddenHostCall,
+                        prototype: other.into_prototype(),
+                    }))
+                }
             }
         }
     }

--- a/src/executor/vm/jit.rs
+++ b/src/executor/vm/jit.rs
@@ -304,13 +304,17 @@ impl JitPrototype {
     }
 
     /// See [`super::VirtualMachinePrototype::start`].
-    pub fn start(mut self, function_name: &str, params: &[WasmValue]) -> Result<Jit, StartErr> {
+    pub fn start(
+        mut self,
+        function_name: &str,
+        params: &[WasmValue],
+    ) -> Result<Jit, (StartErr, Self)> {
         match self.coroutine.run(Some(ToCoroutine::Start(
             function_name.to_owned(),
             params.to_owned(),
         ))) {
             corooteen::RunOut::Interrupted(FromCoroutine::StartResult(Err(err))) => {
-                return Err(err)
+                return Err((err, self))
             }
             corooteen::RunOut::Interrupted(FromCoroutine::StartResult(Ok(()))) => {}
             _ => unreachable!(),

--- a/src/finality/grandpa/chain_config.rs
+++ b/src/finality/grandpa/chain_config.rs
@@ -93,7 +93,7 @@ impl GrandpaGenesisConfiguration {
         // TODO: DRY with the babe config; put a helper in the executor module
         let mut vm: host::HostVm = vm
             .run_no_param("GrandpaApi_grandpa_authorities")
-            .map_err(FromVmPrototypeError::VmStart)?
+            .map_err(|(err, proto)| FromVmPrototypeError::VmStart(err, proto))?
             .into();
 
         Ok(loop {
@@ -148,7 +148,8 @@ impl FromGenesisStorageError {
 #[derive(Debug, derive_more::Display)]
 pub enum FromVmPrototypeError {
     /// Error when initializing the virtual machine.
-    VmStart(host::StartErr),
+    #[display(fmt = "{}", _0)]
+    VmStart(host::StartErr, host::HostVmPrototype),
     /// Crash while running the virtual machine.
     Trapped,
     /// Virtual machine tried to call a host function that isn't valid in this context.
@@ -160,11 +161,13 @@ impl FromVmPrototypeError {
     pub fn is_function_not_found(&self) -> bool {
         matches!(
             self,
-            FromVmPrototypeError::VmStart(host::StartErr::VirtualMachine(
-                vm::StartErr::FunctionNotFound,
-            )) | FromVmPrototypeError::VmStart(host::StartErr::VirtualMachine(
-                vm::StartErr::NotAFunction,
-            ))
+            FromVmPrototypeError::VmStart(
+                host::StartErr::VirtualMachine(vm::StartErr::FunctionNotFound,),
+                _
+            ) | FromVmPrototypeError::VmStart(
+                host::StartErr::VirtualMachine(vm::StartErr::NotAFunction,),
+                _
+            )
         )
     }
 }

--- a/src/metadata/query.rs
+++ b/src/metadata/query.rs
@@ -72,7 +72,7 @@ pub fn query_metadata(virtual_machine: host::HostVmPrototype) -> Query {
 
     match vm {
         Ok(vm) => Query::from_inner(vm),
-        Err(err) => Query::Finished(Err(Error::VmStart(err))),
+        Err((err, proto)) => Query::Finished(Err(Error::VmStart(err, proto))),
     }
 }
 
@@ -116,7 +116,8 @@ pub enum Error {
     /// Error when initializing the virtual machine.
     VmInitialization(host::NewErr),
     /// Error when starting the virtual machine.
-    VmStart(host::StartErr),
+    #[display(fmt = "{}", _0)]
+    VmStart(host::StartErr, host::HostVmPrototype),
     /// Error while running the Wasm virtual machine.
     #[display(fmt = "{}", _0)]
     WasmRun(read_only_runtime_host::Error),

--- a/src/sync/optimistic.rs
+++ b/src/sync/optimistic.rs
@@ -1060,7 +1060,11 @@ impl<TRq, TSrc, TBl> ProcessOne<TRq, TSrc, TBl> {
                 Inner::Step2(blocks_tree::BodyVerifyStep2::Error {
                     chain: old_chain,
                     error,
+                    parent_runtime,
                 }) => {
+                    if shared.inner.finalized_runtime.is_none() {
+                        shared.inner.finalized_runtime = Some(parent_runtime);
+                    }
                     if let Some(source) = shared.inner.sources.get_mut(&shared.source_id) {
                         source.banned = true;
                     }


### PR DESCRIPTION
Fix #597 

It turns out that I need this for parachains syncing (cc #221), because storage proofs can reasonably fail, in which case we need to interrupt the execution but keep the compiled runtime.
