### PR TITLE
Add cancel_all to the JS public API

### DIFF
--- a/bin/wasm-node/javascript/src/bindings-smoldot-js.js
+++ b/bin/wasm-node/javascript/src/bindings-smoldot-js.js
@@ -39,10 +39,10 @@ export default (config) => {
         },
 
         // Used by the Rust side to emit a JSON-RPC response or subscription notification.
-        json_rpc_respond: (ptr, len, chain_index, user_data) => {
+        json_rpc_respond: (ptr, len, chainIndex, userData) => {
             let message = Buffer.from(config.instance.exports.memory.buffer).toString('utf8', ptr, ptr + len);
             if (config.jsonRpcCallback) {
-                config.jsonRpcCallback(message, chain_index, user_data);
+                config.jsonRpcCallback(message, chainIndex, userData);
             }
         },
 

--- a/bin/wasm-node/javascript/src/index.d.ts
+++ b/bin/wasm-node/javascript/src/index.d.ts
@@ -21,7 +21,7 @@ declare class SmoldotError extends Error {
 
 export interface SmoldotClient {
   send_json_rpc(rpc: string, chainIndex?: number, userData?: number): void;
-  unsubscribe_all(userData: number): void;
+  cancel_all(userData: number): void;
   terminate(): void;
 }
 

--- a/bin/wasm-node/javascript/src/index.d.ts
+++ b/bin/wasm-node/javascript/src/index.d.ts
@@ -20,7 +20,8 @@ declare class SmoldotError extends Error {
 }
 
 export interface SmoldotClient {
-  send_json_rpc(rpc: string): void;
+  send_json_rpc(rpc: string, chainIndex?: number, userData?: number): void;
+  unsubscribe_all(userData: number): void;
   terminate(): void;
 }
 

--- a/bin/wasm-node/javascript/src/index.js
+++ b/bin/wasm-node/javascript/src/index.js
@@ -50,6 +50,13 @@ export async function start(config) {
   const worker = new Worker(new URL('./worker.js', import.meta.url));
   let workerError = null;
 
+  // Whenever an `unsubscribeAll` is sent to the worker, the corresponding user data is pushed on
+  // this array. The worker needs to send back a confirmation, which pops the first element of
+  // this array. JSON-RPC responses whose user data is found in this array are silently discarded.
+  // This avoids a race condition where the worker emits a JSON-RPC response while we have already
+  // sent to it an `unsubscribeAll`.
+  let pendingUnsubscribeConfirmations = [];
+
   // Build a promise that will be resolved or rejected after the initalization (that happens in
   // the worker) has finished.
   let initPromiseResolve;
@@ -67,12 +74,17 @@ export async function start(config) {
       // reported with the callback.
       if (initPromiseResolve) {
         initPromiseResolve();
-        // TODO: unsubscribe_all with `user_data` 0
         initPromiseReject = null;
         initPromiseResolve = null;
       } else if (config.json_rpc_callback) {
-        config.json_rpc_callback(message.data, message.chain_index, message.user_data);
+        if (pendingUnsubscribeConfirmations.findIndex(elem => elem == message.userData) === -1)
+          config.json_rpc_callback(message.data, message.chainIndex, message.userData);
       }
+
+    } else if (message.kind == 'unsubscribeAllConfirmation') {
+      const expected = pendingUnsubscribeConfirmations.pop();
+      if (expected != message.userData)
+        throw 'Unexpected unsubscribeAllConfirmation';
 
     } else if (message.kind == 'log') {
       logCallback(message.level, message.target, message.message);
@@ -107,28 +119,36 @@ export async function start(config) {
     maxLogLevel: config.max_log_level || 5
   });
 
-  // After the initialization message, all further messages expected by the worker are JSON-RPC
-  // requests.
-
   // Initialization happens asynchronous, both because we have a worker, but also asynchronously
   // within the worker. In order to detect when initialization was successful, we perform a dummy
   // JSON-RPC request and wait for the response. While this might seem like an unnecessary
   // overhead, it is the most straight-forward solution. Any alternative with a lower overhead
   // would have a higher complexity.
   worker.postMessage({
+    ty: 'request',
     request: '{"jsonrpc":"2.0","id":1,"method":"system_name","params":[]}',
-    chain_index: 0,
-    user_data: 0,
+    chainIndex: 0,
+    userData: 0,
   });
+  pendingUnsubscribeConfirmations.push(0);
+  worker.postMessage({ ty: 'unsubscribeAll', userData: 0 });
 
   // Now blocking until the worker sends back the response.
   // This will throw if the initialization has failed.
   await initPromise;
 
   return {
-    send_json_rpc: (request) => {
+    send_json_rpc: (request, chainIndex, userData) => {
       if (!workerError) {
-        worker.postMessage({ request, chain_index: 0, user_data: 0 });
+        worker.postMessage({ ty: 'request', request, chainIndex, userData: userData || 0 });
+      } else {
+        throw workerError;
+      }
+    },
+    unsubscribe_all: (userData) => {
+      if (!workerError) {
+        pendingUnsubscribeConfirmations.push(userData);
+        worker.postMessage({ ty: 'unsubscribeAll', userData });
       } else {
         throw workerError;
       }

--- a/bin/wasm-node/javascript/src/index.test-d.ts
+++ b/bin/wasm-node/javascript/src/index.test-d.ts
@@ -11,8 +11,8 @@ let sp = smoldot.start({
   max_log_level: 3,
   chain_spec: '',
   parachain_spec: '',
-  json_rpc_callback: (resp, chain_index) => {},
-  log_callback: (level, target, message) => {},
+  json_rpc_callback: (resp, chain_index, user_data) => { },
+  log_callback: (level, target, message) => { },
 });
 
 // Test when not supplying optional options and optional params
@@ -21,12 +21,14 @@ let sp = smoldot.start({
 sp = smoldot.start({
   chain_spec: '',
   parachain_spec: '',
-  json_rpc_callback: (resp) => {},
+  json_rpc_callback: (resp) => { },
 });
 
 sp.then(sm => {
   // $ExpectType void
-  sm.send_json_rpc('{"id":8,"jsonrpc":"2.0","method":"system_health","params":[]}');
+  sm.send_json_rpc('{"id":8,"jsonrpc":"2.0","method":"system_health","params":[]}', 0, 0);
+  // $ExpectType void
+  sm.unsubscribe_all(0);
   // $ExpectType void
   sm.terminate();
 });

--- a/bin/wasm-node/javascript/src/index.test-d.ts
+++ b/bin/wasm-node/javascript/src/index.test-d.ts
@@ -28,7 +28,7 @@ sp.then(sm => {
   // $ExpectType void
   sm.send_json_rpc('{"id":8,"jsonrpc":"2.0","method":"system_health","params":[]}', 0, 0);
   // $ExpectType void
-  sm.unsubscribe_all(0);
+  sm.cancel_all(0);
   // $ExpectType void
   sm.terminate();
 });

--- a/bin/wasm-node/javascript/src/worker.js
+++ b/bin/wasm-node/javascript/src/worker.js
@@ -92,10 +92,10 @@ const startInstance = async (config) => {
       const ptr = result.instance.exports.alloc(len);
       Buffer.from(result.instance.exports.memory.buffer).write(message.request, ptr);
       result.instance.exports.json_rpc_send(ptr, len, message.chainIndex, message.userData);
-    } else if (message.ty == 'unsubscribeAll') {
+    } else if (message.ty == 'cancelAll') {
       result.instance.exports.json_rpc_unsubscribe_all(message.userData);
       // `compat.postMessage` is the same as `postMessage`, but works across environments.
-      compat.postMessage({ kind: 'unsubscribeAllConfirmation', userData: message.userData });
+      compat.postMessage({ kind: 'cancelAllConfirmation', userData: message.userData });
     } else
       throw new Error('unrecognized message type');
   });
@@ -121,10 +121,10 @@ compat.setOnMessage((message) => {
       const ptr = state.exports.alloc(len);
       Buffer.from(state.exports.memory.buffer).write(message.request, ptr);
       state.exports.json_rpc_send(ptr, len, message.chainIndex, message.userData);
-    } else if (message.ty == 'unsubscribeAll') {
+    } else if (message.ty == 'cancelAll') {
       state.exports.json_rpc_unsubscribe_all(message.userData);
       // `compat.postMessage` is the same as `postMessage`, but works across environments.
-      compat.postMessage({ kind: 'unsubscribeAllConfirmation', userData: message.userData });
+      compat.postMessage({ kind: 'cancelAllConfirmation', userData: message.userData });
     } else
       throw new Error('unrecognized message type');
   }

--- a/bin/wasm-node/javascript/src/worker.js
+++ b/bin/wasm-node/javascript/src/worker.js
@@ -92,10 +92,10 @@ const startInstance = async (config) => {
       const ptr = result.instance.exports.alloc(len);
       Buffer.from(result.instance.exports.memory.buffer).write(message.request, ptr);
       result.instance.exports.json_rpc_send(ptr, len, message.chainIndex, message.userData);
-    } else if (message.ty == 'cancelAll') {
+    } else if (message.ty == 'unsubscribeAll') {
       result.instance.exports.json_rpc_unsubscribe_all(message.userData);
       // `compat.postMessage` is the same as `postMessage`, but works across environments.
-      compat.postMessage({ kind: 'cancelAllConfirmation', userData: message.userData });
+      compat.postMessage({ kind: 'unsubscribeAllConfirmation', userData: message.userData });
     } else
       throw new Error('unrecognized message type');
   });
@@ -121,10 +121,10 @@ compat.setOnMessage((message) => {
       const ptr = state.exports.alloc(len);
       Buffer.from(state.exports.memory.buffer).write(message.request, ptr);
       state.exports.json_rpc_send(ptr, len, message.chainIndex, message.userData);
-    } else if (message.ty == 'cancelAll') {
+    } else if (message.ty == 'unsubscribeAll') {
       state.exports.json_rpc_unsubscribe_all(message.userData);
       // `compat.postMessage` is the same as `postMessage`, but works across environments.
-      compat.postMessage({ kind: 'cancelAllConfirmation', userData: message.userData });
+      compat.postMessage({ kind: 'unsubscribeAllConfirmation', userData: message.userData });
     } else
       throw new Error('unrecognized message type');
   }

--- a/bin/wasm-node/javascript/test/demo.js
+++ b/bin/wasm-node/javascript/test/demo.js
@@ -78,7 +78,7 @@ wsServer.on('request', function (request) {
 
     connection.on('close', function (reasonCode, description) {
         console.log((new Date()) + ' Peer ' + connection.remoteAddress + ' disconnected.');
-        client.unsubscribe_all(connectionId);
+        client.cancel_all(connectionId);
         wsConnections[connectionId] = undefined;
     });
 });

--- a/bin/wasm-node/javascript/test/demo.js
+++ b/bin/wasm-node/javascript/test/demo.js
@@ -24,22 +24,21 @@ import * as http from 'http';
 import * as fs from 'fs';
 
 let client = null;
-var unsent_queue = [];
-let ws_connection = null;
+var unsentQueue = [];
+let wsConnections = {};
+let nextWsConnectionId = 0xaaa;
 
 smoldot.start({
     chain_spec: fs.readFileSync('../../westend.json', 'utf8'),
     max_log_level: 3,  // Can be increased for more verbosity
-    json_rpc_callback: (resp, chain_index) => {
-        if (ws_connection) {
-            ws_connection.sendUTF(resp);
-        }
+    json_rpc_callback: (resp, chainIndex, connectionId) => {
+        wsConnections[connectionId].sendUTF(resp);
     }
 })
     .then((c) => {
         client = c;
-        unsent_queue.forEach((m) => client.send_json_rpc(m));
-        unsent_queue = [];
+        unsentQueue.forEach((m) => client.send_json_rpc(m.message, 0, m.connectionId));
+        unsentQueue = [];
     })
 
 let server = http.createServer(function (request, response) {
@@ -58,16 +57,19 @@ let wsServer = new websocket.server({
 });
 
 wsServer.on('request', function (request) {
-    var connection = request.accept(request.requestedProtocols[0], request.origin);
+    const connection = request.accept(request.requestedProtocols[0], request.origin);
+    const connectionId = nextWsConnectionId;
+    nextWsConnectionId += 1;
+
     console.log((new Date()) + ' Connection accepted.');
-    ws_connection = connection;
+    wsConnections[connectionId] = connection;
 
     connection.on('message', function (message) {
         if (message.type === 'utf8') {
             if (client) {
-                client.send_json_rpc(message.utf8Data);
+                client.send_json_rpc(message.utf8Data, 0, connectionId);
             } else {
-                unsent_queue.push(message.utf8Data);
+                unsentQueue.push({ message: message.utf8Data, connectionId });
             }
         } else {
             throw "Unsupported type: " + message.type;
@@ -76,6 +78,7 @@ wsServer.on('request', function (request) {
 
     connection.on('close', function (reasonCode, description) {
         console.log((new Date()) + ' Peer ' + connection.remoteAddress + ' disconnected.');
-        ws_connection = null;
+        client.unsubscribe_all(connectionId);
+        wsConnections[connectionId] = undefined;
     });
 });

--- a/bin/wasm-node/javascript/test/test.js
+++ b/bin/wasm-node/javascript/test/test.js
@@ -43,7 +43,7 @@ const westendSpecs = fs.readFileSync('../../westend.json', 'utf8');
   client
     .start({
       chain_spec: westendSpecs,
-      json_rpc_callback: (resp, chain_index) => {
+      json_rpc_callback: (resp, chainIndex, userData) => {
         if (resp == '{"jsonrpc":"2.0","id":1,"result":"smoldot-js"}') {
           // Test successful
           process.exit(0)
@@ -54,7 +54,7 @@ const westendSpecs = fs.readFileSync('../../westend.json', 'utf8');
       }
     })
     .then((client) => {
-      client.send_json_rpc('{"jsonrpc":"2.0","id":1,"method":"system_name","params":[]}');
+      client.send_json_rpc('{"jsonrpc":"2.0","id":1,"method":"system_name","params":[]}', 0, 0);
     })
     .catch((err) => process.exit(1));
 })();


### PR DESCRIPTION
Exposes `cancel_all` to the JavaScript public API of the client.

Also tweaks `demo.js` to allow multiple clients to connect to the node.

## Context

The `send_json_rpc` function now takes three parameters.
The second parameter must always be zero for now, and will be used when smoldot supports multiple chains.

The third parameter is a "user data". The value of that third parameter must be a number, but its meaning is not interpreted by smoldot. The same value is later passed back as the third parameter of `json_rpc_callback` when the response to the request comes back.
Similarly, if the request passed in `send_json_rpc` is a subscription, all notifications will also be reported with that same third parameter.

A new method has been added: `cancel_all`. When called, all requests and subscriptions whose "user data" is equal to the parameter are instantly stopped. `json_rpc_callback` will never again be called with that "user data", unless this same "user data" is later re-used.
