### PR TITLE
Backport two changes from #845

### DIFF
--- a/bin/wasm-node/rust/src/ffi.rs
+++ b/bin/wasm-node/rust/src/ffi.rs
@@ -127,9 +127,13 @@ pub struct Delay {
 impl Delay {
     pub fn new(when: Duration) -> Self {
         let (tx, rx) = oneshot::channel();
-        start_timer_wrap(when, move || {
+        if when == Duration::new(0, 0) {
             let _ = tx.send(());
-        });
+        } else {
+            start_timer_wrap(when, move || {
+                let _ = tx.send(());
+            });
+        }
         Delay { rx }
     }
 }

--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -136,6 +136,10 @@ impl SyncService {
     ///
     /// Not all updates are necessarily reported. In particular, updates that weren't pulled from
     /// the `Stream` yet might get overwritten by newest updates.
+    ///
+    /// If you have subscribed to new blocks, the finalized blocks reported in this channel are
+    /// guaranteed to have earlier been reported as new blocks.
+    // TODO: is this last paragraph true for parachains?
     pub async fn subscribe_finalized(&self) -> (Vec<u8>, NotificationsReceiver<Vec<u8>>) {
         let (send_back, rx) = oneshot::channel();
 
@@ -1180,6 +1184,9 @@ async fn start_relay_chain(
                     log::info!(target: "sync-verify", "GrandPa warp sync finished to #{}", finalized_num);
                     has_new_finalized = true;
                     has_new_best = true;
+                    // Since there is a gap in the blocks, all active notifications to all blocks
+                    // must be cleared.
+                    all_notifications.clear();
                     requests_to_start.extend(next_actions);
                 }
             }


### PR DESCRIPTION
Since https://github.com/paritytech/smoldot/pull/845 is going to take longer than expected, here are two back-ported changes:

- Don't actually start a timer if we want to delay 0ms.
- Clear all `subscribe_all` notifications in the sync service after a warp sync. This is a bugfix.