### PR TITLE
Better management of pinned Rust version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,6 @@ jobs:
       with:
         node-version: '12'
     - run: apt-get update && apt install -y binaryen # For `wasm-opt`
-      # The Rust version used for compiling the Wasm node is pinned.
-    - run: rustup install --profile=minimal 1.51.0
-    - run: rustup target add --toolchain=1.51.0 wasm32-wasi
     - run: cd bin/wasm-node/javascript && npm install && npm test
 
   check-features:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,8 @@ jobs:
       - run: apt-get update && apt install -y binaryen # For `wasm-opt`
       - uses: actions-rs/toolchain@v1
         with:
+          # Ideally we don't want to install any toolchain, but the GH action doesn't support this.
+          toolchain: stable
           profile: minimal
       - uses: Swatinem/rust-cache@v1
       - run: npm install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,8 @@ jobs:
           node-version: 12
       - run: apt-get update && apt install -y binaryen # For `wasm-opt`
       - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
       - uses: Swatinem/rust-cache@v1
       - run: npm install
         working-directory: ./bin/wasm-node/javascript

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,11 +59,6 @@ jobs:
           node-version: 12
       - run: apt-get update && apt install -y binaryen # For `wasm-opt`
       - uses: actions-rs/toolchain@v1
-        with:
-          # The Rust version used for compiling the Wasm node is pinned.
-          toolchain: 1.51.0
-          target: wasm32-wasi
-          profile: minimal
       - uses: Swatinem/rust-cache@v1
       - run: npm install
         working-directory: ./bin/wasm-node/javascript

--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ The full client is a binary similar to the official Polkadot client, and can be 
 
 > Note: The `Cargo.toml` contains a section `[profile.dev] opt-level = 2`, and as such `cargo run` alone should give performances close to the ones in release mode.
 
+The following list is a best-effort list of packages that must be available on the system in order to compile the full node:
+
+- `clang` or `gcc`
+- `pkg-config`
+- `sqlite`
+
 ### Wasm light node
+
+Pre-requisite: in order to run the wasm light node, you must have installed [rustup](https://rustup.rs/).
 
 The wasm light node can be tested with `cd bin/wasm-node/javascript` and `npm start`. This will start a WebSocket server capable of answering JSON-RPC requests. You can then navigate to <https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944> in order to interact with the Westend chain.
 

--- a/bin/wasm-node/javascript/prepare.js
+++ b/bin/wasm-node/javascript/prepare.js
@@ -21,14 +21,26 @@ import * as fs from 'fs';
 // Which Cargo profile to use to compile the Rust. Should be either `debug` or `release`.
 const build_profile = 'release';
 
+// The Rust version to use.
+// The Rust version is pinned because the wasi target is still unstable. Without pinning, it is
+// possible for the wasm-js bindings to change between two Rust versions. Feel free to update
+// this version pin whenever you like, provided it continues to build.
+const rust_version = '1.51.0';
+
+// Assume that the user has `rustup` installed and make sure that `rust_version` is available.
+child_process.execSync(
+    "rustup install --no-self-update --profile=minimal " + rust_version,
+    { 'stdio': 'inherit' }
+);
+child_process.execSync(
+    "rustup target add --toolchain=" + rust_version + " wasm32-wasi",
+    { 'stdio': 'inherit' }
+);
+
 // The important step in this script is running `cargo build --target wasm32-wasi` on the Rust
 // code. This generates a `wasm` file in `target/wasm32-wasi`.
-//
-// Note: the Rust version is pinned because the wasi target is still unstable. Without pinning, it
-// is possible for the wasm-js bindings to change between two Rust versions. Feel free to update
-// this version pin whenever you like, provided it continues to build.
 child_process.execSync(
-    "cargo +1.51.0 build --package smoldot-js --target wasm32-wasi --no-default-features"
+    "cargo +" + rust_version + " build --package smoldot-js --target wasm32-wasi --no-default-features"
     + (build_profile == 'debug' ? '' : ' --' + build_profile),
     { 'stdio': 'inherit' }
 );


### PR DESCRIPTION
De-duplicates the pinned Rust version.
Should be more automatic and assumes that the user has `rustup` installed.