### PR TITLE
Better debugging of blocks verified

### DIFF
--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -389,6 +389,8 @@ async fn start_relay_chain(
                         break;
                     }
                     all::ProcessOne::VerifyHeader(verify) => {
+                        let verified_hash = verify.hash();
+
                         match verify.perform(ffi::unix_time(), ()) {
                             all::HeaderVerifyOutcome::Success {
                                 sync: sync_out,
@@ -397,6 +399,12 @@ async fn start_relay_chain(
                                 is_new_finalized,
                                 ..
                             } => {
+                                log::debug!(
+                                    target: "sync-verify",
+                                    "Successfully verified header {}",
+                                    HashDisplay(&verified_hash)
+                                );
+
                                 requests_to_start.extend(next_actions);
 
                                 if is_new_best {
@@ -417,9 +425,11 @@ async fn start_relay_chain(
                             } => {
                                 log::warn!(
                                     target: "sync-verify",
-                                    "Error while verifying header: {}",
+                                    "Error while verifying header {}: {}",
+                                    HashDisplay(&verified_hash),
                                     error
                                 );
+
                                 requests_to_start.extend(next_actions);
                                 sync = sync_out;
                                 continue;

--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -401,8 +401,9 @@ async fn start_relay_chain(
                             } => {
                                 log::debug!(
                                     target: "sync-verify",
-                                    "Successfully verified header {}",
-                                    HashDisplay(&verified_hash)
+                                    "Successfully verified header {} (new best: {})",
+                                    HashDisplay(&verified_hash),
+                                    if is_new_best { "yes" } else { "no" }
                                 );
 
                                 requests_to_start.extend(next_actions);

--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -986,6 +986,22 @@ enum HeaderVerifyInner<TRq, TSrc, TBl> {
 }
 
 impl<TRq, TSrc, TBl> HeaderVerify<TRq, TSrc, TBl> {
+    /// Returns the height of the block to be verified.
+    pub fn height(&self) -> u64 {
+        match &self.inner {
+            HeaderVerifyInner::Optimistic(verify) => verify.height(),
+            HeaderVerifyInner::AllForks(verify) => verify.height(),
+        }
+    }
+
+    /// Returns the hash of the block to be verified.
+    pub fn hash(&self) -> [u8; 32] {
+        match &self.inner {
+            HeaderVerifyInner::Optimistic(verify) => verify.hash(),
+            HeaderVerifyInner::AllForks(verify) => *verify.hash(),
+        }
+    }
+
     /// Perform the verification.
     pub fn perform(
         mut self,

--- a/src/sync/optimistic.rs
+++ b/src/sync/optimistic.rs
@@ -659,9 +659,20 @@ pub struct Verify<TRq, TSrc, TBl> {
 }
 
 impl<TRq, TSrc, TBl> Verify<TRq, TSrc, TBl> {
+    /// Returns the height of the block about to be verified.
+    pub fn height(&self) -> u64 {
+        // TODO: unwrap?
+        header::decode(self.header()).unwrap().number
+    }
+
     /// Returns the hash of the block about to be verified.
-    pub fn block_hash(&self) -> [u8; 32] {
-        let block = self
+    pub fn hash(&self) -> [u8; 32] {
+        header::hash_from_scale_encoded_header(self.header())
+    }
+
+    /// Returns the SCALE-encoded header of the block about to be verified.
+    fn header(&self) -> &[u8] {
+        &self
             .inner
             .verification_queue
             .get(0)
@@ -669,9 +680,8 @@ impl<TRq, TSrc, TBl> Verify<TRq, TSrc, TBl> {
                 VerificationQueueEntryTy::Queued { blocks, .. } => blocks.front().unwrap(),
                 _ => unreachable!(),
             })
-            .unwrap();
-
-        header::hash_from_scale_encoded_header(&block.scale_encoded_header)
+            .unwrap()
+            .scale_encoded_header
     }
 
     /// Start the verification of the block.


### PR DESCRIPTION
Print the hash of the blocks that are verified, successfully or not.