### PR TITLE
Make JS code a bit more idiomatic

### DIFF
--- a/bin/wasm-node/javascript/src/index.js
+++ b/bin/wasm-node/javascript/src/index.js
@@ -98,12 +98,12 @@ export async function start(config) {
 
   // The first message expected by the worker contains the configuration.
   worker.postMessage({
-    chain_spec: config.chain_spec,
-    database_content: config.database_content,
-    parachain_spec: config.parachain_spec,
+    chainSpec: config.chain_spec,
+    databaseContent: config.database_content,
+    parachainSpec: config.parachain_spec,
     // Maximum level of log entries sent by the client.
     // 0 = Logging disabled, 1 = Error, 2 = Warn, 3 = Info, 4 = Debug, 5 = Trace
-    max_log_level: config.max_log_level || 5
+    maxLogLevel: config.max_log_level || 5
   });
 
   // After the initialization message, all further messages expected by the worker are JSON-RPC


### PR DESCRIPTION
Replaces a lot of `let` with `const`, and uses camelCase instead of snake_case.
One exception is the configuration passed to `start`, as this would be a breaking change.