### PR TITLE
Enable discovery on the Wasm light client

### DIFF
--- a/bin/wasm-node/rust/src/network_service.rs
+++ b/bin/wasm-node/rust/src/network_service.rs
@@ -38,7 +38,7 @@
 
 use crate::ffi;
 
-use core::{num::NonZeroUsize, pin::Pin, time::Duration};
+use core::{cmp, num::NonZeroUsize, pin::Pin, time::Duration};
 use futures::{channel::mpsc, lock::Mutex, prelude::*};
 use smoldot::{
     informant::HashDisplay,
@@ -355,6 +355,44 @@ impl NetworkService {
                                 is_important_peer,
                             )
                         }));
+                    }
+                }
+            }));
+        }
+
+        // Spawn tasks dedicated to the Kademlia discovery.
+        for chain_index in 0..num_chains {
+            (network_service.guarded.try_lock().unwrap().tasks_executor)(Box::pin({
+                // TODO: keeping a Weak here doesn't really work to shut down tasks
+                let network_service = Arc::downgrade(&network_service);
+                async move {
+                    let mut next_discovery = Duration::from_secs(5);
+
+                    loop {
+                        ffi::Delay::new(next_discovery).await;
+                        next_discovery = cmp::min(next_discovery * 2, Duration::from_secs(120));
+
+                        let network_service = match network_service.upgrade() {
+                            Some(ns) => ns,
+                            None => return,
+                        };
+
+                        match network_service
+                            .network
+                            .kademlia_discovery_round(ffi::Instant::now(), chain_index)
+                            .await
+                        {
+                            Ok(insert) => {
+                                for peer_id in insert.peer_ids() {
+                                    log::trace!(target: "connections", "Discovered {}", peer_id);
+                                }
+
+                                insert.insert(|_| ()).await;
+                            }
+                            Err(error) => {
+                                log::warn!(target: "connections", "Problem during discovery: {}", error);
+                            }
+                        }
                     }
                 }
             }));

--- a/bin/wasm-node/rust/src/network_service.rs
+++ b/bin/wasm-node/rust/src/network_service.rs
@@ -325,6 +325,11 @@ impl NetworkService {
                             }
                         };
 
+                        // TODO: should have a more robust way of limiting the number of connections
+                        if network_service.peers_list().await.count() >= 10 {
+                            continue;
+                        }
+
                         let start_connect =
                             match network_service.network.fill_out_slots(chain_index).await {
                                 Some(sc) => sc,
@@ -403,6 +408,9 @@ impl NetworkService {
             let network_service = Arc::downgrade(&network_service);
             async move {
                 loop {
+                    // TODO: very crappy way of not spamming the network service ; instead we should wake this task up when a disconnect or a discovery happens
+                    ffi::Delay::new(Duration::from_secs(1)).await;
+
                     let network_service = match network_service.upgrade() {
                         Some(ns) => ns,
                         None => {

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -1000,6 +1000,11 @@ impl<'a, TNow, TPeer, TConn> DiscoveryInsert<'a, TNow, TPeer, TConn>
 where
     TNow: Clone + Add<Duration, Output = TNow> + Sub<TNow, Output = Duration> + Ord,
 {
+    /// Returns the list of [`peer_id::PeerId`]s that will be inserted.
+    pub fn peer_ids(&self) -> impl Iterator<Item = &peer_id::PeerId> {
+        self.outcome.iter().map(|(peer_id, _)| peer_id)
+    }
+
     /// Insert the results in the [`ChainNetwork`].
     // TODO: futures cancellation concerns T_T
     pub async fn insert(self, mut or_insert: impl FnMut(&peer_id::PeerId) -> TPeer) {


### PR DESCRIPTION
Can't merge now as it seems to trigger some kind of infinite loop