### PR TITLE
Move fragment verification to sync::all::ProcessOne

### DIFF
--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -744,6 +744,19 @@ async fn start_relay_chain(
                         sync = idle;
                         break;
                     }
+                    all::ProcessOne::VerifyWarpSyncFragment(verify) => {
+                        let (sync_out, next_actions, result) = verify.perform();
+                        sync = sync_out;
+                        requests_to_start.extend(next_actions);
+
+                        if let Err(err) = result {
+                            // TODO: indicate peer who sent it?
+                            log::warn!(
+                                target: "sync-verify",
+                                "Failed to verify warp sync fragment: {}", err
+                            );
+                        }
+                    }
                     all::ProcessOne::VerifyHeader(verify) => {
                         let verified_hash = verify.hash();
 

--- a/src/sync/grandpa_warp_sync.rs
+++ b/src/sync/grandpa_warp_sync.rs
@@ -32,6 +32,8 @@ use crate::{
 
 use alloc::vec::Vec;
 
+pub use warp_sync::Error as FragmentError;
+
 /// Problem encountered during a call to [`grandpa_warp_sync`].
 #[derive(Debug, derive_more::Display)]
 pub enum Error {
@@ -544,7 +546,7 @@ impl<TSrc> Verifier<TSrc> {
         }
     }
 
-    pub fn next(self) -> (InProgressGrandpaWarpSync<TSrc>, Option<warp_sync::Error>) {
+    pub fn next(self) -> (InProgressGrandpaWarpSync<TSrc>, Option<FragmentError>) {
         match self.verifier.next() {
             Ok(warp_sync::Next::NotFinished(next_verifier)) => (
                 InProgressGrandpaWarpSync::Verifier(Self {


### PR DESCRIPTION
Instead of immediately verifying fragments when a GrandPa warp sync response arrives, the user now has to call `process_one` in order to verify a fragment.
This gives the possibility to benchmark and log individual fragments verification.
