### PR TITLE
Remove TODO when calling `ParachainHost_persisted_validation_data`

### DIFF
--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -743,7 +743,6 @@ async fn start_parachain(
                     "ParachainHost_persisted_validation_data",
                     para::persisted_validation_data_parameters(
                         parachain_config.parachain_id,
-                        // TODO: we use TimedOut because that's what cumulus does, but it's unclear if that's correct
                         para::OccupiedCoreAssumption::TimedOut
                     )
                 ).await;


### PR DESCRIPTION
Rob confirmed that it was correct :raised_hands: 