### PR TITLE
Remove some bad networking debug_assert!s

### DIFF
--- a/bin/wasm-node/rust/src/network_service.rs
+++ b/bin/wasm-node/rust/src/network_service.rs
@@ -559,7 +559,6 @@ impl NetworkService {
             }
         }
 
-        debug_assert_eq!(outcome_errors.len(), outcome_errors.capacity());
         Err(StorageQueryError {
             errors: outcome_errors,
         })
@@ -624,7 +623,6 @@ impl NetworkService {
                 }
             }
 
-            debug_assert_eq!(outcome_errors.len(), outcome_errors.capacity());
             return Err(StorageQueryError {
                 errors: outcome_errors,
             });
@@ -693,7 +691,6 @@ impl NetworkService {
             }
         }
 
-        debug_assert_eq!(outcome_errors.len(), outcome_errors.capacity());
         Err(CallProofQueryError {
             errors: outcome_errors,
         })


### PR DESCRIPTION
If we have less than `NUM_ATTEMPTS` peers, then the number of errors will not be equal to `NUM_ATTEMPTS`.