### PR TITLE
Report a new best block after GrandPa warp sync has succeeded

### DIFF
--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -686,6 +686,7 @@ async fn start_relay_chain(
                     let finalized_num = sync.finalized_block_header().number;
                     log::info!(target: "sync-verify", "GrandPa warp sync finished to #{}", finalized_num);
                     has_new_finalized = true;
+                    has_new_best = true;
                     requests_to_start.extend(next_actions);
                 }
             }


### PR DESCRIPTION
Important in situations such as right now where all blocks on top of the warp sync target are bad.