### PR TITLE
Fix "null" being sent back as a JSON-RPC response

### DIFF
--- a/bin/wasm-node/rust/src/ffi.rs
+++ b/bin/wasm-node/rust/src/ffi.rs
@@ -524,8 +524,8 @@ pub(crate) async fn next_json_rpc() -> JsonRpcRequest {
 pub(crate) fn emit_json_rpc_response(rpc: &str, chain_index: usize) {
     unsafe {
         bindings::json_rpc_respond(
-            u32::try_from(rpc.as_ptr() as usize).unwrap(),
-            u32::try_from(rpc.len()).unwrap(),
+            u32::try_from(rpc.as_bytes().as_ptr() as usize).unwrap(),
+            u32::try_from(rpc.as_bytes().len()).unwrap(),
             u32::try_from(chain_index).unwrap(),
         );
     }

--- a/bin/wasm-node/rust/src/json_rpc_service.rs
+++ b/bin/wasm-node/rust/src/json_rpc_service.rs
@@ -423,7 +423,7 @@ impl JsonRpcService {
                     })
                     .to_json_response(request_id)
                 } else {
-                    "null".to_owned()
+                    json_rpc::parse::build_success_response(request_id, "null")
                 });
             }
             methods::MethodCall::chain_getBlockHash { height } => {


### PR DESCRIPTION
- Send `rpc.as_bytes().len()` instead of `rpc.len()`. It doesn't actually make a difference, because `len()` returns the length in bytes of the string, but it makes it explicitly correct.

- Don't send back `"null"` but properly wrap it in a response. This is an actual bugfix.