### PR TITLE
Add a terminate() function to the Wasm client

### DIFF
--- a/bin/wasm-node/javascript/src/index.d.ts
+++ b/bin/wasm-node/javascript/src/index.d.ts
@@ -21,6 +21,7 @@ declare class SmoldotError extends Error {
 
 export interface SmoldotClient {
   send_json_rpc(rpc: string): void;
+  terminate(): void;
 }
 
 export type SmoldotJsonRpcCallback = (response: string) => void;

--- a/bin/wasm-node/javascript/src/index.js
+++ b/bin/wasm-node/javascript/src/index.js
@@ -64,6 +64,9 @@ export async function start(config) {
   return {
     send_json_rpc: (request) => {
       worker.postMessage(request);
+    },
+    terminate: () => {
+      worker.terminate();
     }
   }
 }

--- a/bin/wasm-node/javascript/src/index.test-d.ts
+++ b/bin/wasm-node/javascript/src/index.test-d.ts
@@ -9,4 +9,6 @@ smoldot.start({
   relay_chain_spec: '',
   json_rpc_callback: (resp) => {},
   database_save_callback: (content) => {},
+}).then(sm => {
+  sm.terminate();
 });


### PR DESCRIPTION
Call this in order to destroy the smoldot client.