### PR TITLE
Make chain_index parameter optional for json_rpc_callback

### DIFF
--- a/bin/wasm-node/javascript/src/index.d.ts
+++ b/bin/wasm-node/javascript/src/index.d.ts
@@ -24,7 +24,7 @@ export interface SmoldotClient {
   terminate(): void;
 }
 
-export type SmoldotJsonRpcCallback = (response: string, chain_index: number) => void;
+export type SmoldotJsonRpcCallback = (response: string, chain_index?: number) => void;
 export type SmoldotLogCallback = (level: number, target: string, message: string) => void;
 
 export interface SmoldotOptions {

--- a/bin/wasm-node/javascript/src/index.test-d.ts
+++ b/bin/wasm-node/javascript/src/index.test-d.ts
@@ -1,12 +1,27 @@
-import smoldot from 'smoldot'; // smoldot is Smoldot
+import smoldot, { Smoldot, SmoldotClient } from 'smoldot';
+
+// Test the export type
+
+// smoldot;  // $ExpectType Smoldot
+
+// Test when suppliying all options and all params to json_rpc_callback
 
 // $ExpectType Promise<SmoldotClient>
-const sp = smoldot.start({
+let sp = smoldot.start({
   max_log_level: 3,
   chain_spec: '',
   parachain_spec: '',
   json_rpc_callback: (resp, chain_index) => {},
   log_callback: (level, target, message) => {},
+});
+
+// Test when not supplying optional options and optional params
+
+// $ExpectType Promise<SmoldotClient>
+sp = smoldot.start({
+  chain_spec: '',
+  parachain_spec: '',
+  json_rpc_callback: (resp) => {},
 });
 
 sp.then(sm => {


### PR DESCRIPTION
* I added an accompanying typings test testing using smoldot with none of the optional options or parameters. 
* I made the exported types tests more explicit using the longer `ExpectType` comment for consistency.