### PR TITLE
Increase allowed warp sync size to 128MiB

### DIFF
--- a/src/libp2p/connection/established.rs
+++ b/src/libp2p/connection/established.rs
@@ -1099,7 +1099,7 @@ impl<TNow, TRqUd, TNotifUd> Inner<TNow, TRqUd, TNotifUd> {
                             *substream.user_data() = Substream::RequestOut {
                                 timeout,
                                 user_data,
-                                response: leb128::FramedInProgress::new(10 * 1024 * 1024), // TODO: proper max size
+                                response: leb128::FramedInProgress::new(128 * 1024 * 1024), // TODO: proper max size
                             };
                             let substream_id = substream.id();
                             let _already_closed = substream.close();

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -246,7 +246,7 @@ where
             .chain(iter::once(libp2p::ConfigRequestResponse {
                 name: format!("/{}/sync/warp", chain.protocol_id),
                 inbound_config: libp2p::ConfigRequestResponseIn::Payload { max_size: 32 },
-                max_response_size: 128 * 1024 * 1024,  // TODO: this is way too large at the moment ; see https://github.com/paritytech/substrate/pull/8578
+                max_response_size: 128 * 1024 * 1024, // TODO: this is way too large at the moment ; see https://github.com/paritytech/substrate/pull/8578
                 // We don't support inbound warp sync requests (yet).
                 inbound_allowed: false,
                 timeout: Duration::from_secs(20),

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -246,7 +246,7 @@ where
             .chain(iter::once(libp2p::ConfigRequestResponse {
                 name: format!("/{}/sync/warp", chain.protocol_id),
                 inbound_config: libp2p::ConfigRequestResponseIn::Payload { max_size: 32 },
-                max_response_size: 16 * 1024 * 1024,
+                max_response_size: 128 * 1024 * 1024,  // TODO: this is way too large at the moment ; see https://github.com/paritytech/substrate/pull/8578
                 // We don't support inbound warp sync requests (yet).
                 inbound_allowed: false,
                 timeout: Duration::from_secs(20),


### PR DESCRIPTION
See https://github.com/paritytech/substrate/pull/8578

Should be reverted after the Substrate PR has been merged and deployed.
