### PR TITLE
Use less memory when receiving responses

### DIFF
--- a/src/util/leb128.rs
+++ b/src/util/leb128.rs
@@ -102,7 +102,7 @@ impl FramedInProgress {
     pub fn new(max_len: usize) -> Self {
         FramedInProgress {
             max_len,
-            buffer: Vec::with_capacity(max_len),
+            buffer: Vec::with_capacity(32), // Reserve enough for the length prefix.
             inner: FramedInner::Length,
         }
     }
@@ -151,6 +151,7 @@ impl FramedInProgress {
                             });
                         }
                         self.buffer.clear();
+                        self.buffer.reserve(expected_len);
                         self.inner = FramedInner::Body { expected_len };
                     }
                 }


### PR DESCRIPTION
Right now, if the maximum allowed size of a response is 128MiB (which is the case after https://github.com/paritytech/smoldot/pull/750), we will immediately allocate a 128MiB buffer.
This makes us use large amounts of memory for nothing.

This PR changes this. We only allocate enough for the size of the response announced by the remote.