### PR TITLE
Some bugfixes and tweaks to GrandPa warp sync

### DIFF
--- a/bin/wasm-node/rust/src/network_service.rs
+++ b/bin/wasm-node/rust/src/network_service.rs
@@ -482,12 +482,22 @@ impl NetworkService {
             .grandpa_warp_sync_request(ffi::Instant::now(), target.clone(), chain_index, begin_hash)
             .await;
 
-        log::debug!(
-            target: "network",
-            "Connection({}) => GrandpaWarpSyncRequest({:?})",
-            target,
-            result.as_ref().map(|response| response.fragments.len()),
-        );
+        if let Ok(response) = result.as_ref() {
+            log::debug!(
+                target: "network",
+                "Connection({}) => GrandpaWarpSyncRequest(num_fragments: {:?}, finished: {:?})",
+                target,
+                response.fragments.len(),
+                response.is_finished,
+            );
+        } else {
+            log::debug!(
+                target: "network",
+                "Connection({}) => GrandpaWarpSyncRequest({:?})",
+                target,
+                result,
+            );
+        }
 
         result
     }

--- a/src/finality/grandpa/warp_sync.rs
+++ b/src/finality/grandpa/warp_sync.rs
@@ -62,8 +62,6 @@ impl Verifier {
             _ => unimplemented!(),
         };
 
-        dbg!(&authorities_list);
-
         Self {
             index: 0,
             authorities_set_id,

--- a/src/finality/grandpa/warp_sync.rs
+++ b/src/finality/grandpa/warp_sync.rs
@@ -19,7 +19,7 @@ use crate::chain::chain_information::{ChainInformationFinality, ChainInformation
 use crate::finality::justification::verify::{
     verify, Config as VerifyConfig, Error as VerifyError,
 };
-use crate::header::{DigestItemRef, GrandpaConsensusLogRef, Header};
+use crate::header::{DigestItemRef, GrandpaAuthority, GrandpaConsensusLogRef, Header};
 use crate::network::protocol::GrandpaWarpSyncResponseFragment;
 
 use alloc::vec::Vec;
@@ -38,7 +38,7 @@ pub enum Error {
 pub struct Verifier {
     index: usize,
     authorities_set_id: u64,
-    authorities_list: Vec<[u8; 32]>,
+    authorities_list: Vec<GrandpaAuthority>,
     fragments: Vec<GrandpaWarpSyncResponseFragment>,
     is_proof_complete: bool,
 }
@@ -55,16 +55,14 @@ impl Verifier {
                 after_finalized_block_authorities_set_id,
                 ..
             } => {
-                let authorities_list = finalized_triggered_authorities
-                    .iter()
-                    .map(|auth| auth.public_key)
-                    .collect();
-
+                let authorities_list = finalized_triggered_authorities.iter().cloned().collect();
                 (authorities_list, after_finalized_block_authorities_set_id)
             }
             // TODO:
             _ => unimplemented!(),
         };
+
+        dbg!(&authorities_list);
 
         Self {
             index: 0,
@@ -84,7 +82,7 @@ impl Verifier {
 
         verify(VerifyConfig {
             justification: (&fragment.justification).into(),
-            authorities_list: self.authorities_list.iter(),
+            authorities_list: self.authorities_list.iter().map(|a| &a.public_key),
             authorities_set_id: self.authorities_set_id,
         })
         .map_err(Error::Verify)?;
@@ -104,11 +102,7 @@ impl Verifier {
                 _ => None,
             })
             .next()
-            .map(|next_authorities| {
-                next_authorities
-                    .map(|authority| *authority.public_key)
-                    .collect()
-            });
+            .map(|next_authorities| next_authorities.map(GrandpaAuthority::from).collect());
 
         self.index += 1;
 
@@ -124,27 +118,7 @@ impl Verifier {
                 header: fragment.header.clone(),
                 chain_information_finality: ChainInformationFinality::Grandpa {
                     after_finalized_block_authorities_set_id: self.authorities_set_id,
-                    finalized_triggered_authorities: {
-                        fragment
-                            .header
-                            .digest
-                            .logs()
-                            .filter_map(|log_item| match log_item {
-                                DigestItemRef::GrandpaConsensus(grandpa_log_item) => {
-                                    match grandpa_log_item {
-                                        GrandpaConsensusLogRef::ScheduledChange(change)
-                                        | GrandpaConsensusLogRef::ForcedChange { change, .. } => {
-                                            Some(change.next_authorities)
-                                        }
-                                        _ => None,
-                                    }
-                                }
-                                _ => None,
-                            })
-                            .flat_map(|next_authorities| next_authorities)
-                            .map(|authority_ref| authority_ref.into())
-                            .collect()
-                    },
+                    finalized_triggered_authorities: self.authorities_list,
                     finalized_scheduled_change: None,
                 },
             })

--- a/src/network/protocol/grandpa_warp_sync.rs
+++ b/src/network/protocol/grandpa_warp_sync.rs
@@ -39,13 +39,13 @@ pub enum DecodeGrandpaWarpSyncResponseError {
 pub fn decode_grandpa_warp_sync_response(
     bytes: &[u8],
 ) -> Result<GrandpaWarpSyncResponse, DecodeGrandpaWarpSyncResponseError> {
-    nom::combinator::map(
+    nom::combinator::all_consuming(nom::combinator::map(
         nom::sequence::tuple((decode_fragments, nom::number::complete::le_u8)),
         |(fragments, is_finished)| GrandpaWarpSyncResponse {
             fragments,
             is_finished: is_finished != 0,
         },
-    )(bytes)
+    ))(bytes)
     .map(|(_, parse_result)| parse_result)
     .map_err(|_| DecodeGrandpaWarpSyncResponseError::BadResponse)
 }


### PR DESCRIPTION
Three changes:

- Better logging of warp sync responses.

- In the `ChainInformation` produced by GrandPa warp sync, we were fetching the authorities from the last header. However, since the latest changes in Substrate, the last header is no longer necessarily a new session. We now properly use `self.authorities_list`.

- Use `nom::all_consuming` to parse the protocol message. Older Substrate nodes don't include the `is_finished` boolean, but because we weren't using `all_consuming`, smoldot was misinterpreting the first byte of the next fragment as being a boolean, and the data behind as not part of the response.
