### PR TITLE
Change relay_chain_spec field to parachain_spec

### DIFF
--- a/bin/wasm-node/javascript/src/index.d.ts
+++ b/bin/wasm-node/javascript/src/index.d.ts
@@ -33,7 +33,7 @@ export interface SmoldotOptions {
   json_rpc_callback: SmoldotJsonRpcCallback;
   database_save_callback: SmoldotDatabaseSaveCallback;
   database_content?: string;
-  relay_chain_spec?: string;
+  parachain_spec?: string;
 }
 
 export interface Smoldot {

--- a/bin/wasm-node/javascript/src/index.js
+++ b/bin/wasm-node/javascript/src/index.js
@@ -52,7 +52,7 @@ export async function start(config) {
   worker.postMessage({
     chain_spec: config.chain_spec,
     database_content: config.database_content,
-    relay_chain_spec: config.relay_chain_spec,
+    parachain_spec: config.parachain_spec,
     // Maximum level of log entries sent by the client.
     // 0 = Logging disabled, 1 = Error, 2 = Warn, 3 = Info, 4 = Debug, 5 = Trace
     max_log_level: config.max_log_level || 5

--- a/bin/wasm-node/javascript/src/index.test-d.ts
+++ b/bin/wasm-node/javascript/src/index.test-d.ts
@@ -6,7 +6,7 @@ smoldot.start({
   max_log_level: 3,
   chain_spec: '',
   database_content: '',
-  relay_chain_spec: '',
+  parachain_spec: '',
   json_rpc_callback: (resp) => {},
   database_save_callback: (content) => {},
 }).then(sm => {

--- a/bin/wasm-node/javascript/src/worker.js
+++ b/bin/wasm-node/javascript/src/worker.js
@@ -40,7 +40,7 @@ let has_thrown = false;
 const startInstance = async (config) => {
   const chain_spec = config.chain_spec;
   const database_content = config.database_content;
-  const relay_chain_spec = config.relay_chain_spec;
+  const parachain_spec = config.parachain_spec;
   const max_log_level = config.max_log_level;
 
   // The actual Wasm bytecode is base64-decoded from a constant found in a different file.
@@ -96,18 +96,18 @@ const startInstance = async (config) => {
       .write(database_content, database_ptr);
   }
 
-  let relay_chain_spec_len = relay_chain_spec ? Buffer.byteLength(relay_chain_spec, 'utf8') : 0;
-  let relay_chain_spec_ptr = (relay_chain_spec_len != 0) ? result.instance.exports.alloc(relay_chain_spec_len) : 0;
-  if (relay_chain_spec_len != 0) {
+  let parachain_spec_len = parachain_spec ? Buffer.byteLength(parachain_spec, 'utf8') : 0;
+  let parachain_spec_ptr = (parachain_spec_len != 0) ? result.instance.exports.alloc(parachain_spec_len) : 0;
+  if (parachain_spec_len != 0) {
     Buffer.from(result.instance.exports.memory.buffer)
-      .write(relay_chain_spec, relay_chain_spec_ptr);
+      .write(parachain_spec, parachain_spec_ptr);
   }
 
   try {
     result.instance.exports.init(
       chain_spec_ptr, chain_spec_len,
       database_ptr, database_len,
-      relay_chain_spec_ptr, relay_chain_spec_len,
+      parachain_spec_ptr, parachain_spec_len,
       max_log_level
     );
 

--- a/bin/wasm-node/rust/src/ffi.rs
+++ b/bin/wasm-node/rust/src/ffi.rs
@@ -439,16 +439,16 @@ fn init(
     chain_specs_len: u32,
     database_content_ptr: u32,
     database_content_len: u32,
-    relay_chain_specs_ptr: u32,
-    relay_chain_specs_len: u32,
+    parachain_specs_ptr: u32,
+    parachain_specs_len: u32,
     max_log_level: u32,
 ) {
     let chain_specs_ptr = usize::try_from(chain_specs_ptr).unwrap();
     let chain_specs_len = usize::try_from(chain_specs_len).unwrap();
     let database_content_ptr = usize::try_from(database_content_ptr).unwrap();
     let database_content_len = usize::try_from(database_content_len).unwrap();
-    let relay_chain_specs_ptr = usize::try_from(relay_chain_specs_ptr).unwrap();
-    let relay_chain_specs_len = usize::try_from(relay_chain_specs_len).unwrap();
+    let parachain_specs_ptr = usize::try_from(parachain_specs_ptr).unwrap();
+    let parachain_specs_len = usize::try_from(parachain_specs_len).unwrap();
 
     let chain_specs: Box<[u8]> = unsafe {
         Box::from_raw(slice::from_raw_parts_mut(
@@ -471,11 +471,11 @@ fn init(
         None
     };
 
-    let relay_chain_specs = if relay_chain_specs_ptr != 0 {
+    let parachain_specs = if parachain_specs_ptr != 0 {
         let data: Box<[u8]> = unsafe {
             Box::from_raw(slice::from_raw_parts_mut(
-                relay_chain_specs_ptr as *mut u8,
-                relay_chain_specs_len,
+                parachain_specs_ptr as *mut u8,
+                parachain_specs_len,
             ))
         };
         Some(String::from_utf8(Vec::from(data)).expect("non-utf8 relay chain specs"))
@@ -498,7 +498,7 @@ fn init(
             database_content,
         })
         .chain(
-            relay_chain_specs
+            parachain_specs
                 .into_iter()
                 .map(|specification| super::ChainConfig {
                     specification,

--- a/bin/wasm-node/rust/src/ffi/bindings.rs
+++ b/bin/wasm-node/rust/src/ffi/bindings.rs
@@ -196,15 +196,15 @@ pub extern "C" fn alloc(len: u32) -> u32 {
 /// Initializes the client.
 ///
 /// Use [`alloc`] to allocate either one to three buffers: one for the chain specs, an optional
-/// one for the database content, and an optional one for the chain specs of the relay chain if
-/// the chain is a parachain.
+/// one for the database content, and an optional one for the chain specs of the parachain if
+/// the chain is a relay chain.
 /// The buffers **must** have been allocated with [`alloc`]. They are freed when this function is
 /// called.
 ///
-/// Write the chain specs, the database content, and the relay chain specs in these three buffers.
+/// Write the chain specs, the database content, and the parachain specs in these three buffers.
 /// Then, pass the pointer and length of these buffers to this function.
 /// Pass `0` for `database_content_ptr` and `database_content_len` if the database is empty.
-/// Pass `0` for `relay_chain_specs_ptr` and `relay_chain_specs_len` if the chain is not a
+/// Pass `0` for `parachain_specs_ptr` and `parachain_specs_len` if the chain is not a
 /// parachain.
 ///
 /// The client will emit log messages by calling the [`log()`] function, provided the log level is
@@ -215,8 +215,8 @@ pub extern "C" fn init(
     chain_specs_len: u32,
     database_content_ptr: u32,
     database_content_len: u32,
-    relay_chain_specs_ptr: u32,
-    relay_chain_specs_len: u32,
+    parachain_specs_ptr: u32,
+    parachain_specs_len: u32,
     max_log_level: u32,
 ) {
     super::init(
@@ -224,8 +224,8 @@ pub extern "C" fn init(
         chain_specs_len,
         database_content_ptr,
         database_content_len,
-        relay_chain_specs_ptr,
-        relay_chain_specs_len,
+        parachain_specs_ptr,
+        parachain_specs_len,
         max_log_level,
     )
 }


### PR DESCRIPTION
cc #221 

Before this PR, you're expected to pass a parachain spec (simply called `chain_spec`), relay chain spec, and database.
There's a problem with that: the database shouldn't apply to the parachain but to the relay chain.

This PR renames the `relay_chain_spec` field to `parachain_spec`.
If you passed for example `{ chain_spec: tick, relay_chain_spec: rococo }` you now have to pass `{ chain_spec: rococo, parachain: tick }`.
This makes the database apply to the relay chain, as intended.
