### PR TITLE
Clean up error handling in Wasm node

### DIFF
--- a/bin/wasm-node/javascript/src/bindings-wasi.js
+++ b/bin/wasm-node/javascript/src/bindings-wasi.js
@@ -104,9 +104,7 @@ export default (config) => {
 
         // Used by Rust in catastrophic situations, such as a double panic.
         proc_exit: (ret_code) => {
-            if (config.onTerminated)
-                config.onTerminated();
-            throw new SmoldotError(`proc_exit called: ${ret_code}`);
+            throw new Error(`proc_exit called: ${ret_code}`);
         },
 
         // Return the number of environment variables and the total size of all environment

--- a/bin/wasm-node/javascript/src/compat-browser.js
+++ b/bin/wasm-node/javascript/src/compat-browser.js
@@ -20,5 +20,6 @@
 export const net = null;
 export const Worker = typeof window != 'undefined' ? window.Worker : null;
 export const workerOnMessage = (worker, callback) => { worker.onmessage = (event) => callback(event.data) };
+export const workerOnError = (worker, callback) => { worker.onerror = callback; };  // TODO: unclear if the parameter of the callback is same as with NodeJS
 export const postMessage = (msg) => self.postMessage(msg);
 export const setOnMessage = (callback) => { self.onmessage = (event) => callback(event.data) };

--- a/bin/wasm-node/javascript/src/compat-nodejs.js
+++ b/bin/wasm-node/javascript/src/compat-nodejs.js
@@ -25,5 +25,6 @@ export { default as net } from 'net';
 export { Worker } from 'worker_threads';
 
 export const workerOnMessage = (worker, callback) => worker.on('message', callback);
+export const workerOnError = (worker, callback) => worker.on('error', callback);
 export const postMessage = (msg) => parentPort.postMessage(msg);
 export const setOnMessage = (callback) => parentPort.on('message', callback);

--- a/bin/wasm-node/javascript/src/index.js
+++ b/bin/wasm-node/javascript/src/index.js
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { Worker, workerOnMessage } from './compat-nodejs.js';
+import { Worker, workerOnError, workerOnMessage } from './compat-nodejs.js';
 
 export class SmoldotError extends Error {
   constructor(message) {
@@ -46,17 +46,7 @@ export async function start(config) {
 
   // The worker can send us either a database save message, or a JSON-RPC answer.
   workerOnMessage(worker, (message) => {
-    if (message.kind == 'error') {
-      // A problem happened in the worker or the smoldot Wasm VM.
-      // We might still be initializing.
-      if (initPromiseReject) {
-        initPromiseReject(message.error);
-      }
-      initPromiseReject = null;
-      initPromiseResolve = null;
-      worker.terminate();
-
-    } else if (message.kind == 'jsonrpc') {
+    if (message.kind == 'jsonrpc') {
       // If `initPromiseResolve` is non-null, then this is the initial dummy JSON-RPC request
       // that is used to determine when initialization is over. See below. It is intentionally not
       // reported with the callback.
@@ -75,6 +65,18 @@ export async function start(config) {
     } else {
       console.error('Unknown message type', message);
     }
+  });
+
+  workerOnError(worker, (error) => {
+    // A problem happened in the worker or the smoldot Wasm VM.
+    // We might still be initializing.
+    if (initPromiseReject) {
+      initPromiseReject(error);
+      initPromiseReject = null;
+      initPromiseResolve = null;
+    }
+
+    // Nothing is in place if we are no longer initializing.
   });
 
   // The first message expected by the worker contains the configuration.

--- a/bin/wasm-node/rust/src/ffi.rs
+++ b/bin/wasm-node/rust/src/ffi.rs
@@ -48,9 +48,7 @@ pub(crate) fn throw(message: String) -> ! {
             u32::try_from(message.as_bytes().len()).unwrap(),
         );
 
-        // Note: we could theoretically use `unreachable_unchecked` here, but this relies on the
-        // fact that `ffi::throw` is correctly implemented, which isn't 100% guaranteed.
-        unreachable!();
+        core::arch::wasm32::unreachable()
     }
 }
 

--- a/bin/wasm-node/rust/src/ffi.rs
+++ b/bin/wasm-node/rust/src/ffi.rs
@@ -48,7 +48,13 @@ pub(crate) fn throw(message: String) -> ! {
             u32::try_from(message.as_bytes().len()).unwrap(),
         );
 
-        core::arch::wasm32::unreachable()
+        // Even though this code is intended to only ever be compiled for Wasm, it might, for
+        // various reasons, be compiled for the host platform as well. We use platform-specific
+        // code to make sure that it compiles for all platforms.
+        #[cfg(target_arch = "wasm32")]
+        core::arch::wasm32::unreachable();
+        #[cfg(not(target_arch = "wasm32"))]
+        unreachable!();
     }
 }
 


### PR DESCRIPTION
Close #644 

Once smoldot has panicked, it is important to not call any of its functions ever again, as the state of the memory might be corrupted. See [this comment](https://github.com/paritytech/smoldot/blob/547ede25683f6c621e0fdaa87489cb94c62e3ca2/bin/wasm-node/rust/src/ffi/bindings.rs#L51).
For this reason, there currently exists a complicated system that detects throwing and prevents any further call.

Now that we use a `Worker`, we can use a much easier strategy: simply make the worker throw whenever a panic happens. This instantly terminates the worker.
The error is then detected by the code outside the worker and can be reported on the API level.
