### PR TITLE
Don't send empty WebSocket frames

### DIFF
--- a/bin/wasm-node/rust/src/network_service.rs
+++ b/bin/wasm-node/rust/src/network_service.rs
@@ -935,7 +935,9 @@ async fn connection_task(
             return;
         }
 
-        websocket.send(&write_buffer[..read_write.written_bytes]);
+        if read_write.written_bytes != 0 {
+            websocket.send(&write_buffer[..read_write.written_bytes]);
+        }
 
         websocket.advance_read_cursor(read_write.read_bytes);
 


### PR DESCRIPTION
It seems that Firefox discards empty frames, which is why I've never noticed when testing on my machine, but Chrome doesn't discard them and sends them anyway.