### PR TITLE
Fix Westend after runtime upgrade

### DIFF
--- a/src/chain/blocks_tree/best_block.rs
+++ b/src/chain/blocks_tree/best_block.rs
@@ -18,8 +18,12 @@
 //! Extension module containing the best block determination.
 
 use super::*;
+use core::iter;
 
 /// Accepts as parameter a container of blocks and indices within this container.
+///
+/// `maybe_new_best_parent` is to be `None` if the parent is the finalized block that is the
+/// parent of all the leaves of the tree.
 ///
 /// Returns true if `maybe_new_best` on top of `maybe_new_best_parent` is a better block compared
 /// to `old_best`.
@@ -49,7 +53,15 @@ pub(super) fn is_better_block<T>(
         // - If the number for the new block is strictly superior, then the new block is
         //   out new best.
         //
-        let (ascend, descend) = blocks.ascend_and_descend(old_best, maybe_new_best_parent.unwrap());
+        let (ascend, descend) = if let Some(maybe_new_best_parent) = maybe_new_best_parent {
+            let (asc, desc) = blocks.ascend_and_descend(old_best, maybe_new_best_parent);
+            (either::Left(asc), either::Left(desc))
+        } else {
+            (
+                either::Right(blocks.node_to_root_path(old_best)),
+                either::Right(iter::empty()),
+            )
+        };
 
         // TODO: update for Aura?
         // TODO: what if there's a mix of Babe and non-Babe blocks here?

--- a/src/chain/blocks_tree/best_block.rs
+++ b/src/chain/blocks_tree/best_block.rs
@@ -22,11 +22,11 @@ use core::iter;
 
 /// Accepts as parameter a container of blocks and indices within this container.
 ///
-/// `maybe_new_best_parent` is to be `None` if the parent is the finalized block that is the
-/// parent of all the leaves of the tree.
-///
 /// Returns true if `maybe_new_best` on top of `maybe_new_best_parent` is a better block compared
 /// to `old_best`.
+///
+/// `maybe_new_best_parent` is to be `None` if the parent is the finalized block that is the
+/// parent of all the leaves of the tree.
 pub(super) fn is_better_block<T>(
     blocks: &fork_tree::ForkTree<Block<T>>,
     old_best: fork_tree::NodeIndex,

--- a/src/chain/fork_tree.rs
+++ b/src/chain/fork_tree.rs
@@ -263,8 +263,8 @@ impl<T> ForkTree<T> {
             .node_to_root_path(node1)
             .take_while(move |v| Some(*v) != common_ancestor);
         let iter2 = self
-            .node_to_root_path(node2)
-            .take_while(move |v| Some(*v) != common_ancestor);
+            .root_to_node_path(node2)
+            .skip_while(move |v| Some(*v) != common_ancestor);
 
         (iter1, iter2)
     }

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -1457,7 +1457,7 @@ impl ReadyToRun {
                     });
                 }
                 HostFunction::ext_logging_max_level_version_1 => {
-                    // TODO: always returns `0`, which means "Off"
+                    // TODO: always returns `0` at the moment (which means "Off"); make this configurable?
                     // see https://github.com/paritytech/substrate/blob/bb22414e9729fa6ffc3b3126c57d3a9f2b85a2ff/primitives/core/src/lib.rs#L341
                     self = ReadyToRun {
                         resume_value: Some(vm::WasmValue::I32(0)),

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -647,6 +647,7 @@ impl ReadyToRun {
                 HostFunction::ext_allocator_malloc_version_1 => 1,
                 HostFunction::ext_allocator_free_version_1 => 1,
                 HostFunction::ext_logging_log_version_1 => 3,
+                HostFunction::ext_logging_max_level_version_1 => 0,
             };
             if params.len() != expected_params_num {
                 return HostVm::Error {
@@ -1454,6 +1455,14 @@ impl ReadyToRun {
                         inner: self.inner,
                         log_entry,
                     });
+                }
+                HostFunction::ext_logging_max_level_version_1 => {
+                    // TODO: always returns `0`, which means "Off"
+                    // see https://github.com/paritytech/substrate/blob/bb22414e9729fa6ffc3b3126c57d3a9f2b85a2ff/primitives/core/src/lib.rs#L341
+                    self = ReadyToRun {
+                        resume_value: Some(vm::WasmValue::I32(0)),
+                        inner: self.inner,
+                    };
                 }
             }
         }
@@ -2490,6 +2499,7 @@ externalities! {
     ext_allocator_malloc_version_1,
     ext_allocator_free_version_1,
     ext_logging_log_version_1,
+    ext_logging_max_level_version_1,
 }
 
 // Glue between the `allocator` module and the `vm` module.


### PR DESCRIPTION
Two changes:

- One bugfix in the logic of choosing which fork is the best.
- Adds the missing runtime host function for getting the log max level.
