### PR TITLE
Alter imports of 'randombytes' and 'performance-now' packages 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 **/*.rs.bk
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 /target
 **/*.rs.bk
-# MacOS files that we do not want to be pushed
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
+# MacOS files that we do not want to be pushed
 .DS_Store

--- a/bin/wasm-node/javascript/src/bindings-smoldot-js.js
+++ b/bin/wasm-node/javascript/src/bindings-smoldot-js.js
@@ -22,7 +22,7 @@
 
 import { Buffer } from 'buffer';
 import Websocket from 'websocket';
-import { default as now } from 'performance-now';
+import now from 'performance-now';
 import { net } from './compat-nodejs.js';
 
 export default (config) => {

--- a/bin/wasm-node/javascript/src/bindings-wasi.js
+++ b/bin/wasm-node/javascript/src/bindings-wasi.js
@@ -24,7 +24,7 @@
 //! of that object with the Wasm instance.
 
 import { Buffer } from 'buffer';
-import { default as randombytes } from 'randombytes';
+import randombytes from 'randombytes';
 
 export default (config) => {
     // List of environment variables to feed to the Rust program. An array of strings.


### PR DESCRIPTION
Alter imports of 'randombytes' and 'performance-now' packages that was causing the 'is not a function' issue when importing smoldot. 

Fixes #703