### PR TITLE
Fix bad decoding/encoding of Babe next config digest

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -189,6 +189,7 @@ pub enum Error {
     BadBabeSealLength,
     BadBabePreDigestRefType,
     BadBabeConsensusRefType,
+    BadBabeNextConfigVersion,
     /// There are multiple Babe pre-runtime digests in the block header.
     MultipleBabePreRuntimeDigests,
     /// There are multiple Babe epoch descriptor digests in the block header.


### PR DESCRIPTION
Happens when syncing Rococo.

Reference: https://github.com/paritytech/substrate/blob/93b231e79f5b4e551c34234e89fa4a2e5e9c1510/primitives/consensus/babe/src/digests.rs#L140-L141