### PR TITLE
Allow getting storage root in read-only runtime call

### DIFF
--- a/bin/wasm-node/rust/src/runtime_service.rs
+++ b/bin/wasm-node/rust/src/runtime_service.rs
@@ -310,6 +310,9 @@ impl RuntimeService {
                     executor::read_only_runtime_host::RuntimeHostVm::NextKey(_) => {
                         todo!() // TODO:
                     }
+                    executor::read_only_runtime_host::RuntimeHostVm::StorageRoot(storage_root) => {
+                        runtime_call = storage_root.resume(&runtime_block_state_root);
+                    }
                 }
             }
         }

--- a/src/chain/chain_information/babe_fetch_epoch.rs
+++ b/src/chain/chain_information/babe_fetch_epoch.rs
@@ -91,6 +91,8 @@ pub enum Query {
     StorageGet(StorageGet),
     /// Fetching the key that follows a given one is required in order to continue.
     NextKey(NextKey),
+    /// Fetching the storage trie root is required in order to continue.
+    StorageRoot(StorageRoot),
 }
 
 impl Query {
@@ -126,6 +128,9 @@ impl Query {
             }
             read_only_runtime_host::RuntimeHostVm::StorageGet(inner) => {
                 Query::StorageGet(StorageGet(inner))
+            }
+            read_only_runtime_host::RuntimeHostVm::StorageRoot(inner) => {
+                Query::StorageRoot(StorageRoot(inner))
             }
             read_only_runtime_host::RuntimeHostVm::NextKey(inner) => Query::NextKey(NextKey(inner)),
         }
@@ -173,6 +178,17 @@ impl NextKey {
     ///
     pub fn inject_key(self, key: Option<impl AsRef<[u8]>>) -> Query {
         Query::from_inner(self.0.inject_key(key))
+    }
+}
+
+/// Fetching the storage trie root is required in order to continue.
+#[must_use]
+pub struct StorageRoot(read_only_runtime_host::StorageRoot);
+
+impl StorageRoot {
+    /// Writes the trie root hash to the Wasm VM and prepares it for resume.
+    pub fn resume(self, hash: &[u8; 32]) -> Query {
+        Query::from_inner(self.0.resume(hash))
     }
 }
 

--- a/src/metadata/query.rs
+++ b/src/metadata/query.rs
@@ -106,6 +106,9 @@ impl Query {
             read_only_runtime_host::RuntimeHostVm::NextKey(_) => {
                 Query::Finished(Err(Error::HostFunctionNotAllowed))
             }
+            read_only_runtime_host::RuntimeHostVm::StorageRoot(_) => {
+                Query::Finished(Err(Error::HostFunctionNotAllowed))
+            }
         }
     }
 }


### PR DESCRIPTION
cc #221 #301

Allows obtaining the storage trie root from within the runtime during a read-only call.
Adds a `RuntimeHostVm::StorageRoot` variant that requires passing the state trie root in order to resume execution.

I've had to turn `GrandpaWarpSync::from_babe_fetch_epoch_query` into a loop in order to allow resuming execution instantly.
