### PR TITLE
Add kusama-connect and polkadot-connect nodes

### DIFF
--- a/bin/kusama.json
+++ b/bin/kusama.json
@@ -11,7 +11,7 @@
     "/dns/kusama-bootnode-0.paritytech.net/tcp/30333/p2p/12D3KooWSueCPH3puP2PcvqPJdNaDNF3jMZjtJtDiSy35pWrbt5h",
     "/dns/kusama-bootnode-0.paritytech.net/tcp/30334/ws/p2p/12D3KooWSueCPH3puP2PcvqPJdNaDNF3jMZjtJtDiSy35pWrbt5h",
     "/dns/kusama-bootnode-1.paritytech.net/tcp/30333/p2p/12D3KooWQKqane1SqWJNWMQkbia9qiMWXkcHtAdfW5eVF8hbwEDw",
-    "/ip4/34.71.135.129/tcp/30333/ws/p2p/12D3KooWPAmqUvTTKzk5unq1PXJ3Lypi22WBSrvgFFT6Xy6Nti6A"
+    "/dns/kusama-connect-0.parity.io/tcp/443/wss/p2p/12D3KooWBNDUxpWVqDfq7qzEoY2NYEG1nKcQ9AJd4hqG1iYZkzWL"
   ],
   "telemetryEndpoints": [
     [


### PR DESCRIPTION
We have spawned two new "connect" nodes with a TLS certificate in front, for when within a web page.