### PR TITLE
Revamp the public JavaScript API

### DIFF
--- a/bin/wasm-node/javascript/src/index.d.ts
+++ b/bin/wasm-node/javascript/src/index.d.ts
@@ -30,7 +30,7 @@ export type SmoldotLogCallback = (level: number, target: string, message: string
 
 export interface SmoldotOptions {
   maxLogLevel?: number;
-  chainSpec: string;
+  chainSpecs: Array<string>;
   jsonRpcCallback?: SmoldotJsonRpcCallback;
   logCallback?: SmoldotLogCallback;
   parachainSpec?: string;

--- a/bin/wasm-node/javascript/src/index.d.ts
+++ b/bin/wasm-node/javascript/src/index.d.ts
@@ -20,20 +20,20 @@ declare class SmoldotError extends Error {
 }
 
 export interface SmoldotClient {
-  send_json_rpc(rpc: string, chainIndex?: number, userData?: number): void;
-  cancel_all(userData: number): void;
+  sendJsonRpc(rpc: string, chainIndex?: number, userData?: number): void;
+  cancelAll(userData: number): void;
   terminate(): void;
 }
 
-export type SmoldotJsonRpcCallback = (response: string, chain_index?: number, user_data?: number) => void;
+export type SmoldotJsonRpcCallback = (response: string, chainIndex?: number, userData?: number) => void;
 export type SmoldotLogCallback = (level: number, target: string, message: string) => void;
 
 export interface SmoldotOptions {
-  max_log_level?: number;
-  chain_spec: string;
-  json_rpc_callback?: SmoldotJsonRpcCallback;
-  log_callback?: SmoldotLogCallback;
-  parachain_spec?: string;
+  maxLogLevel?: number;
+  chainSpec: string;
+  jsonRpcCallback?: SmoldotJsonRpcCallback;
+  logCallback?: SmoldotLogCallback;
+  parachainSpec?: string;
 }
 
 export interface Smoldot {

--- a/bin/wasm-node/javascript/src/index.d.ts
+++ b/bin/wasm-node/javascript/src/index.d.ts
@@ -30,7 +30,7 @@ export type SmoldotLogCallback = (level: number, target: string, message: string
 
 export interface SmoldotOptions {
   maxLogLevel?: number;
-  chainSpecs: Array<string>;
+  chainSpecs: string[];
   jsonRpcCallback?: SmoldotJsonRpcCallback;
   logCallback?: SmoldotLogCallback;
 }

--- a/bin/wasm-node/javascript/src/index.d.ts
+++ b/bin/wasm-node/javascript/src/index.d.ts
@@ -33,7 +33,6 @@ export interface SmoldotOptions {
   chainSpecs: Array<string>;
   jsonRpcCallback?: SmoldotJsonRpcCallback;
   logCallback?: SmoldotLogCallback;
-  parachainSpec?: string;
 }
 
 export interface Smoldot {

--- a/bin/wasm-node/javascript/src/index.d.ts
+++ b/bin/wasm-node/javascript/src/index.d.ts
@@ -20,12 +20,12 @@ declare class SmoldotError extends Error {
 }
 
 export interface SmoldotClient {
-  sendJsonRpc(rpc: string, chainIndex?: number, userData?: number): void;
+  sendJsonRpc(rpc: string, chainIndex: number, userData?: number): void;
   cancelAll(userData: number): void;
   terminate(): void;
 }
 
-export type SmoldotJsonRpcCallback = (response: string, chainIndex?: number, userData?: number) => void;
+export type SmoldotJsonRpcCallback = (response: string, chainIndex: number, userData?: number) => void;
 export type SmoldotLogCallback = (level: number, target: string, message: string) => void;
 
 export interface SmoldotOptions {

--- a/bin/wasm-node/javascript/src/index.js
+++ b/bin/wasm-node/javascript/src/index.js
@@ -24,10 +24,10 @@ export class SmoldotError extends Error {
 }
 
 export async function start(config) {
-  if (Object.prototype.toString.call(config.chain_spec) !== '[object String]')
-    throw new SmoldotError('config must include a string chain_spec');
+  if (Object.prototype.toString.call(config.chainSpec) !== '[object String]')
+    throw new SmoldotError('config must include a string chainSpec');
 
-  const logCallback = config.log_callback || ((level, target, message) => {
+  const logCallback = config.logCallback || ((level, target, message) => {
     if (level <= 1) {
       console.error("[" + target + "]", message);
     } else if (level == 2) {
@@ -54,7 +54,7 @@ export async function start(config) {
   // this array. The worker needs to send back a confirmation, which pops the first element of
   // this array. JSON-RPC responses whose user data is found in this array are silently discarded.
   // This avoids a race condition where the worker emits a JSON-RPC response while we have already
-  // sent to it an `unsubscribeAll`. It is also what makes it possible for `cancel_all` to cancel
+  // sent to it an `unsubscribeAll`. It is also what makes it possible for `cancelAll` to cancel
   // requests that are not subscription notifications, even while the worker only supports
   // cancelling subscriptions.
   let pendingCancelConfirmations = [];
@@ -78,9 +78,9 @@ export async function start(config) {
         initPromiseResolve();
         initPromiseReject = null;
         initPromiseResolve = null;
-      } else if (config.json_rpc_callback) {
+      } else if (config.jsonRpcCallback) {
         if (pendingCancelConfirmations.findIndex(elem => elem == message.userData) === -1)
-          config.json_rpc_callback(message.data, message.chainIndex, message.userData);
+          config.jsonRpcCallback(message.data, message.chainIndex, message.userData);
       }
 
     } else if (message.kind == 'unsubscribeAllConfirmation') {
@@ -114,11 +114,11 @@ export async function start(config) {
 
   // The first message expected by the worker contains the configuration.
   worker.postMessage({
-    chainSpec: config.chain_spec,
-    parachainSpec: config.parachain_spec,
+    chainSpec: config.chainSpec,
+    parachainSpec: config.parachainSpec,
     // Maximum level of log entries sent by the client.
     // 0 = Logging disabled, 1 = Error, 2 = Warn, 3 = Info, 4 = Debug, 5 = Trace
-    maxLogLevel: config.max_log_level || 5
+    maxLogLevel: config.maxLogLevel || 5
   });
 
   // Initialization happens asynchronous, both because we have a worker, but also asynchronously
@@ -140,14 +140,14 @@ export async function start(config) {
   await initPromise;
 
   return {
-    send_json_rpc: (request, chainIndex, userData) => {
+    sendJsonRpc: (request, chainIndex, userData) => {
       if (!workerError) {
         worker.postMessage({ ty: 'request', request, chainIndex, userData: userData || 0 });
       } else {
         throw workerError;
       }
     },
-    cancel_all: (userData) => {
+    cancelAll: (userData) => {
       if (!workerError) {
         pendingCancelConfirmations.push(userData);
         worker.postMessage({ ty: 'unsubscribeAll', userData });

--- a/bin/wasm-node/javascript/src/index.test-d.ts
+++ b/bin/wasm-node/javascript/src/index.test-d.ts
@@ -9,7 +9,7 @@ import smoldot, { Smoldot, SmoldotClient } from 'smoldot';
 // $ExpectType Promise<SmoldotClient>
 let sp = smoldot.start({
   maxLogLevel: 3,
-  chainSpec: '',
+  chainSpecs: [''],
   parachainSpec: '',
   jsonRpcCallback: (resp, chainIndex, userData) => { },
   logCallback: (level, target, message) => { },
@@ -19,7 +19,7 @@ let sp = smoldot.start({
 
 // $ExpectType Promise<SmoldotClient>
 sp = smoldot.start({
-  chainSpec: '',
+  chainSpecs: [''],
   parachainSpec: '',
   jsonRpcCallback: (resp) => { },
 });

--- a/bin/wasm-node/javascript/src/index.test-d.ts
+++ b/bin/wasm-node/javascript/src/index.test-d.ts
@@ -8,27 +8,27 @@ import smoldot, { Smoldot, SmoldotClient } from 'smoldot';
 
 // $ExpectType Promise<SmoldotClient>
 let sp = smoldot.start({
-  max_log_level: 3,
-  chain_spec: '',
-  parachain_spec: '',
-  json_rpc_callback: (resp, chain_index, user_data) => { },
-  log_callback: (level, target, message) => { },
+  maxLogLevel: 3,
+  chainSpec: '',
+  parachainSpec: '',
+  jsonRpcCallback: (resp, chainIndex, userData) => { },
+  logCallback: (level, target, message) => { },
 });
 
 // Test when not supplying optional options and optional params
 
 // $ExpectType Promise<SmoldotClient>
 sp = smoldot.start({
-  chain_spec: '',
-  parachain_spec: '',
-  json_rpc_callback: (resp) => { },
+  chainSpec: '',
+  parachainSpec: '',
+  jsonRpcCallback: (resp) => { },
 });
 
 sp.then(sm => {
   // $ExpectType void
-  sm.send_json_rpc('{"id":8,"jsonrpc":"2.0","method":"system_health","params":[]}', 0, 0);
+  sm.sendJsonRpc('{"id":8,"jsonrpc":"2.0","method":"system_health","params":[]}', 0, 0);
   // $ExpectType void
-  sm.cancel_all(0);
+  sm.cancelAll(0);
   // $ExpectType void
   sm.terminate();
 });

--- a/bin/wasm-node/javascript/src/index.test-d.ts
+++ b/bin/wasm-node/javascript/src/index.test-d.ts
@@ -10,7 +10,6 @@ import smoldot, { Smoldot, SmoldotClient } from 'smoldot';
 let sp = smoldot.start({
   maxLogLevel: 3,
   chainSpecs: [''],
-  parachainSpec: '',
   jsonRpcCallback: (resp, chainIndex, userData) => { },
   logCallback: (level, target, message) => { },
 });
@@ -20,7 +19,6 @@ let sp = smoldot.start({
 // $ExpectType Promise<SmoldotClient>
 sp = smoldot.start({
   chainSpecs: [''],
-  parachainSpec: '',
   jsonRpcCallback: (resp) => { },
 });
 

--- a/bin/wasm-node/javascript/test/demo.js
+++ b/bin/wasm-node/javascript/test/demo.js
@@ -29,7 +29,7 @@ let wsConnections = {};
 let nextWsConnectionId = 0xaaa;
 
 smoldot.start({
-    chainSpec: fs.readFileSync('../../westend.json', 'utf8'),
+    chainSpecs: [fs.readFileSync('../../westend.json', 'utf8')],
     maxLogLevel: 3,  // Can be increased for more verbosity
     jsonRpcCallback: (resp, chainIndex, connectionId) => {
         wsConnections[connectionId].sendUTF(resp);

--- a/bin/wasm-node/javascript/test/demo.js
+++ b/bin/wasm-node/javascript/test/demo.js
@@ -29,15 +29,15 @@ let wsConnections = {};
 let nextWsConnectionId = 0xaaa;
 
 smoldot.start({
-    chain_spec: fs.readFileSync('../../westend.json', 'utf8'),
-    max_log_level: 3,  // Can be increased for more verbosity
-    json_rpc_callback: (resp, chainIndex, connectionId) => {
+    chainSpec: fs.readFileSync('../../westend.json', 'utf8'),
+    maxLogLevel: 3,  // Can be increased for more verbosity
+    jsonRpcCallback: (resp, chainIndex, connectionId) => {
         wsConnections[connectionId].sendUTF(resp);
     }
 })
     .then((c) => {
         client = c;
-        unsentQueue.forEach((m) => client.send_json_rpc(m.message, 0, m.connectionId));
+        unsentQueue.forEach((m) => client.sendJsonRpc(m.message, 0, m.connectionId));
         unsentQueue = [];
     })
 
@@ -67,7 +67,7 @@ wsServer.on('request', function (request) {
     connection.on('message', function (message) {
         if (message.type === 'utf8') {
             if (client) {
-                client.send_json_rpc(message.utf8Data, 0, connectionId);
+                client.sendJsonRpc(message.utf8Data, 0, connectionId);
             } else {
                 unsentQueue.push({ message: message.utf8Data, connectionId });
             }
@@ -78,7 +78,7 @@ wsServer.on('request', function (request) {
 
     connection.on('close', function (reasonCode, description) {
         console.log((new Date()) + ' Peer ' + connection.remoteAddress + ' disconnected.');
-        client.cancel_all(connectionId);
+        client.cancelAll(connectionId);
         wsConnections[connectionId] = undefined;
     });
 });

--- a/bin/wasm-node/javascript/test/test.js
+++ b/bin/wasm-node/javascript/test/test.js
@@ -25,7 +25,7 @@ process.exitCode = 1;
 // Note that the flow control below is a bit complicated and would need to be refactored if we
 // add more tests.
 
-const westendSpecs = fs.readFileSync('../../westend.json', 'utf8');
+const westendSpec = fs.readFileSync('../../westend.json', 'utf8');
 
 (async () => {
   // Test that invalid chain specs errors are properly caught.
@@ -42,7 +42,7 @@ const westendSpecs = fs.readFileSync('../../westend.json', 'utf8');
   // Basic `system_name` test.
   client
     .start({
-      chainSpec: westendSpecs,
+      chainSpecs: [westendSpec],
       jsonRpcCallback: (resp, chainIndex, userData) => {
         if (resp == '{"jsonrpc":"2.0","id":1,"result":"smoldot-js"}') {
           // Test successful

--- a/bin/wasm-node/javascript/test/test.js
+++ b/bin/wasm-node/javascript/test/test.js
@@ -31,7 +31,7 @@ const westendSpec = fs.readFileSync('../../westend.json', 'utf8');
   // Test that invalid chain specs errors are properly caught.
   await client
     .start({
-      chainSpec: "invalid chain spec",
+      chainSpecs: ["invalid chain spec"],
     })
     .then(() => {
       console.error("Client loaded successfully despite invalid chain spec");

--- a/bin/wasm-node/javascript/test/test.js
+++ b/bin/wasm-node/javascript/test/test.js
@@ -31,7 +31,7 @@ const westendSpecs = fs.readFileSync('../../westend.json', 'utf8');
   // Test that invalid chain specs errors are properly caught.
   await client
     .start({
-      chain_spec: "invalid chain spec",
+      chainSpec: "invalid chain spec",
     })
     .then(() => {
       console.error("Client loaded successfully despite invalid chain spec");
@@ -42,8 +42,8 @@ const westendSpecs = fs.readFileSync('../../westend.json', 'utf8');
   // Basic `system_name` test.
   client
     .start({
-      chain_spec: westendSpecs,
-      json_rpc_callback: (resp, chainIndex, userData) => {
+      chainSpec: westendSpecs,
+      jsonRpcCallback: (resp, chainIndex, userData) => {
         if (resp == '{"jsonrpc":"2.0","id":1,"result":"smoldot-js"}') {
           // Test successful
           process.exit(0)
@@ -54,7 +54,7 @@ const westendSpecs = fs.readFileSync('../../westend.json', 'utf8');
       }
     })
     .then((client) => {
-      client.send_json_rpc('{"jsonrpc":"2.0","id":1,"method":"system_name","params":[]}', 0, 0);
+      client.sendJsonRpc('{"jsonrpc":"2.0","id":1,"method":"system_name","params":[]}', 0, 0);
     })
     .catch((err) => process.exit(1));
 })();

--- a/bin/wasm-node/rust/src/ffi.rs
+++ b/bin/wasm-node/rust/src/ffi.rs
@@ -25,6 +25,7 @@ use core::{
     iter, marker,
     ops::{Add, Sub},
     pin::Pin,
+    ptr,
     slice,
     task::{Context, Poll, Waker},
     time::Duration,
@@ -428,37 +429,50 @@ fn alloc(len: u32) -> u32 {
 }
 
 fn init(
-    chain_specs_ptr: u32,
-    chain_specs_len: u32,
-    parachain_specs_ptr: u32,
-    parachain_specs_len: u32,
+    chain_specs_pointers_ptr: u32,
+    chain_specs_pointers_len: u32,
     max_log_level: u32,
 ) {
-    let chain_specs_ptr = usize::try_from(chain_specs_ptr).unwrap();
-    let chain_specs_len = usize::try_from(chain_specs_len).unwrap();
-    let parachain_specs_ptr = usize::try_from(parachain_specs_ptr).unwrap();
-    let parachain_specs_len = usize::try_from(parachain_specs_len).unwrap();
+    let chain_specs_pointers_ptr = usize::try_from(chain_specs_pointers_ptr).unwrap();
+    let chain_specs_pointers_len = usize::try_from(chain_specs_pointers_len).unwrap();
 
-    let chain_specs: Box<[u8]> = unsafe {
+    let chain_specs_pointers: Box<[u8]> = unsafe {
         Box::from_raw(slice::from_raw_parts_mut(
-            chain_specs_ptr as *mut u8,
-            chain_specs_len,
+            chain_specs_pointers_ptr as *mut u8,
+            chain_specs_pointers_len,
         ))
     };
 
-    let chain_specs = String::from_utf8(Vec::from(chain_specs)).expect("non-utf8 chain specs");
+    assert_eq!(chain_specs_pointers.len() % 8, 0);
+    let mut chain_specs = Vec::with_capacity(chain_specs_pointers.len() / 8);
 
-    let parachain_specs = if parachain_specs_ptr != 0 {
-        let data: Box<[u8]> = unsafe {
+    for chain_spec_index in 0..(chain_specs.capacity()) {
+        let spec_pointer = {
+            let val = <[u8; 4]>::try_from(&chain_specs_pointers[(chain_spec_index * 8)..(chain_spec_index * 8 + 4)]).unwrap();
+            usize::try_from(u32::from_le_bytes(val)).unwrap()
+        };
+
+        let spec_len = {
+            let val = <[u8; 4]>::try_from(&chain_specs_pointers[(chain_spec_index * 8 + 4)..(chain_spec_index * 8 + 8)]).unwrap();
+            usize::try_from(u32::from_le_bytes(val)).unwrap()
+        };
+
+        let chain_spec: Box<[u8]> = unsafe {
             Box::from_raw(slice::from_raw_parts_mut(
-                parachain_specs_ptr as *mut u8,
-                parachain_specs_len,
+                spec_pointer as *mut u8,
+                spec_len,
             ))
         };
-        Some(String::from_utf8(Vec::from(data)).expect("non-utf8 relay chain specs"))
-    } else {
-        None
-    };
+
+        let chain_spec = String::from_utf8(Vec::from(chain_spec)).expect("non-utf8 chain specs");
+
+        chain_specs.push(super::ChainConfig {
+            specification: chain_spec,
+            json_rpc_running: true,
+        });
+    }
+
+    debug_assert_eq!(chain_specs.len(), chain_specs.capacity());
 
     let max_log_level = match max_log_level {
         0 => log::LevelFilter::Off,
@@ -470,18 +484,7 @@ fn init(
     };
 
     spawn_task(super::start_client(
-        iter::once(super::ChainConfig {
-            specification: chain_specs,
-            json_rpc_running: true,
-        })
-        .chain(
-            parachain_specs
-                .into_iter()
-                .map(|specification| super::ChainConfig {
-                    specification,
-                    json_rpc_running: false,
-                }),
-        ),
+        chain_specs.into_iter(),
         max_log_level,
     ));
 }

--- a/bin/wasm-node/rust/src/ffi.rs
+++ b/bin/wasm-node/rust/src/ffi.rs
@@ -461,7 +461,7 @@ fn init(chain_specs_pointers_ptr: u32, chain_specs_pointers_len: u32, max_log_le
         let chain_spec: Box<[u8]> =
             unsafe { Box::from_raw(slice::from_raw_parts_mut(spec_pointer as *mut u8, spec_len)) };
 
-        let chain_spec = String::from_utf8(Vec::from(chain_spec)).expect("non-utf8 chain specs");
+        let chain_spec = String::from_utf8(Vec::from(chain_spec)).expect("non-utf8 chain spec");
 
         chain_specs.push(super::ChainConfig {
             specification: chain_spec,

--- a/bin/wasm-node/rust/src/ffi.rs
+++ b/bin/wasm-node/rust/src/ffi.rs
@@ -25,8 +25,7 @@ use core::{
     iter, marker,
     ops::{Add, Sub},
     pin::Pin,
-    ptr,
-    slice,
+    ptr, slice,
     task::{Context, Poll, Waker},
     time::Duration,
 };
@@ -428,11 +427,7 @@ fn alloc(len: u32) -> u32 {
     u32::try_from(ptr as *mut u8 as usize).unwrap()
 }
 
-fn init(
-    chain_specs_pointers_ptr: u32,
-    chain_specs_pointers_len: u32,
-    max_log_level: u32,
-) {
+fn init(chain_specs_pointers_ptr: u32, chain_specs_pointers_len: u32, max_log_level: u32) {
     let chain_specs_pointers_ptr = usize::try_from(chain_specs_pointers_ptr).unwrap();
     let chain_specs_pointers_len = usize::try_from(chain_specs_pointers_len).unwrap();
 
@@ -448,21 +443,23 @@ fn init(
 
     for chain_spec_index in 0..(chain_specs.capacity()) {
         let spec_pointer = {
-            let val = <[u8; 4]>::try_from(&chain_specs_pointers[(chain_spec_index * 8)..(chain_spec_index * 8 + 4)]).unwrap();
+            let val = <[u8; 4]>::try_from(
+                &chain_specs_pointers[(chain_spec_index * 8)..(chain_spec_index * 8 + 4)],
+            )
+            .unwrap();
             usize::try_from(u32::from_le_bytes(val)).unwrap()
         };
 
         let spec_len = {
-            let val = <[u8; 4]>::try_from(&chain_specs_pointers[(chain_spec_index * 8 + 4)..(chain_spec_index * 8 + 8)]).unwrap();
+            let val = <[u8; 4]>::try_from(
+                &chain_specs_pointers[(chain_spec_index * 8 + 4)..(chain_spec_index * 8 + 8)],
+            )
+            .unwrap();
             usize::try_from(u32::from_le_bytes(val)).unwrap()
         };
 
-        let chain_spec: Box<[u8]> = unsafe {
-            Box::from_raw(slice::from_raw_parts_mut(
-                spec_pointer as *mut u8,
-                spec_len,
-            ))
-        };
+        let chain_spec: Box<[u8]> =
+            unsafe { Box::from_raw(slice::from_raw_parts_mut(spec_pointer as *mut u8, spec_len)) };
 
         let chain_spec = String::from_utf8(Vec::from(chain_spec)).expect("non-utf8 chain specs");
 
@@ -483,10 +480,7 @@ fn init(
         _ => log::LevelFilter::Trace,
     };
 
-    spawn_task(super::start_client(
-        chain_specs.into_iter(),
-        max_log_level,
-    ));
+    spawn_task(super::start_client(chain_specs.into_iter(), max_log_level));
 }
 
 pub(crate) enum JsonRpcMessage {

--- a/bin/wasm-node/rust/src/ffi/bindings.rs
+++ b/bin/wasm-node/rust/src/ffi/bindings.rs
@@ -186,31 +186,30 @@ pub extern "C" fn alloc(len: u32) -> u32 {
 
 /// Initializes the client.
 ///
-/// Use [`alloc`] to allocate either one to three buffers: one for the chain specs, and an
-/// optional one for the chain specs of the parachain if the chain is a relay chain.
+/// Use [`alloc`] to allocate one buffer for each spec of each chain that needs to be started.
 /// The buffers **must** have been allocated with [`alloc`]. They are freed when this function is
 /// called.
+/// Write the chain specs in these buffers.
 ///
-/// Write the chain specs and the parachain specs in these buffers.
-/// Then, pass the pointer and length of these buffers to this function.
-/// Pass `0` for `parachain_specs_ptr` and `parachain_specs_len` if the chain is not a
-/// parachain.
+/// Then, use [`alloc`] to allocate one additional buffer containing a list of pairs of
+/// little-endian u32s. Each pair must be a pointer and a length to the buffers allocated in the
+/// previous step.
+///
+/// Then, pass the pointer and length (in bytes) of this last buffer to this function.
+///
+/// > **Note**: This API is similar to the one of `writev(2)`, which you might be familiar with.
 ///
 /// The client will emit log messages by calling the [`log()`] function, provided the log level is
 /// inferior or equal to the value of `max_log_level` passed here.
 #[no_mangle]
 pub extern "C" fn init(
-    chain_specs_ptr: u32,
-    chain_specs_len: u32,
-    parachain_specs_ptr: u32,
-    parachain_specs_len: u32,
+    chain_specs_pointers_ptr: u32,
+    chain_specs_pointers_len: u32,
     max_log_level: u32,
 ) {
     super::init(
-        chain_specs_ptr,
-        chain_specs_len,
-        parachain_specs_ptr,
-        parachain_specs_len,
+        chain_specs_pointers_ptr,
+        chain_specs_pointers_len,
         max_log_level,
     )
 }


### PR DESCRIPTION
cc @raoulmillais @wirednkod

This PR revamps the public JavaScript API:

- All the `snake_case` methods and fields now use `camelCase`, since that's what is idiomatic in JavaScript. `chain_spec` has been renamed to `chainSpecs` (with an `s`) because of the next point.

- Instead of passing one chain spec for the relay chain (and one for the parachain), you can now pass an array of chain specs (of arbitrary length). When you call `sendJsonRpc`, you should pass the index, within that array, of the chain that is concerned. This index is also passed back in return in the JSON-RPC callback.

See the changes to `demo.rs` to know how to propagate these changes to substrate-connect.

I'll publish 0.2.0 afterwards.
