### PR TITLE
Move `with_buffers` module to `libp2p`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2498,7 +2498,6 @@ dependencies = [
  "hashbrown 0.11.2",
  "hex",
  "parking_lot",
- "pin-project",
  "rand 0.8.3",
  "smoldot",
  "structopt",

--- a/bin/full-node/Cargo.toml
+++ b/bin/full-node/Cargo.toml
@@ -26,7 +26,6 @@ futures-timer = "3.0"
 hashbrown = { version = "0.11.2", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 parking_lot = { version = "0.11.1" }
-pin-project = "1.0.7"
 rand = "0.8.3"
 smoldot = { version = "0.1.0", path = "../..", default-features = false, features = ["database-sqlite", "std"] }
 structopt = { version = "0.3.21", default-features = false, features = ["color", "suggestions", "wrap_help"] }

--- a/bin/full-node/src/network_service.rs
+++ b/bin/full-node/src/network_service.rs
@@ -32,8 +32,7 @@ use futures::{channel::mpsc, prelude::*};
 use smoldot::{
     informant::HashDisplay,
     libp2p::{
-        async_rw_with_buffers,
-        connection,
+        async_rw_with_buffers, connection,
         multiaddr::{Multiaddr, Protocol},
         peer_id::PeerId,
     },

--- a/bin/full-node/src/network_service.rs
+++ b/bin/full-node/src/network_service.rs
@@ -32,6 +32,7 @@ use futures::{channel::mpsc, prelude::*};
 use smoldot::{
     informant::HashDisplay,
     libp2p::{
+        async_rw_with_buffers,
         connection,
         multiaddr::{Multiaddr, Protocol},
         peer_id::PeerId,
@@ -40,8 +41,6 @@ use smoldot::{
 };
 use std::{io, net::SocketAddr, num::NonZeroUsize, sync::Arc, time::Instant};
 use tracing::Instrument as _;
-
-mod with_buffers;
 
 /// Configuration for a [`NetworkService`].
 pub struct Config {
@@ -504,7 +503,7 @@ async fn connection_task(
     // The socket is wrapped around a `WithBuffers` object containing a read buffer and a write
     // buffer. These are the buffers whose pointer is passed to `read(2)` and `write(2)` when
     // reading/writing the socket.
-    let tcp_socket = with_buffers::WithBuffers::new(tcp_socket);
+    let tcp_socket = async_rw_with_buffers::WithBuffers::new(tcp_socket);
     futures::pin_mut!(tcp_socket);
 
     loop {

--- a/src/libp2p.rs
+++ b/src/libp2p.rs
@@ -112,6 +112,7 @@ use futures::{
 use rand::Rng as _;
 use rand_chacha::{rand_core::SeedableRng as _, ChaCha20Rng};
 
+pub mod async_rw_with_buffers;
 pub mod connection;
 pub mod discovery;
 pub mod peer_id;

--- a/src/libp2p/async_rw_with_buffers.rs
+++ b/src/libp2p/async_rw_with_buffers.rs
@@ -15,6 +15,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#![cfg(feature = "std")]
+#![cfg_attr(docsrs, doc(cfg(feature = "std")))]
+
 //! Augments an implementation of `AsyncRead` and `AsyncWrite` with a read buffer and a write
 //! buffer.
 //!


### PR DESCRIPTION
Moves this module in `src` under the `std` feature flag, for code reuse purposes.