### PR TITLE
Implement remove_source when GrandPa warp syncing

### DIFF
--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -535,10 +535,8 @@ async fn start_relay_chain(
                             if chain_index == network_chain_index =>
                         {
                             let id = peers_source_id_map.remove(&peer_id).unwrap();
-                            let (rq_list, _) = sync.remove_source(id);
-                            for rq_id in rq_list {
-                                pending_requests.remove(&rq_id).unwrap().abort();
-                            }
+                            let (requests, _) = sync.remove_source(id);
+                            requests_to_start.extend(requests);
                         },
                         network_service::Event::BlockAnnounce { chain_index, peer_id, announce }
                             if chain_index == network_chain_index =>

--- a/src/sync/grandpa_warp_sync.rs
+++ b/src/sync/grandpa_warp_sync.rs
@@ -303,7 +303,7 @@ impl<TSrc> InProgressGrandpaWarpSync<TSrc> {
     ///
     /// Panics if the source wasn't added to the list earlier.
     ///
-    pub fn remove_source(mut self, to_remove: SourceId) -> (TSrc, InProgressGrandpaWarpSync<TSrc>) {
+    pub fn remove_source(self, to_remove: SourceId) -> (TSrc, InProgressGrandpaWarpSync<TSrc>) {
         match self {
             Self::WaitingForSources(waiting_for_sources) => {
                 waiting_for_sources.remove_source(to_remove)
@@ -362,12 +362,16 @@ impl<TSrc> StorageGet<TSrc> {
     }
 
     /// Returns the source that we received the warp sync data from.
-    pub fn warp_sync_source(&self) -> &TSrc {
+    pub fn warp_sync_source(&self) -> (SourceId, &TSrc) {
         debug_assert!(self
             .state
             .sources
             .contains(self.state.warp_sync_source_id.0));
-        &self.state.sources[self.state.warp_sync_source_id.0].user_data
+
+        (
+            self.state.warp_sync_source_id,
+            &self.state.sources[self.state.warp_sync_source_id.0].user_data,
+        )
     }
 
     /// Returns the header that we're warp syncing up to.
@@ -418,12 +422,15 @@ impl<TSrc> NextKey<TSrc> {
     }
 
     /// Returns the source that we received the warp sync data from.
-    pub fn warp_sync_source(&self) -> &TSrc {
+    pub fn warp_sync_source(&self) -> (SourceId, &TSrc) {
         debug_assert!(self
             .state
             .sources
             .contains(self.state.warp_sync_source_id.0));
-        &self.state.sources[self.state.warp_sync_source_id.0].user_data
+        (
+            self.state.warp_sync_source_id,
+            &self.state.sources[self.state.warp_sync_source_id.0].user_data,
+        )
     }
 
     /// Returns the header that we're warp syncing up to.
@@ -705,12 +712,16 @@ pub struct VirtualMachineParamsGet<TSrc> {
 
 impl<TSrc> VirtualMachineParamsGet<TSrc> {
     /// Returns the source that we received the warp sync data from.
-    pub fn warp_sync_source(&self) -> &TSrc {
+    pub fn warp_sync_source(&self) -> (SourceId, &TSrc) {
         debug_assert!(self
             .state
             .sources
             .contains(self.state.warp_sync_source_id.0));
-        &self.state.sources[self.state.warp_sync_source_id.0].user_data
+
+        (
+            self.state.warp_sync_source_id,
+            &self.state.sources[self.state.warp_sync_source_id.0].user_data,
+        )
     }
 
     /// Returns the header that we're warp syncing up to.


### PR DESCRIPTION
Fixes the `todo!()` and implements it correctly.

I could test that it works thanks to Rococo whose bootnodes disconnect us.
