### PR TITLE
Work towards properly querying nodes that know about desired block

### DIFF
--- a/bin/wasm-node/rust/src/json_rpc_service.rs
+++ b/bin/wasm-node/rust/src/json_rpc_service.rs
@@ -573,13 +573,17 @@ impl JsonRpcService {
                 let mut lock = self.blocks.lock().await;
 
                 let block_hash = lock.best_block;
-                let state_root = lock.known_blocks.get(&block_hash).unwrap().state_root;
+                let (state_root, block_number) = {
+                    let block = lock.known_blocks.get(&block_hash).unwrap();
+                    (block.state_root, block.number)
+                };
                 drop(lock);
 
                 let outcome = self
                     .sync_service
                     .clone()
                     .storage_prefix_keys_query(
+                        block_number,
                         &block_hash,
                         &prefix.unwrap().0, // TODO: don't unwrap! what is this Option?
                         &state_root,

--- a/bin/wasm-node/rust/src/json_rpc_service.rs
+++ b/bin/wasm-node/rust/src/json_rpc_service.rs
@@ -437,10 +437,9 @@ impl JsonRpcService {
 
                 // Block bodies and justifications aren't stored locally. Ask the network.
                 let result = self
-                    .network_service
+                    .sync_service
                     .clone()
                     .block_query(
-                        self.network_chain_index,
                         hash,
                         protocol::BlocksRequestFields {
                             header: true,
@@ -578,10 +577,9 @@ impl JsonRpcService {
                 drop(lock);
 
                 let outcome = self
-                    .network_service
+                    .sync_service
                     .clone()
                     .storage_prefix_keys_query(
-                        self.network_chain_index,
                         &block_hash,
                         &prefix.unwrap().0, // TODO: don't unwrap! what is this Option?
                         &state_root,
@@ -1405,14 +1403,9 @@ impl JsonRpcService {
                             for (key_index, key) in list.iter().enumerate() {
                                 // TODO: parallelism?
                                 match client
-                                    .network_service
+                                    .sync_service
                                     .clone()
-                                    .storage_query(
-                                        client.network_chain_index,
-                                        &block_hash,
-                                        state_trie_root,
-                                        iter::once(&key.0),
-                                    )
+                                    .storage_query(&block_hash, state_trie_root, iter::once(&key.0))
                                     .await
                                 {
                                     Ok(mut values) => {
@@ -1510,14 +1503,9 @@ impl JsonRpcService {
         let trie_root_hash = header::decode(&header).unwrap().state_root;
 
         let mut result = self
-            .network_service
+            .sync_service
             .clone()
-            .storage_query(
-                self.network_chain_index,
-                hash,
-                &trie_root_hash,
-                iter::once(key),
-            )
+            .storage_query(hash, &trie_root_hash, iter::once(key))
             .await
             .map_err(StorageQueryError::StorageRetrieval)?;
         Ok(result.pop().unwrap())
@@ -1533,10 +1521,9 @@ impl JsonRpcService {
         } else {
             // Header isn't known locally. Ask the network.
             let result = self
-                .network_service
+                .sync_service
                 .clone()
                 .block_query(
-                    self.network_chain_index,
                     *hash,
                     protocol::BlocksRequestFields {
                         header: true,
@@ -1564,7 +1551,7 @@ enum StorageQueryError {
     FindStorageRootHashError,
     /// Error while retrieving the storage item from other nodes.
     #[display(fmt = "{}", _0)]
-    StorageRetrieval(network_service::StorageQueryError),
+    StorageRetrieval(sync_service::StorageQueryError),
 }
 
 impl StorageQueryError {

--- a/bin/wasm-node/rust/src/lib.rs
+++ b/bin/wasm-node/rust/src/lib.rs
@@ -280,7 +280,6 @@ async fn start_services(
                 let new_task_tx = new_task_tx.clone();
                 move |fut| new_task_tx.unbounded_send(fut).unwrap()
             }),
-            network_service: (network_service.clone(), chain_index),
             sync_service: sync_service.clone(),
             chain_spec: &chain_spec,
             genesis_block_hash: genesis_chain_information.finalized_block_header.hash(),
@@ -352,7 +351,6 @@ async fn start_services(
                 let new_task_tx = new_task_tx.clone();
                 move |fut| new_task_tx.unbounded_send(fut).unwrap()
             }),
-            network_service: (network_service.clone(), chain_index),
             sync_service: sync_service.clone(),
             chain_spec,
             genesis_block_hash: genesis_chain_information.finalized_block_header.hash(),

--- a/bin/wasm-node/rust/src/network_service.rs
+++ b/bin/wasm-node/rust/src/network_service.rs
@@ -50,7 +50,6 @@ use smoldot::{
     informant::HashDisplay,
     libp2p::{connection, multiaddr::Multiaddr, peer_id::PeerId},
     network::{protocol, service},
-    trie::{self, prefix_proof, proof_verify},
 };
 use std::{collections::HashSet, sync::Arc};
 
@@ -386,77 +385,6 @@ impl NetworkService {
         (network_service, receivers)
     }
 
-    // TODO: doc; explain the guarantees
-    pub async fn block_query(
-        self: Arc<Self>,
-        chain_index: usize,
-        hash: [u8; 32],
-        fields: protocol::BlocksRequestFields,
-    ) -> Result<protocol::BlockData, ()> {
-        // TODO: better error?
-        const NUM_ATTEMPTS: usize = 3;
-
-        let request_config = protocol::BlocksRequestConfig {
-            start: protocol::BlocksRequestConfigStart::Hash(hash),
-            desired_count: NonZeroU32::new(1).unwrap(),
-            direction: protocol::BlocksRequestDirection::Ascending,
-            fields: fields.clone(),
-        };
-
-        // TODO: better peers selection ; don't just take the first 3
-        // TODO: must only ask the peers that know about this block
-        for target in self.peers_list().await.take(NUM_ATTEMPTS) {
-            let mut result = match self
-                .clone()
-                .blocks_request(target, chain_index, request_config.clone())
-                .await
-            {
-                Ok(b) => b,
-                Err(_) => continue,
-            };
-
-            if result.len() != 1 {
-                continue;
-            }
-
-            let result = result.remove(0);
-
-            if result.header.is_none() && fields.header {
-                continue;
-            }
-            if result
-                .header
-                .as_ref()
-                .map_or(false, |h| header::decode(h).is_err())
-            {
-                continue;
-            }
-            if result.body.is_none() && fields.body {
-                continue;
-            }
-            // Note: the presence of a justification isn't checked and can't be checked, as not
-            // all blocks have a justification in the first place.
-            if result.hash != hash {
-                continue;
-            }
-            if result.header.as_ref().map_or(false, |h| {
-                header::hash_from_scale_encoded_header(&h) != result.hash
-            }) {
-                continue;
-            }
-            match (&result.header, &result.body) {
-                (Some(_), Some(_)) => {
-                    // TODO: verify correctness of body
-                }
-                _ => {}
-            }
-
-            return Ok(result);
-        }
-
-        Err(())
-    }
-
     /// Sends a blocks request to the given peer.
     // TODO: more docs
     pub async fn blocks_request(
@@ -540,141 +468,6 @@ impl NetworkService {
             .await
     }
 
-    /// Performs one or more storage proof requests in order to find the value of the given
-    /// `requested_keys`.
-    ///
-    /// Must be passed a block hash and the Merkle value of the root node of the storage trie of
-    /// this same block. The value of `storage_trie_root` corresponds to the value in the
-    /// [`smoldot::header::HeaderRef::state_root`] field.
-    ///
-    /// Returns the storage values of `requested_keys` in the storage of the block, or an error if
-    /// it couldn't be determined. If `Ok`, the `Vec` is guaranteed to have the same number of
-    /// elements as `requested_keys`.
-    ///
-    /// This function is equivalent to calling [`NetworkService::storage_proof_request`] and
-    /// verifying the proof, potentially multiple times until it succeeds. The number of attempts
-    /// and the selection of peers is done through reasonable heuristics.
-    pub async fn storage_query(
-        self: Arc<Self>,
-        chain_index: usize,
-        block_hash: &[u8; 32],
-        storage_trie_root: &[u8; 32],
-        requested_keys: impl Iterator<Item = impl AsRef<[u8]>> + Clone,
-    ) -> Result<Vec<Option<Vec<u8>>>, StorageQueryError> {
-        const NUM_ATTEMPTS: usize = 3;
-
-        let mut outcome_errors = Vec::with_capacity(NUM_ATTEMPTS);
-
-        // TODO: better peers selection ; don't just take the first 3
-        // TODO: must only ask the peers that know about this block
-        for target in self.peers_list().await.take(NUM_ATTEMPTS) {
-            let result = self
-                .clone()
-                .storage_proof_request(
-                    chain_index,
-                    target,
-                    protocol::StorageProofRequestConfig {
-                        block_hash: *block_hash,
-                        keys: requested_keys.clone(),
-                    },
-                )
-                .await
-                .map_err(StorageQueryErrorDetail::Network)
-                .and_then(|outcome| {
-                    let mut result = Vec::with_capacity(requested_keys.clone().count());
-                    for key in requested_keys.clone() {
-                        result.push(
-                            proof_verify::verify_proof(proof_verify::VerifyProofConfig {
-                                proof: outcome.iter().map(|nv| &nv[..]),
-                                requested_key: key.as_ref(),
-                                trie_root_hash: &storage_trie_root,
-                            })
-                            .map_err(StorageQueryErrorDetail::ProofVerification)?
-                            .map(|v| v.to_owned()),
-                        );
-                    }
-                    debug_assert_eq!(result.len(), result.capacity());
-                    Ok(result)
-                });
-
-            match result {
-                Ok(values) => return Ok(values),
-                Err(err) => {
-                    outcome_errors.push(err);
-                }
-            }
-        }
-
-        Err(StorageQueryError {
-            errors: outcome_errors,
-        })
-    }
-
-    pub async fn storage_prefix_keys_query(
-        self: Arc<Self>,
-        chain_index: usize,
-        block_hash: &[u8; 32],
-        prefix: &[u8],
-        storage_trie_root: &[u8; 32],
-    ) -> Result<Vec<Vec<u8>>, StorageQueryError> {
-        let mut prefix_scan = prefix_proof::prefix_scan(prefix_proof::Config {
-            prefix,
-            trie_root_hash: *storage_trie_root,
-        });
-
-        'main_scan: loop {
-            const NUM_ATTEMPTS: usize = 3;
-
-            let mut outcome_errors = Vec::with_capacity(NUM_ATTEMPTS);
-
-            // TODO: better peers selection ; don't just take the first 3
-            // TODO: must only ask the peers that know about this block
-            for target in self.peers_list().await.take(NUM_ATTEMPTS) {
-                let result = self
-                    .clone()
-                    .storage_proof_request(
-                        chain_index,
-                        target,
-                        protocol::StorageProofRequestConfig {
-                            block_hash: *block_hash,
-                            keys: prefix_scan.requested_keys().map(|nibbles| {
-                                trie::nibbles_to_bytes_extend(nibbles).collect::<Vec<_>>()
-                            }),
-                        },
-                    )
-                    .await
-                    .map_err(StorageQueryErrorDetail::Network);
-
-                match result {
-                    Ok(proof) => {
-                        match prefix_scan.resume(proof.iter().map(|v| &v[..])) {
-                            Ok(prefix_proof::ResumeOutcome::InProgress(scan)) => {
-                                // Continue next step of the proof.
-                                prefix_scan = scan;
-                                continue 'main_scan;
-                            }
-                            Ok(prefix_proof::ResumeOutcome::Success { keys }) => {
-                                return Ok(keys);
-                            }
-                            Err((scan, err)) => {
-                                prefix_scan = scan;
-                                outcome_errors
-                                    .push(StorageQueryErrorDetail::ProofVerification(err));
-                            }
-                        }
-                    }
-                    Err(err) => {
-                        outcome_errors.push(err);
-                    }
-                }
-            }
-
-            return Err(StorageQueryError {
-                errors: outcome_errors,
-            });
-        }
-    }
-
     /// Sends a storage proof request to the given peer.
     ///
     /// See also [`NetworkService::storage_query`].
@@ -706,40 +499,6 @@ impl NetworkService {
         );
 
         result
-    }
-
-    // TODO: documentation
-    pub async fn call_proof_query<'a>(
-        self: Arc<Self>,
-        chain_index: usize,
-        config: protocol::CallProofRequestConfig<
-            'a,
-            impl Iterator<Item = impl AsRef<[u8]>> + Clone,
-        >,
-    ) -> Result<Vec<Vec<u8>>, CallProofQueryError> {
-        const NUM_ATTEMPTS: usize = 3;
-
-        let mut outcome_errors = Vec::with_capacity(NUM_ATTEMPTS);
-
-        // TODO: better peers selection ; don't just take the first 3
-        // TODO: must only ask the peers that know about this block
-        for target in self.peers_list().await.take(NUM_ATTEMPTS) {
-            let result = self
-                .clone()
-                .call_proof_request(chain_index, target, config.clone())
-                .await;
-
-            match result {
-                Ok(value) => return Ok(value),
-                Err(err) => {
-                    outcome_errors.push(err);
-                }
-            }
-        }
-
-        Err(CallProofQueryError {
-            errors: outcome_errors,
-        })
     }
 
     /// Sends a call proof request to the given peer.
@@ -837,77 +596,6 @@ pub enum Event {
         chain_index: usize,
         message: service::EncodedGrandpaCommitMessage,
     },
-}
-
-/// Error that can happen when calling [`NetworkService::storage_query`].
-#[derive(Debug)]
-pub struct StorageQueryError {
-    /// Contains one error per peer that has been contacted. If this list is empty, then we
-    /// aren't connected to any node.
-    pub errors: Vec<StorageQueryErrorDetail>,
-}
-
-impl StorageQueryError {
-    /// Returns `true` if this is caused by networking issues, as opposed to a consensus-related
-    /// issue.
-    pub fn is_network_problem(&self) -> bool {
-        self.errors.iter().all(|err| match err {
-            StorageQueryErrorDetail::Network(service::StorageProofRequestError::Request(_)) => true,
-            StorageQueryErrorDetail::Network(service::StorageProofRequestError::Decode(_)) => false,
-            // TODO: as a temporary hack, we consider `TrieRootNotFound` as the remote not knowing about the requested block; see https://github.com/paritytech/substrate/pull/8046
-            StorageQueryErrorDetail::ProofVerification(proof_verify::Error::TrieRootNotFound) => {
-                true
-            }
-            StorageQueryErrorDetail::ProofVerification(_) => false,
-        })
-    }
-}
-
-impl fmt::Display for StorageQueryError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.errors.is_empty() {
-            write!(f, "No node available for storage query")
-        } else {
-            write!(f, "Storage query errors:")?;
-            for err in &self.errors {
-                write!(f, "\n- {}", err)?;
-            }
-            Ok(())
-        }
-    }
-}
-
-/// See [`StorageQueryError`].
-#[derive(Debug, derive_more::Display)]
-pub enum StorageQueryErrorDetail {
-    /// Error during the network request.
-    #[display(fmt = "{}", _0)]
-    Network(service::StorageProofRequestError),
-    /// Error verifying the proof.
-    #[display(fmt = "{}", _0)]
-    ProofVerification(proof_verify::Error),
-}
-
-/// Error that can happen when calling [`NetworkService::call_proof_query`].
-#[derive(Debug)]
-pub struct CallProofQueryError {
-    /// Contains one error per peer that has been contacted. If this list is empty, then we
-    /// aren't connected to any node.
-    pub errors: Vec<service::CallProofRequestError>,
-}
-
-impl fmt::Display for CallProofQueryError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.errors.is_empty() {
-            write!(f, "No node available for call proof query")
-        } else {
-            write!(f, "Call proof query errors:")?;
-            for err in &self.errors {
-                write!(f, "\n- {}", err)?;
-            }
-            Ok(())
-        }
-    }
 }
 
 /// Asynchronous task managing a specific connection.

--- a/bin/wasm-node/rust/src/network_service.rs
+++ b/bin/wasm-node/rust/src/network_service.rs
@@ -469,8 +469,6 @@ impl NetworkService {
     }
 
     /// Sends a storage proof request to the given peer.
-    ///
-    /// See also [`NetworkService::storage_query`].
     // TODO: more docs
     pub async fn storage_proof_request(
         self: Arc<Self>,

--- a/bin/wasm-node/rust/src/runtime_service.rs
+++ b/bin/wasm-node/rust/src/runtime_service.rs
@@ -261,10 +261,9 @@ impl RuntimeService {
             // If the call proof fail, do as if the proof was empty. This will enable the
             // fallback consisting in performing individual storage proof requests.
             let call_proof = self
-                .network_service
+                .sync_service
                 .clone()
                 .call_proof_query(
-                    self.network_chain_index,
                     protocol::CallProofRequestConfig {
                         block_hash: runtime_block_hash,
                         method,
@@ -604,10 +603,9 @@ async fn start_background_task(runtime_service: &Arc<RuntimeService>) {
                 let new_best_block_decoded = header::decode(&new_best_block).unwrap();
                 let new_best_block_hash = header::hash_from_scale_encoded_header(&new_best_block);
                 let code_query_result = runtime_service
-                    .network_service
+                    .sync_service
                     .clone()
                     .storage_query(
-                        runtime_service.network_chain_index,
                         &new_best_block_hash,
                         new_best_block_decoded.state_root,
                         iter::once(&b":code"[..]).chain(iter::once(&b":heappages"[..])),

--- a/bin/wasm-node/rust/src/runtime_service.rs
+++ b/bin/wasm-node/rust/src/runtime_service.rs
@@ -36,10 +36,6 @@ pub struct Config<'a> {
     /// Closure that spawns background tasks.
     pub tasks_executor: Box<dyn FnMut(Pin<Box<dyn Future<Output = ()> + Send>>) + Send>,
 
-    /// Service responsible for the networking of the chain, and index of the chain within the
-    /// network service to handle.
-    pub network_service: (Arc<network_service::NetworkService>, usize),
-
     /// Service responsible for synchronizing the chain.
     pub sync_service: Arc<sync_service::SyncService>,
 
@@ -69,10 +65,6 @@ pub struct RuntimeService {
     /// See [`Config::tasks_executor`].
     tasks_executor: Mutex<Box<dyn FnMut(Pin<Box<dyn Future<Output = ()> + Send>>) + Send>>,
 
-    /// See [`Config::network_service`].
-    network_service: Arc<network_service::NetworkService>,
-    /// See [`Config::network_service`].
-    network_chain_index: usize,
     /// See [`Config::sync_service`].
     sync_service: Arc<sync_service::SyncService>,
 
@@ -138,6 +130,7 @@ impl RuntimeService {
                 runtime_code: code,
                 heap_pages,
                 runtime_block_hash: config.genesis_block_hash,
+                runtime_block_height: 0,
                 runtime_block_state_root: config.genesis_block_state_root,
                 runtime_version_subscriptions: Vec::new(),
                 best_blocks_subscriptions: Vec::new(),
@@ -146,8 +139,6 @@ impl RuntimeService {
 
         let runtime_service = Arc::new(RuntimeService {
             tasks_executor: Mutex::new(config.tasks_executor),
-            network_service: config.network_service.0,
-            network_chain_index: config.network_service.1,
             sync_service: config.sync_service,
             latest_known_runtime: Mutex::new(latest_known_runtime),
         });
@@ -240,9 +231,9 @@ impl RuntimeService {
         // it with the value previously found. If there is a mismatch, the entire runtime call
         // is restarted from scratch.
         loop {
-            // Get `runtime_block_hash` and `runtime_block_state_root`, the hash and state trie
-            // root of a recent best block that uses this runtime.
-            let (spec_version, runtime_block_hash, runtime_block_state_root) = {
+            // Get `runtime_block_hash`, `runtime_block_height` and `runtime_block_state_root`,
+            // the hash, height, and state trie root of a recent best block that uses this runtime.
+            let (spec_version, runtime_block_hash, runtime_block_height, runtime_block_state_root) = {
                 let lock = self.latest_known_runtime.lock().await;
                 (
                     lock.runtime
@@ -252,6 +243,7 @@ impl RuntimeService {
                         .decode()
                         .spec_version,
                     lock.runtime_block_hash,
+                    lock.runtime_block_height,
                     lock.runtime_block_state_root,
                 )
             };
@@ -264,6 +256,7 @@ impl RuntimeService {
                 .sync_service
                 .clone()
                 .call_proof_query(
+                    runtime_block_height,
                     protocol::CallProofRequestConfig {
                         block_hash: runtime_block_hash,
                         method,
@@ -467,6 +460,8 @@ struct LatestKnownRuntime {
     /// Hash of a block known to have the runtime found in the [`LatestKnownRuntime::runtime`]
     /// field. Always updated to a recent block having this runtime.
     runtime_block_hash: [u8; 32],
+    /// Height of the block whose hash is [`LatestKnownRuntime::runtime_block_hash`].
+    runtime_block_height: u64,
     /// Storage trie root of the block whose hash is [`LatestKnownRuntime::runtime_block_hash`].
     runtime_block_state_root: [u8; 32],
 
@@ -650,6 +645,7 @@ async fn start_background_task(runtime_service: &Arc<RuntimeService>) {
                 // `runtime_block_hash` is always updated in order to have the most recent
                 // block possible.
                 latest_known_runtime.runtime_block_hash = new_best_block_hash;
+                latest_known_runtime.runtime_block_height = new_best_block_decoded.number;
                 latest_known_runtime.runtime_block_state_root = *new_best_block_decoded.state_root;
 
                 // `continue` if there wasn't any change in `:code` and `:heappages`.

--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -294,9 +294,10 @@ impl SyncService {
     /// it couldn't be determined. If `Ok`, the `Vec` is guaranteed to have the same number of
     /// elements as `requested_keys`.
     ///
-    /// This function is equivalent to calling [`NetworkService::storage_proof_request`] and
-    /// verifying the proof, potentially multiple times until it succeeds. The number of attempts
-    /// and the selection of peers is done through reasonable heuristics.
+    /// This function is equivalent to calling
+    /// [`network_service::NetworkService::storage_proof_request`] and verifying the proof,
+    /// potentially multiple times until it succeeds. The number of attempts and the selection of
+    /// peers is done through reasonable heuristics.
     pub async fn storage_query(
         self: Arc<Self>,
         block_hash: &[u8; 32],
@@ -461,7 +462,7 @@ impl SyncService {
     }
 }
 
-/// Error that can happen when calling [`NetworkService::storage_query`].
+/// Error that can happen when calling [`SyncService::storage_query`].
 #[derive(Debug)]
 pub struct StorageQueryError {
     /// Contains one error per peer that has been contacted. If this list is empty, then we
@@ -510,7 +511,7 @@ pub enum StorageQueryErrorDetail {
     ProofVerification(proof_verify::Error),
 }
 
-/// Error that can happen when calling [`NetworkService::call_proof_query`].
+/// Error that can happen when calling [`SyncService::call_proof_query`].
 #[derive(Debug)]
 pub struct CallProofQueryError {
     /// Contains one error per peer that has been contacted. If this list is empty, then we

--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -39,11 +39,11 @@ use smoldot::{
     chain, header,
     informant::HashDisplay,
     libp2p::{self, PeerId},
-    network,
+    network::{self, protocol, service},
     sync::{all, para},
-    trie::proof_verify,
+    trie::{self, prefix_proof, proof_verify},
 };
-use std::{collections::HashMap, convert::TryFrom as _, num::NonZeroU32, pin::Pin, sync::Arc};
+use std::{collections::HashMap, convert::TryFrom as _, fmt, num::NonZeroU32, pin::Pin, sync::Arc};
 
 pub use crate::lossy_channel::Receiver as NotificationsReceiver;
 
@@ -94,6 +94,11 @@ pub struct BlocksRequestId(usize);
 pub struct SyncService {
     /// Sender of messages towards the background task.
     to_background: Mutex<mpsc::Sender<ToBackground>>,
+
+    /// See [`Config::network_service`].
+    network_service: Arc<network_service::NetworkService>,
+    /// See [`Config::network_service`].
+    network_chain_index: usize,
 }
 
 impl SyncService {
@@ -111,7 +116,7 @@ impl SyncService {
                 start_relay_chain(
                     config.chain_information,
                     from_foreground,
-                    config.network_service.0,
+                    config.network_service.0.clone(),
                     config.network_service.1,
                     config.network_events_receiver,
                 )
@@ -121,6 +126,8 @@ impl SyncService {
 
         SyncService {
             to_background: Mutex::new(to_background),
+            network_service: config.network_service.0,
+            network_chain_index: config.network_service.1,
         }
     }
 
@@ -179,6 +186,7 @@ impl SyncService {
 
     /// Returns the list of peers from the [`network_service::NetworkService`] that are known to
     /// be aware of the given block.
+    // TODO: remove block_number
     pub async fn peers_know_blocks(
         &self,
         block_number: u64,
@@ -198,6 +206,317 @@ impl SyncService {
             .unwrap();
 
         rx.await.unwrap().into_iter()
+    }
+
+    // TODO: doc; explain the guarantees
+    pub async fn block_query(
+        self: Arc<Self>,
+        hash: [u8; 32],
+        fields: protocol::BlocksRequestFields,
+    ) -> Result<protocol::BlockData, ()> {
+        // TODO: better error?
+        const NUM_ATTEMPTS: usize = 3;
+
+        let request_config = protocol::BlocksRequestConfig {
+            start: protocol::BlocksRequestConfigStart::Hash(hash),
+            desired_count: NonZeroU32::new(1).unwrap(),
+            direction: protocol::BlocksRequestDirection::Ascending,
+            fields: fields.clone(),
+        };
+
+        // TODO: better peers selection ; don't just take the first 3
+        // TODO: must only ask the peers that know about this block
+        for target in self.network_service.peers_list().await.take(NUM_ATTEMPTS) {
+            let mut result = match self
+                .network_service
+                .clone()
+                .blocks_request(target, self.network_chain_index, request_config.clone())
+                .await
+            {
+                Ok(b) => b,
+                Err(_) => continue,
+            };
+
+            if result.len() != 1 {
+                continue;
+            }
+
+            let result = result.remove(0);
+
+            if result.header.is_none() && fields.header {
+                continue;
+            }
+            if result
+                .header
+                .as_ref()
+                .map_or(false, |h| header::decode(h).is_err())
+            {
+                continue;
+            }
+            if result.body.is_none() && fields.body {
+                continue;
+            }
+            // Note: the presence of a justification isn't checked and can't be checked, as not
+            // all blocks have a justification in the first place.
+            if result.hash != hash {
+                continue;
+            }
+            if result.header.as_ref().map_or(false, |h| {
+                header::hash_from_scale_encoded_header(&h) != result.hash
+            }) {
+                continue;
+            }
+            match (&result.header, &result.body) {
+                (Some(_), Some(_)) => {
+                    // TODO: verify correctness of body
+                }
+                _ => {}
+            }
+
+            return Ok(result);
+        }
+
+        Err(())
+    }
+
+    /// Performs one or more storage proof requests in order to find the value of the given
+    /// `requested_keys`.
+    ///
+    /// Must be passed a block hash and the Merkle value of the root node of the storage trie of
+    /// this same block. The value of `storage_trie_root` corresponds to the value in the
+    /// [`smoldot::header::HeaderRef::state_root`] field.
+    ///
+    /// Returns the storage values of `requested_keys` in the storage of the block, or an error if
+    /// it couldn't be determined. If `Ok`, the `Vec` is guaranteed to have the same number of
+    /// elements as `requested_keys`.
+    ///
+    /// This function is equivalent to calling [`NetworkService::storage_proof_request`] and
+    /// verifying the proof, potentially multiple times until it succeeds. The number of attempts
+    /// and the selection of peers is done through reasonable heuristics.
+    pub async fn storage_query(
+        self: Arc<Self>,
+        block_hash: &[u8; 32],
+        storage_trie_root: &[u8; 32],
+        requested_keys: impl Iterator<Item = impl AsRef<[u8]>> + Clone,
+    ) -> Result<Vec<Option<Vec<u8>>>, StorageQueryError> {
+        const NUM_ATTEMPTS: usize = 3;
+
+        let mut outcome_errors = Vec::with_capacity(NUM_ATTEMPTS);
+
+        // TODO: better peers selection ; don't just take the first 3
+        // TODO: must only ask the peers that know about this block
+        for target in self.network_service.peers_list().await.take(NUM_ATTEMPTS) {
+            let result = self
+                .network_service
+                .clone()
+                .storage_proof_request(
+                    self.network_chain_index,
+                    target,
+                    protocol::StorageProofRequestConfig {
+                        block_hash: *block_hash,
+                        keys: requested_keys.clone(),
+                    },
+                )
+                .await
+                .map_err(StorageQueryErrorDetail::Network)
+                .and_then(|outcome| {
+                    let mut result = Vec::with_capacity(requested_keys.clone().count());
+                    for key in requested_keys.clone() {
+                        result.push(
+                            proof_verify::verify_proof(proof_verify::VerifyProofConfig {
+                                proof: outcome.iter().map(|nv| &nv[..]),
+                                requested_key: key.as_ref(),
+                                trie_root_hash: &storage_trie_root,
+                            })
+                            .map_err(StorageQueryErrorDetail::ProofVerification)?
+                            .map(|v| v.to_owned()),
+                        );
+                    }
+                    debug_assert_eq!(result.len(), result.capacity());
+                    Ok(result)
+                });
+
+            match result {
+                Ok(values) => return Ok(values),
+                Err(err) => {
+                    outcome_errors.push(err);
+                }
+            }
+        }
+
+        Err(StorageQueryError {
+            errors: outcome_errors,
+        })
+    }
+
+    pub async fn storage_prefix_keys_query(
+        self: Arc<Self>,
+        block_hash: &[u8; 32],
+        prefix: &[u8],
+        storage_trie_root: &[u8; 32],
+    ) -> Result<Vec<Vec<u8>>, StorageQueryError> {
+        let mut prefix_scan = prefix_proof::prefix_scan(prefix_proof::Config {
+            prefix,
+            trie_root_hash: *storage_trie_root,
+        });
+
+        'main_scan: loop {
+            const NUM_ATTEMPTS: usize = 3;
+
+            let mut outcome_errors = Vec::with_capacity(NUM_ATTEMPTS);
+
+            // TODO: better peers selection ; don't just take the first 3
+            // TODO: must only ask the peers that know about this block
+            for target in self.network_service.peers_list().await.take(NUM_ATTEMPTS) {
+                let result = self
+                    .network_service
+                    .clone()
+                    .storage_proof_request(
+                        self.network_chain_index,
+                        target,
+                        protocol::StorageProofRequestConfig {
+                            block_hash: *block_hash,
+                            keys: prefix_scan.requested_keys().map(|nibbles| {
+                                trie::nibbles_to_bytes_extend(nibbles).collect::<Vec<_>>()
+                            }),
+                        },
+                    )
+                    .await
+                    .map_err(StorageQueryErrorDetail::Network);
+
+                match result {
+                    Ok(proof) => {
+                        match prefix_scan.resume(proof.iter().map(|v| &v[..])) {
+                            Ok(prefix_proof::ResumeOutcome::InProgress(scan)) => {
+                                // Continue next step of the proof.
+                                prefix_scan = scan;
+                                continue 'main_scan;
+                            }
+                            Ok(prefix_proof::ResumeOutcome::Success { keys }) => {
+                                return Ok(keys);
+                            }
+                            Err((scan, err)) => {
+                                prefix_scan = scan;
+                                outcome_errors
+                                    .push(StorageQueryErrorDetail::ProofVerification(err));
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        outcome_errors.push(err);
+                    }
+                }
+            }
+
+            return Err(StorageQueryError {
+                errors: outcome_errors,
+            });
+        }
+    }
+
+    // TODO: documentation
+    pub async fn call_proof_query<'a>(
+        self: Arc<Self>,
+        config: protocol::CallProofRequestConfig<
+            'a,
+            impl Iterator<Item = impl AsRef<[u8]>> + Clone,
+        >,
+    ) -> Result<Vec<Vec<u8>>, CallProofQueryError> {
+        const NUM_ATTEMPTS: usize = 3;
+
+        let mut outcome_errors = Vec::with_capacity(NUM_ATTEMPTS);
+
+        // TODO: better peers selection ; don't just take the first 3
+        // TODO: must only ask the peers that know about this block
+        for target in self.network_service.peers_list().await.take(NUM_ATTEMPTS) {
+            let result = self
+                .network_service
+                .clone()
+                .call_proof_request(self.network_chain_index, target, config.clone())
+                .await;
+
+            match result {
+                Ok(value) => return Ok(value),
+                Err(err) => {
+                    outcome_errors.push(err);
+                }
+            }
+        }
+
+        Err(CallProofQueryError {
+            errors: outcome_errors,
+        })
+    }
+}
+
+/// Error that can happen when calling [`NetworkService::storage_query`].
+#[derive(Debug)]
+pub struct StorageQueryError {
+    /// Contains one error per peer that has been contacted. If this list is empty, then we
+    /// aren't connected to any node.
+    pub errors: Vec<StorageQueryErrorDetail>,
+}
+
+impl StorageQueryError {
+    /// Returns `true` if this is caused by networking issues, as opposed to a consensus-related
+    /// issue.
+    pub fn is_network_problem(&self) -> bool {
+        self.errors.iter().all(|err| match err {
+            StorageQueryErrorDetail::Network(service::StorageProofRequestError::Request(_)) => true,
+            StorageQueryErrorDetail::Network(service::StorageProofRequestError::Decode(_)) => false,
+            // TODO: as a temporary hack, we consider `TrieRootNotFound` as the remote not knowing about the requested block; see https://github.com/paritytech/substrate/pull/8046
+            StorageQueryErrorDetail::ProofVerification(proof_verify::Error::TrieRootNotFound) => {
+                true
+            }
+            StorageQueryErrorDetail::ProofVerification(_) => false,
+        })
+    }
+}
+
+impl fmt::Display for StorageQueryError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.errors.is_empty() {
+            write!(f, "No node available for storage query")
+        } else {
+            write!(f, "Storage query errors:")?;
+            for err in &self.errors {
+                write!(f, "\n- {}", err)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+/// See [`StorageQueryError`].
+#[derive(Debug, derive_more::Display)]
+pub enum StorageQueryErrorDetail {
+    /// Error during the network request.
+    #[display(fmt = "{}", _0)]
+    Network(service::StorageProofRequestError),
+    /// Error verifying the proof.
+    #[display(fmt = "{}", _0)]
+    ProofVerification(proof_verify::Error),
+}
+
+/// Error that can happen when calling [`NetworkService::call_proof_query`].
+#[derive(Debug)]
+pub struct CallProofQueryError {
+    /// Contains one error per peer that has been contacted. If this list is empty, then we
+    /// aren't connected to any node.
+    pub errors: Vec<service::CallProofRequestError>,
+}
+
+impl fmt::Display for CallProofQueryError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.errors.is_empty() {
+            write!(f, "No node available for call proof query")
+        } else {
+            write!(f, "Call proof query errors:")?;
+            for err in &self.errors {
+                write!(f, "\n- {}", err)?;
+            }
+            Ok(())
+        }
     }
 }
 

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -305,21 +305,27 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     /// Returns true if the source has earlier announced the block passed as parameter or one of
     /// its descendants.
     ///
+    /// Also returns true if the requested block is inferior or equal to the known finalized block
+    /// and the source has announced a block higher or equal to the known finalized block.
+    ///
     /// # Panic
     ///
     /// Panics if the [`SourceId`] is out of range.
     ///
-    // TODO: document precisely what it means
-    // TODO: shouldn't take &mut self but just &self
-    pub fn source_knows_block(
-        &mut self,
-        source_id: SourceId,
-        height: u64,
-        hash: &[u8; 32],
-    ) -> bool {
+    pub fn source_knows_block(&self, source_id: SourceId, height: u64, hash: &[u8; 32]) -> bool {
         self.inner
             .blocks
-            .source_knows_non_finalized_block(source_id, height, hash) // TODO: doesn't match the outer API
+            .source_knows_block(source_id, height, hash)
+    }
+
+    /// Returns the list of sources for which [`AllForksSync::source_knows_block`] would return
+    /// `true`.
+    pub fn knows_block<'a>(
+        &'a self,
+        height: u64,
+        hash: &[u8; 32],
+    ) -> impl Iterator<Item = SourceId> + 'a {
+        self.inner.blocks.knows_block(height, hash)
     }
 
     /// Returns the user data associated to the source. This is the value originally passed

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -302,6 +302,11 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
         self.inner.blocks.remove_source(source_id)
     }
 
+    /// Returns the list of sources in this state machine.
+    pub fn sources(&'_ self) -> impl ExactSizeIterator<Item = SourceId> + '_ {
+        self.inner.blocks.sources()
+    }
+
     /// Returns true if the source has earlier announced the block passed as parameter or one of
     /// its descendants.
     ///
@@ -312,20 +317,49 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     ///
     /// Panics if the [`SourceId`] is out of range.
     ///
-    pub fn source_knows_block(&self, source_id: SourceId, height: u64, hash: &[u8; 32]) -> bool {
+    /// Panics if `height` is inferior or equal to the finalized block height. Finalized blocks
+    /// are intentionally not tracked by this data structure, and panicking when asking for a
+    /// potentially-finalized block prevents potentially confusing or erroneous situations.
+    ///
+    pub fn source_knows_non_finalized_block(
+        &self,
+        source_id: SourceId,
+        height: u64,
+        hash: &[u8; 32],
+    ) -> bool {
         self.inner
             .blocks
-            .source_knows_block(source_id, height, hash)
+            .source_knows_non_finalized_block(source_id, height, hash)
     }
 
-    /// Returns the list of sources for which [`AllForksSync::source_knows_block`] would return
-    /// `true`.
-    pub fn knows_block<'a>(
+    /// Returns the list of sources for which [`AllForksSync::source_knows_non_finalized_block`]
+    /// would return `true`.
+    ///
+    /// # Panic
+    ///
+    /// Panics if `height` is inferior or equal to the finalized block height. Finalized blocks
+    /// are intentionally not tracked by this data structure, and panicking when asking for a
+    /// potentially-finalized block prevents potentially confusing or erroneous situations.
+    ///
+    pub fn knows_non_finalized_block<'a>(
         &'a self,
         height: u64,
         hash: &[u8; 32],
     ) -> impl Iterator<Item = SourceId> + 'a {
-        self.inner.blocks.knows_block(height, hash)
+        self.inner.blocks.knows_non_finalized_block(height, hash)
+    }
+
+    /// Returns the current best block of the given source.
+    ///
+    /// This corresponds either the latest call to [`AllForksSync::block_announce`] where
+    /// `is_best` was `true`, or to the parameter passed to [`AllForksSync::add_source`].
+    ///
+    /// # Panic
+    ///
+    /// Panics if the [`SourceId`] is invalid.
+    ///
+    pub fn source_best_block(&self, source_id: SourceId) -> (u64, &[u8; 32]) {
+        self.inner.blocks.source_best_block(source_id)
     }
 
     /// Returns the user data associated to the source. This is the value originally passed

--- a/src/sync/all_forks/sources.rs
+++ b/src/sync/all_forks/sources.rs
@@ -294,60 +294,63 @@ impl<TSrc> AllForksSources<TSrc> {
         source.best_block_hash = hash;
     }
 
-    /// Returns the list of sources for which [`AllForksSources::knows_block`]
+    /// Returns the current best block of the given source.
+    ///
+    /// This corresponds either the latest call to [`AllForksSources::set_best_block`],
+    /// or to the parameter passed to [`AllForksSources::add_source`].
+    ///
+    /// # Panic
+    ///
+    /// Panics if the [`SourceId`] is invalid.
+    ///
+    pub fn best_block(&self, source_id: SourceId) -> (u64, &[u8; 32]) {
+        let source = self.sources.get(&source_id).unwrap();
+        (source.best_block_number, &source.best_block_hash)
+    }
+
+    /// Returns the list of sources for which [`AllForksSources::knows_non_finalized_block`]
     /// would return `true`.
     ///
-    /// If the requested block is inferior or equal to the finalized block height, the check is
-    /// simply whether the best block reported by the source is superior or equal to the requested
-    /// block.
-    pub fn knows_block<'a>(
+    /// # Panic
+    ///
+    /// Panics if `height` is inferior or equal to the finalized block height. Finalized blocks
+    /// are intentionally not tracked by this data structure, and panicking when asking for a
+    /// potentially-finalized block prevents potentially confusing or erroneous situations.
+    ///
+    pub fn knows_non_finalized_block<'a>(
         &'a self,
         height: u64,
         hash: &[u8; 32],
     ) -> impl Iterator<Item = SourceId> + 'a {
-        if height <= self.finalized_block_height {
-            let hash = *hash;
-            either::Left(
-                self.sources
-                    .iter()
-                    .filter(move |(_, s)| {
-                        s.best_block_number > height
-                            || (s.best_block_number == height && s.best_block_hash == hash)
-                    })
-                    .map(|(s, _)| *s),
+        assert!(height > self.finalized_block_height);
+        self.known_blocks2
+            .range(
+                (height, *hash, SourceId(u64::min_value()))
+                    ..=(height, *hash, SourceId(u64::max_value())),
             )
-        } else {
-            either::Right(
-                self.known_blocks2
-                    .range(
-                        (height, *hash, SourceId(u64::min_value()))
-                            ..=(height, *hash, SourceId(u64::max_value())),
-                    )
-                    .map(|(_, _, id)| *id),
-            )
-        }
+            .map(|(_, _, id)| *id)
     }
 
     /// Returns true if [`AllForksSources::add_known_block`] or [`AllForksSources::set_best_block`]
     /// has earlier been called on this source with this height and hash, or if the source was
     /// originally created (using [`AllForksSources::add_source`]) with this height and hash.
     ///
-    /// If the requested block is inferior or equal to the finalized block height, the check is
-    /// simply whether the best block reported by the source is superior or equal to the requested
-    /// block.
-    ///
     /// # Panic
     ///
     /// Panics if the [`SourceId`] is out of range.
     ///
-    pub fn source_knows_block(&self, source_id: SourceId, height: u64, hash: &[u8; 32]) -> bool {
-        if height <= self.finalized_block_height {
-            let source = self.sources.get(&source_id).unwrap();
-            source.best_block_number > height
-                || (source.best_block_number == height && source.best_block_hash == *hash)
-        } else {
-            self.known_blocks1.contains(&(source_id, height, *hash))
-        }
+    /// Panics if `height` is inferior or equal to the finalized block height. Finalized blocks
+    /// are intentionally not tracked by this data structure, and panicking when asking for a
+    /// potentially-finalized block prevents potentially confusing or erroneous situations.
+    ///
+    pub fn source_knows_non_finalized_block(
+        &self,
+        source_id: SourceId,
+        height: u64,
+        hash: &[u8; 32],
+    ) -> bool {
+        assert!(height > self.finalized_block_height);
+        self.known_blocks1.contains(&(source_id, height, *hash))
     }
 
     /// Returns `true` if the [`SourceId`] is present in the collection.
@@ -403,17 +406,17 @@ mod tests {
         assert!(!sources.is_empty());
         assert_eq!(sources.len(), 1);
         assert_eq!(sources.num_blocks(), 1);
-        assert!(sources.source_knows_block(source1, 12, &[1; 32]));
+        assert!(sources.source_knows_non_finalized_block(source1, 12, &[1; 32]));
 
         sources.set_best_block(source1, 13, [2; 32]);
         assert_eq!(sources.num_blocks(), 2);
-        assert!(sources.source_knows_block(source1, 12, &[1; 32]));
-        assert!(sources.source_knows_block(source1, 13, &[2; 32]));
+        assert!(sources.source_knows_non_finalized_block(source1, 12, &[1; 32]));
+        assert!(sources.source_knows_non_finalized_block(source1, 13, &[2; 32]));
 
         sources.remove_known_block(13, &[2; 32]);
         assert_eq!(sources.num_blocks(), 1);
-        assert!(sources.source_knows_block(source1, 12, &[1; 32]));
-        assert!(!sources.source_knows_block(source1, 13, &[2; 32]));
+        assert!(sources.source_knows_non_finalized_block(source1, 12, &[1; 32]));
+        assert!(!sources.source_knows_non_finalized_block(source1, 13, &[2; 32]));
 
         sources.set_finalized_block_height(12);
         assert_eq!(sources.num_blocks(), 0);

--- a/src/sync/optimistic.rs
+++ b/src/sync/optimistic.rs
@@ -413,6 +413,10 @@ impl<TRq, TSrc, TBl> OptimisticSync<TRq, TSrc, TBl> {
         (src_user_data, drain)
     }
 
+    pub fn source_user_data(&self, source_id: SourceId) -> &TSrc {
+        &self.inner.sources.get(&source_id).unwrap().user_data
+    }
+
     pub fn source_user_data_mut(&mut self, source_id: SourceId) -> &mut TSrc {
         &mut self.inner.sources.get_mut(&source_id).unwrap().user_data
     }

--- a/src/sync/optimistic.rs
+++ b/src/sync/optimistic.rs
@@ -377,6 +377,23 @@ impl<TRq, TSrc, TBl> OptimisticSync<TRq, TSrc, TBl> {
         new_id
     }
 
+    /// Returns the current best block of the given source.
+    ///
+    /// This corresponds either the latest call to [`OptimisticSync::raise_source_best_block`],
+    /// or to the parameter passed to [`OptimisticSync::add_source`].
+    ///
+    /// # Panic
+    ///
+    /// Panics if the [`SourceId`] is invalid.
+    ///
+    pub fn source_best_block(&self, source_id: SourceId) -> u64 {
+        self.inner
+            .sources
+            .get(&source_id)
+            .unwrap()
+            .best_block_number
+    }
+
     /// Updates the best known block of the source.
     ///
     /// Has no effect if the previously-known best block is lower than the new one.
@@ -411,6 +428,11 @@ impl<TRq, TSrc, TBl> OptimisticSync<TRq, TSrc, TBl> {
             source_id,
         };
         (src_user_data, drain)
+    }
+
+    /// Returns the list of sources in this state machine.
+    pub fn sources(&'_ self) -> impl ExactSizeIterator<Item = SourceId> + '_ {
+        self.inner.sources.keys().map(|id| *id)
     }
 
     pub fn source_user_data(&self, source_id: SourceId) -> &TSrc {


### PR DESCRIPTION
This PR performs a lot of progress towards https://github.com/paritytech/smoldot/issues/731

- All the methods on `NetworkService` that apply on the network as a whole and query things about a block are now moved to `SyncService`, as the `SyncService` is the piece of code that tracks which peer has which block.

- Adds `AllSync::knows_block` and `AllSync::source_knows_block` methods.

- Tweak the similar methods in `sources.rs` to assume that sources always know about all blocks that are part of the finalized chain if their best block is superior to the desired block.
