### PR TITLE
Fix GRANDPA commit and catchup message

### DIFF
--- a/src/network/protocol/grandpa.rs
+++ b/src/network/protocol/grandpa.rs
@@ -123,6 +123,7 @@ pub struct CatchUpRequest {
 
 #[derive(Debug, Clone)]
 pub struct CatchUpRef<'a> {
+    pub set_id: u64,
     pub round_number: u64,
     pub prevotes: Vec<PrevoteRef<'a>>,
     pub precommits: Vec<PrecommitRef<'a>>,
@@ -385,6 +386,7 @@ fn catch_up(bytes: &[u8]) -> nom::IResult<&[u8], CatchUpRef> {
         nom::combinator::map(
             nom::sequence::tuple((
                 nom::number::complete::le_u64,
+                nom::number::complete::le_u64,
                 nom::combinator::flat_map(crate::util::nom_scale_compact_usize, |num_elems| {
                     nom::multi::many_m_n(num_elems, num_elems, prevote)
                 }),
@@ -403,7 +405,8 @@ fn catch_up(bytes: &[u8]) -> nom::IResult<&[u8], CatchUpRef> {
                 nom::bytes::complete::take(32u32),
                 nom::number::complete::le_u32,
             )),
-            |(round_number, prevotes, precommits, base_hash, base_number)| CatchUpRef {
+            |(set_id, round_number, prevotes, precommits, base_hash, base_number)| CatchUpRef {
+                set_id,
                 round_number,
                 prevotes,
                 precommits,


### PR DESCRIPTION
Use unsigned pre-commits in compact commit message (see [grandpa crate](https://github.com/paritytech/finality-grandpa/blob/master/src/lib.rs#L318)) and add authority set id to CatchUp message (see [substrate](https://github.com/paritytech/substrate/blob/master/client/finality-grandpa/src/communication/gossip.rs#L398)).