### PR TITLE
Prototype for using the browser's Wasm VM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,12 @@ jobs:
     - uses: Swatinem/rust-cache@v1
     - run: cargo check --package smoldot --locked --no-default-features
     - run: cargo check --package smoldot --locked --no-default-features --features database-sled
+    - run: cargo check --package smoldot --locked --no-default-features --features javascript-wasm-vm
     - run: cargo check --package smoldot --locked --no-default-features --features std
+    - run: cargo check --package smoldot --locked --no-default-features --features database-sled --features javascript-wasm-vm
     - run: cargo check --package smoldot --locked --no-default-features --features database-sled --features std
+    - run: cargo check --package smoldot --locked --no-default-features --features javascript-wasm-vm --features std
+    - run: cargo check --package smoldot --locked --no-default-features --features database-sled --features std --features javascript-wasm-vm
 
   check-rustdoc-links:
     name: Check rustdoc intra-doc links

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ database-sled = [
     "sled",
     "std"   # A database stored on the filesystem can't reasonably work without a filesystem.
 ]
+javascript-wasm-vm = []
 std = [
     "async-std",
     "futures/thread-pool",

--- a/bin/wasm-node/javascript/child-wasm-worker.js
+++ b/bin/wasm-node/javascript/child-wasm-worker.js
@@ -1,0 +1,62 @@
+// Smoldot
+// Copyright (C) 2019-2021  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+let instance = null;
+
+startInstance = (incomingMessage) => {
+  const moduleImports = WebAssembly.Module.imports(incomingMessage.module);
+  let constructedImports = {};
+  const returnValueSharedArrayBuffer = new Int32Array(incomingMessage.returnValueSharedArrayBuffer);
+
+  moduleImports.forEach((moduleImport, i) => {
+    if (!constructedImports[moduleImport.module])
+      constructedImports[moduleImport.module] = {};
+
+    if (moduleImport.kind == 'function') {
+      constructedImports[moduleImport.module][moduleImport.name] = () => {
+        postMessage({ functionId: requestedImports[i] });
+        Atomics.wait(returnValueSharedArrayBuffer, 0, 0);
+        returnValueSharedArrayBuffer[0] = 0;
+        var returnValue = returnValueSharedArrayBuffer[1];
+        throw requestedImports[i];
+      };
+
+    } else if (moduleImport.kind == 'memory') {
+      constructedImports[moduleImport.module][moduleImport.name] =
+        new WebAssembly.Memory({ initial: requestedImports[i], maximum: requestedImports[i], shared: true });
+
+    } else {
+      throw "Unknown kind: " + kind;
+    }
+  })
+
+  // TODO: must handle errors
+  instance = new WebAssembly.Instance(incomingMessage.module, constructedImports);
+};
+
+onmessage = (incomingMessage) => {
+  if (!instance) {
+    // The first message that is expected to come is of the form
+    // `{ module: <some Wasm module> , requestedImports: [..] }`. We instantiate this module.
+    startInstance(incomingMessage);
+  } else {
+    // The second message that is expected to come is of the form
+    // `{ functionName: "foo", params: [..] }`.
+    const to_start = instance.exports[incomingMessage.functionName];
+    to_start(incomingMessage.params);
+  }
+};

--- a/bin/wasm-node/rust/Cargo.toml
+++ b/bin/wasm-node/rust/Cargo.toml
@@ -21,4 +21,4 @@ log = { version = "0.4.14", features = ["std"] }
 lru = "0.6.5"
 rand = "0.8.3"
 serde_json = "1.0.64"
-smoldot = { version = "0.1.0", path = "../../..", default-features = false }
+smoldot = { version = "0.1.0", path = "../../..", default-features = false, features = ["javascript-wasm-vm"] }

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -232,7 +232,7 @@ impl HostVmPrototype {
                 &module,
                 heap_pages,
                 // This closure is called back for each function that the runtime imports.
-                |mod_name, f_name, _signature| {
+                |mod_name, f_name| {
                     if mod_name != "env" {
                         return Err(());
                     }

--- a/src/executor/vm/javascript.rs
+++ b/src/executor/vm/javascript.rs
@@ -1,0 +1,372 @@
+// Smoldot
+// Copyright (C) 2019-2021  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Implements the API documented [in the parent module](..).
+
+use super::{
+    ExecOutcome, GlobalValueErr, HeapPages, ModuleError, NewErr, OutOfBoundsError, RunErr,
+    Signature, StartErr, Trap, ValueType, WasmValue,
+};
+
+use alloc::{
+    borrow::ToOwned as _,
+    boxed::Box,
+    format,
+    string::{String, ToString as _},
+    sync::Arc,
+    vec::Vec,
+};
+use core::{
+    cell::RefCell,
+    convert::{TryFrom, TryInto as _},
+    fmt,
+};
+
+/// This module uses external functions that the environment (i.e. browser or NodeJS) must
+/// implement.
+///
+/// This functions ressemble the functions of the `WebAssembly` w3c specifications.
+/// See <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly>.
+/// However, due notably to the requirement that Wasm functions execution be asynchronous, there
+/// exists some significant differences. Make sure to carefully read the documentation.
+// TODO: properly document functions
+#[link(wasm_import_module = "javascript_wasm_vm")]
+extern "C" {
+    fn new_module(module_ptr: *const u8, module_size: usize, num_imports: *mut u32) -> i32;
+
+    /// Returns 1 if the `import_num`th import of the module identified by `module_id` is a
+    /// function. Returns 0 if it is a memory.
+    fn module_import_is_fn(module_id: i32, import_num: u32) -> i32;
+
+    /// Returns the length of the name in bytes of the name of the module of the import
+    /// represented by `module_id` and `import_num`.
+    fn module_import_module_len(module_id: i32, import_num: u32) -> i32;
+
+    /// Writes in `out` the name in bytes of the name of the module of the import represented by
+    /// `module_id` and `import_num`.
+    fn module_import_module(module_id: i32, import_num: u32, out: *mut u8);
+
+    /// Returns the length of the name in bytes of the name of the import represented by
+    /// `module_id` and `import_num`.
+    fn module_import_name_len(module_id: i32, import_num: u32) -> i32;
+
+    /// Writes in `out` the name in bytes of the name of the import represented by `module_id` and
+    /// `import_num`.
+    fn module_import_name(module_id: i32, import_num: u32, out: *mut u8);
+
+    /// Permits freeing the memory associated with the given module. The passed `module_id` is no
+    /// longer considered valid.
+    ///
+    /// > **Note**: This doesn't mean that the module must be destroyed now, only that we will no
+    /// >           longer reference it. It is likely for this function to be called while there
+    /// >           is one or more instances using that module.
+    fn destroy_module(module_id: i32);
+
+    fn new_instance(module_id: i32, imports_ptr: *const u32) -> i32;
+
+    fn instance_push_i32(instance_id: i32, value: i32);
+
+    fn instance_push_i64(instance_id: i32, value: i64);
+
+    fn instance_start(instance_id: i32, function_name_ptr: *const u8, function_name_size: usize);
+
+    fn instance_resume(instance_id: i32);
+
+    fn destroy_instance(instance_id: i32);
+
+    /// Fetch from the given instance the value of the export whose name is passed as parameter.
+    /// The export must be of type `i32`.
+    ///
+    /// The export name is a UTF-8 string found in the memory at offset `name_ptr` and with
+    /// length `name_size`.
+    ///
+    /// Must return 0 to indicate success. The value of the global must have been written at the
+    /// address designated by `out`.
+    /// Must return 1 if the export wasn't found. Must return 2 if the export isn't a global
+    /// value of type `i32`.
+    fn global_value(instance_id: i32, name_ptr: *const u8, name_size: usize, out: *mut u32) -> i32;
+
+    /// Must return the current size of the memory in bytes of the given instance.
+    fn memory_size(instance_id: i32) -> u32;
+
+    /// Must read `size` bytes from the memory of the instance starting at `offset` and write
+    /// them to `out`.
+    fn read_memory(instance_id: i32, offset: u32, size: u32, out: *mut u8);
+
+    /// Must write `size` bytes into the memory of the instance starting at `offset`. The data
+    /// can be found in `data`.
+    fn write_memory(instance_id: i32, offset: u32, size: u32, data: *const u8);
+}
+
+/// See [`super::Module`].
+#[derive(Clone)]
+pub struct Module {
+    /// The value returned by the environment when creating the module.
+    external_identifier: i32,
+    /// Number of imports made by the module.
+    num_imports: u32,
+}
+
+impl Module {
+    /// See [`super::Module::new`].
+    pub fn new(module_bytes: impl AsRef<[u8]>) -> Result<Self, NewErr> {
+        let module_bytes = module_bytes.as_ref();
+
+        let mut num_imports = 0u32;
+        let external_identifier =
+            unsafe { new_module(module_bytes.as_ptr(), module_bytes.len(), &mut num_imports) };
+
+        Ok(Module {
+            external_identifier,
+            num_imports,
+        })
+    }
+}
+
+impl Drop for Module {
+    fn drop(&mut self) {
+        unsafe {
+            destroy_module(self.external_identifier);
+        }
+    }
+}
+
+/// See [`super::VirtualMachinePrototype`].
+pub struct JsVmPrototype {
+    // The value returned by the environment when creating the instance.
+    external_identifier: InstanceRaii,
+}
+
+impl JsVmPrototype {
+    /// See [`super::VirtualMachinePrototype::new`].
+    pub fn new(
+        module: &Module,
+        heap_pages: HeapPages,
+        mut symbols: impl FnMut(&str, &str) -> Result<usize, ()>,
+    ) -> Result<Self, NewErr> {
+        let mut imports = Vec::with_capacity(usize::try_from(module.num_imports).unwrap());
+
+        for import_num in 0..module.num_imports {
+            let module_name = unsafe {
+                let len = usize::try_from(module_import_module_len(
+                    module.external_identifier,
+                    import_num,
+                ))
+                .unwrap();
+                let mut out = Vec::<u8>::with_capacity(len);
+                module_import_module(
+                    module.external_identifier,
+                    import_num,
+                    out.as_mut_ptr() as *mut u8,
+                );
+                out.set_len(len);
+                String::from_utf8(out).unwrap()
+            };
+
+            let name = unsafe {
+                let len = usize::try_from(module_import_name_len(
+                    module.external_identifier,
+                    import_num,
+                ))
+                .unwrap();
+                let mut out = Vec::<u8>::with_capacity(len);
+                module_import_name(
+                    module.external_identifier,
+                    import_num,
+                    out.as_mut_ptr() as *mut u8,
+                );
+                out.set_len(len);
+                String::from_utf8(out).unwrap()
+            };
+
+            let is_function =
+                unsafe { module_import_is_fn(module.external_identifier, import_num) != 0 };
+
+            if is_function {
+                let index = match symbols(&module_name, &name) {
+                    Ok(i) => i,
+                    Err(_) => {
+                        return Err(NewErr::ModuleError(ModuleError(format!(
+                            "Couldn't resolve `{}`:`{}`",
+                            module_name, name
+                        ))))
+                    }
+                };
+
+                imports.push(u32::try_from(index).unwrap());
+            } else {
+                imports.push(heap_pages.0);
+            }
+        }
+
+        let external_identifier =
+            InstanceRaii(unsafe { new_instance(module.external_identifier, imports.as_ptr()) });
+
+        Ok(JsVmPrototype {
+            external_identifier,
+        })
+    }
+
+    /// See [`super::VirtualMachinePrototype::global_value`].
+    pub fn global_value(&self, name: &str) -> Result<u32, GlobalValueErr> {
+        unsafe {
+            let mut out = 0u32;
+            let ret = global_value(
+                self.external_identifier.0,
+                name.as_bytes().as_ptr(),
+                name.as_bytes().len(),
+                &mut out as *mut u32,
+            );
+
+            if ret == 0 {
+                Ok(out)
+            } else if ret == 1 {
+                Err(GlobalValueErr::NotFound)
+            } else if ret == 2 {
+                Err(GlobalValueErr::Invalid)
+            } else {
+                unreachable!()
+            }
+        }
+    }
+
+    /// See [`super::VirtualMachinePrototype::start`].
+    pub fn start(
+        self,
+        function_name: &str,
+        params: &[WasmValue],
+    ) -> Result<JsVm, (StartErr, Self)> {
+        unsafe {
+            for param in params {
+                match *param {
+                    WasmValue::I32(value) => instance_push_i32(self.external_identifier.0, value),
+                    WasmValue::I64(value) => instance_push_i64(self.external_identifier.0, value),
+                }
+            }
+
+            // TODO: error handling
+            instance_start(
+                self.external_identifier.0,
+                function_name.as_bytes().as_ptr(),
+                function_name.as_bytes().len(),
+            );
+        }
+
+        Ok(JsVm {
+            external_identifier: self.external_identifier,
+        })
+    }
+}
+
+impl fmt::Debug for JsVmPrototype {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("JsVmPrototype").finish()
+    }
+}
+
+/// See [`super::VirtualMachine`].
+pub struct JsVm {
+    // The value returned by the environment when creating the instance.
+    external_identifier: InstanceRaii,
+}
+
+impl JsVm {
+    /// See [`super::VirtualMachine::run`].
+    pub fn run(&mut self, value: Option<WasmValue>) -> Result<ExecOutcome, RunErr> {
+        unsafe {
+            match value {
+                Some(WasmValue::I32(value)) => instance_push_i32(self.external_identifier.0, value),
+                Some(WasmValue::I64(value)) => instance_push_i64(self.external_identifier.0, value),
+                None => {}
+            }
+
+            instance_resume(self.external_identifier.0);
+
+            todo!()
+        }
+    }
+
+    /// See [`super::VirtualMachine::memory_size`].
+    pub fn memory_size(&self) -> u32 {
+        // Because the child Wasm instance is free to resize its memory while it is executing,
+        // we need to re-query it every single time.
+        unsafe { memory_size(self.external_identifier.0) }
+    }
+
+    /// See [`super::VirtualMachine::read_memory`].
+    pub fn read_memory(
+        &'_ self,
+        offset: u32,
+        size: u32,
+    ) -> Result<impl AsRef<[u8]> + '_, OutOfBoundsError> {
+        if offset + size > self.memory_size() {
+            return Err(OutOfBoundsError);
+        }
+
+        unsafe {
+            let mut out = Vec::<u8>::with_capacity(usize::try_from(size).unwrap());
+            read_memory(self.external_identifier.0, offset, size, out.as_mut_ptr());
+            out.set_len(usize::try_from(size).unwrap());
+            Ok(out)
+        }
+    }
+
+    /// See [`super::VirtualMachine::write_memory`].
+    pub fn write_memory(&mut self, offset: u32, value: &[u8]) -> Result<(), OutOfBoundsError> {
+        let value_len = u32::try_from(value.len()).unwrap();
+        if offset + value_len > self.memory_size() {
+            return Err(OutOfBoundsError);
+        }
+
+        unsafe {
+            write_memory(
+                self.external_identifier.0,
+                offset,
+                value_len,
+                value.as_ptr(),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// See [`super::VirtualMachine::into_prototype`].
+    pub fn into_prototype(self) -> JsVmPrototype {
+        // TODO: interrupt the current execution?
+        // TODO: zero the memory
+
+        JsVmPrototype {
+            external_identifier: self.external_identifier,
+        }
+    }
+}
+
+impl fmt::Debug for JsVm {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("JsVm").finish()
+    }
+}
+
+struct InstanceRaii(i32);
+
+impl Drop for InstanceRaii {
+    fn drop(&mut self) {
+        unsafe {
+            destroy_instance(self.0);
+        }
+    }
+}

--- a/src/executor/vm/jit.rs
+++ b/src/executor/vm/jit.rs
@@ -79,7 +79,7 @@ impl JitPrototype {
     pub fn new(
         module: &Module,
         heap_pages: HeapPages,
-        mut symbols: impl FnMut(&str, &str, &Signature) -> Result<usize, ()>,
+        mut symbols: impl FnMut(&str, &str) -> Result<usize, ()>,
     ) -> Result<Self, NewErr> {
         let store = wasmtime::Store::new_async(&module.inner.engine());
 
@@ -98,9 +98,10 @@ impl JitPrototype {
                 match import.ty() {
                     wasmtime::ExternType::Func(f) => {
                         // TODO: don't panic below
-                        let function_index = match import.name().and_then(|name| {
-                            symbols(import.module(), name, &TryFrom::try_from(&f).unwrap()).ok()
-                        }) {
+                        let function_index = match import
+                            .name()
+                            .and_then(|name| symbols(import.module(), name).ok())
+                        {
                             Some(idx) => idx,
                             None => {
                                 return Err(NewErr::ModuleError(ModuleError(format!(


### PR DESCRIPTION
This is a work-in-progress for adding a third "Wasm provider" for executing the runtime, next to wasmi and wasmtime: the browser's virtual machine. Sorry for that pile of mess, I'm mostly using draft PRs to keep track of ongoing work.

Doing so has two main advantages:

- Removing `wasmi` from the code shrinks the generated wasm-node Wasm from ~5MiB to ~3MiB.
- It's more than likely much faster to use the browser's VM than wasmi (if anything, for the fact that wasmi itself is executed by the browser).

This change is implemented by adding an `extern {}` block containing function definitions that the environment (i.e. `index.js`) must implement. These functions include creating a new Wasm VM, running it, and so on. In order to avoid poisoning the required functions, this feature is enabled only when `--features javascript-wasm-vm` is passed.

The main difficulty in this change is that JS doesn't allow asynchronous functions as callback. Basically, it is mandatory for host functions to return instantaneously. There is however one trick that can be used: [`Atomics.wait`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait). It is the one and only JS function that browsers accept and that can block the current "thread". [This repo](https://github.com/hyperdivision/async-wasm) shows that is should indeed work.

The idea is: we spawn a worker thread, start executing the Wasm synchronously, and went it calls a host function, we use `Atomics.wait` to wait until the call to the host function is handled by the non-worker thread.

However, it gets trickier. Smoldot, similarly, assumes that [executing Wasm code is synchronous](https://github.com/paritytech/smoldot/blob/c7e1729d9197a78202b74e1541a2e66fbdc82839/src/executor/vm.rs#L251) (which it normally is). The `VirtualMachine::run` function (which I just linked) is expected to run a little bit of Wasm then report about it has done.

Because of this, smoldot itself must use the same trick: run in a worker and use `Atomics.wait` when `VirtualMachine::run`.

Before continuing this PR, I'm going to try investigate what the trade-offs are when it comes to running smoldot in a worker itself.
