### PR TITLE
Fix persisted validation data decoding and tweak nom_option_decode

### DIFF
--- a/src/database/full_sled.rs
+++ b/src/database/full_sled.rs
@@ -1365,7 +1365,7 @@ fn decode_babe_epoch_information<E: From<AccessError>>(
     let result = nom::combinator::all_consuming(nom::combinator::map(
         nom::sequence::tuple((
             nom::number::complete::le_u64,
-            |b| util::nom_option_decode(b, nom::number::complete::le_u64),
+            util::nom_option_decode(nom::number::complete::le_u64),
             nom::combinator::flat_map(crate::util::nom_scale_compact_usize, |num_elems| {
                 nom::multi::many_m_n(
                     num_elems,

--- a/src/metadata/decode.rs
+++ b/src/metadata/decode.rs
@@ -257,9 +257,9 @@ fn module_metadata(bytes: &[u8]) -> nom::IResult<&[u8], ModuleMetadataRef, NomEr
         nom::combinator::map(
             nom::sequence::tuple((
                 string_decode,
-                |i| crate::util::nom_option_decode(i, storage_metadata),
-                |i| crate::util::nom_option_decode(i, |i| vec_decode(i, function_metadata)),
-                |i| crate::util::nom_option_decode(i, |i| vec_decode(i, event_metadata)),
+                crate::util::nom_option_decode(storage_metadata),
+                crate::util::nom_option_decode(|i| vec_decode(i, function_metadata)),
+                crate::util::nom_option_decode(|i| vec_decode(i, event_metadata)),
                 |i| vec_decode(i, module_constant_metadata),
                 |i| vec_decode(i, error_metadata),
             )),

--- a/src/sync/para.rs
+++ b/src/sync/para.rs
@@ -70,12 +70,14 @@ impl OccupiedCoreAssumption {
     }
 }
 
-/// Attempt to decode the given SCALE-encoded persisted validation data.
-// TODO: shouldn't this method be specific to Grandpa?
-pub fn decode_persisted_validation_data(
+/// Attempt to decode the return value of the  `ParachainHost_persisted_validation_data` runtime
+/// call.
+pub fn decode_persisted_validation_data_return_value(
     scale_encoded: &[u8],
-) -> Result<PersistedValidationDataRef, Error> {
-    match nom::combinator::all_consuming(persisted_validation_data)(scale_encoded) {
+) -> Result<Option<PersistedValidationDataRef>, Error> {
+    match nom::combinator::all_consuming(crate::util::nom_option_decode(persisted_validation_data))(
+        scale_encoded,
+    ) {
         Ok((_, data)) => Ok(data),
         Err(err) => Err(Error(err)),
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -22,21 +22,20 @@ use core::convert::TryFrom as _;
 
 pub(crate) mod leb128;
 
-/// Decodes a SCALE-encoded `Option`.
+/// Returns a parser that decodes a SCALE-encoded `Option`.
 ///
 /// > **Note**: When using this function outside of a `nom` "context", you might have to explicit
 /// >           the type of `E`. Use `nom::Err<nom::error::Error>`.
 pub(crate) fn nom_option_decode<'a, O, E: nom::error::ParseError<&'a [u8]>>(
-    bytes: &'a [u8],
     inner_decode: impl Fn(&'a [u8]) -> nom::IResult<&'a [u8], O, E>,
-) -> nom::IResult<&'a [u8], Option<O>, E> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], Option<O>, E> {
     nom::branch::alt((
         nom::combinator::map(nom::bytes::complete::tag(&[0]), |_| None),
         nom::combinator::map(
             nom::sequence::preceded(nom::bytes::complete::tag(&[1]), inner_decode),
             Some,
         ),
-    ))(bytes)
+    ))
 }
 
 /// Decodes a SCALE-compact-encoded usize.


### PR DESCRIPTION
The return value of the runtime call is in fact an `Option`, not just a plain struct.

cc #221 