### PR TITLE
Implement SyncService::subscribe_all

### DIFF
--- a/bin/wasm-node/rust/src/json_rpc_service.rs
+++ b/bin/wasm-node/rust/src/json_rpc_service.rs
@@ -1169,6 +1169,7 @@ impl JsonRpcService {
                 futures::pin_mut!(next_block);
                 match future::select(next_block, &mut unsubscribe_rx).await {
                     future::Either::Left((block, _)) => {
+                        // TODO: don't unwrap `block`! channel can be legitimately closed if full
                         let header = header_conv(header::decode(&block.unwrap()).unwrap());
 
                         let per_source_subscriptions =

--- a/src/chain/blocks_tree.rs
+++ b/src/chain/blocks_tree.rs
@@ -207,7 +207,12 @@ impl<T> NonFinalizedTree<T> {
     ///
     /// The order of the blocks is unspecified.
     pub fn iter(&'_ self) -> impl Iterator<Item = header::HeaderRef<'_>> + '_ {
-        self.inner.as_ref().unwrap().blocks.iter().map(|b| (&b.header).into())
+        self.inner
+            .as_ref()
+            .unwrap()
+            .blocks
+            .iter()
+            .map(|b| (&b.header).into())
     }
 
     /// Reserves additional capacity for at least `additional` new blocks without allocating.

--- a/src/chain/blocks_tree.rs
+++ b/src/chain/blocks_tree.rs
@@ -203,6 +203,13 @@ impl<T> NonFinalizedTree<T> {
         self.inner.as_ref().unwrap().blocks.len()
     }
 
+    /// Returns the header of all known non-finalized blocks in the chain.
+    ///
+    /// The order of the blocks is unspecified.
+    pub fn iter(&'_ self) -> impl Iterator<Item = header::HeaderRef<'_>> + '_ {
+        self.inner.as_ref().unwrap().blocks.iter().map(|b| (&b.header).into())
+    }
+
     /// Reserves additional capacity for at least `additional` new blocks without allocating.
     pub fn reserve(&mut self, additional: usize) {
         self.inner.as_mut().unwrap().blocks.reserve(additional)

--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -209,6 +209,24 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         }
     }
 
+    /// Returns the header of all known non-finalized blocks in the chain.
+    ///
+    /// The order of the blocks is unspecified.
+    pub fn non_finalized_blocks(&self) -> impl Iterator<Item = header::HeaderRef> {
+        match &self.inner {
+            AllSyncInner::Optimistic(sync) => {
+                let iter = sync.non_finalized_blocks();
+                either::Left(either::Left(iter))
+            }
+            AllSyncInner::AllForks(sync) => {
+                let iter = sync.non_finalized_blocks();
+                either::Left(either::Right(iter))
+            }
+            AllSyncInner::GrandpaWarpSync(_) => either::Right(iter::empty()),
+            AllSyncInner::Poisoned => unreachable!(),
+        }
+    }
+
     /// Returns true if it is believed that we are near the head of the chain.
     ///
     /// The way this method is implemented is opaque and cannot be relied on. The return value

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -234,6 +234,13 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
         self.chain.best_block_hash()
     }
 
+    /// Returns the header of all known non-finalized blocks in the chain.
+    ///
+    /// The order of the blocks is unspecified.
+    pub fn non_finalized_blocks(&'_ self) -> impl Iterator<Item = header::HeaderRef<'_>> + '_ {
+        self.chain.iter()
+    }
+
     /// Inform the [`AllForksSync`] of a new potential source of blocks.
     ///
     /// The `user_data` parameter is opaque and decided entirely by the user. It can later be

--- a/src/sync/optimistic.rs
+++ b/src/sync/optimistic.rs
@@ -327,6 +327,13 @@ impl<TRq, TSrc, TBl> OptimisticSync<TRq, TSrc, TBl> {
         self.chain.best_block_hash()
     }
 
+    /// Returns the header of all known non-finalized blocks in the chain.
+    ///
+    /// The order of the blocks is unspecified.
+    pub fn non_finalized_blocks(&'_ self) -> impl Iterator<Item = header::HeaderRef<'_>> + '_ {
+        self.chain.iter()
+    }
+
     /// Disassembles the state machine into its raw components.
     pub fn disassemble(self) -> Disassemble<TRq, TSrc> {
         Disassemble {


### PR DESCRIPTION
Necessary work for https://github.com/paritytech/smoldot/pull/845

Note that the code isn't fully implemented for parachains, as it's kind of complicated. One would need to download the runtime code of all blocks of all forks, which has little chance of succeeding flawlessly.
