### PR TITLE
Add `NonFinalizedTree::finality_checkpoints`

### DIFF
--- a/src/chain/blocks_tree.rs
+++ b/src/chain/blocks_tree.rs
@@ -211,8 +211,8 @@ impl<T> NonFinalizedTree<T> {
             .as_ref()
             .unwrap()
             .blocks
-            .iter()
-            .map(|b| (&b.header).into())
+            .iter_unordered()
+            .map(|(_, b)| (&b.header).into())
     }
 
     /// Reserves additional capacity for at least `additional` new blocks without allocating.
@@ -332,7 +332,12 @@ where
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let inner = self.inner.as_ref().unwrap();
         f.debug_map()
-            .entries(inner.blocks.iter().map(|v| (&v.hash, &v.user_data)))
+            .entries(
+                inner
+                    .blocks
+                    .iter_unordered()
+                    .map(|(_, v)| (&v.hash, &v.user_data)),
+            )
             .finish()
     }
 }

--- a/src/chain/fork_tree.rs
+++ b/src/chain/fork_tree.rs
@@ -122,8 +122,8 @@ impl<T> ForkTree<T> {
     }
 
     /// Returns an iterator to all the node values without any specific order.
-    pub fn iter(&self) -> impl Iterator<Item = &T> {
-        self.nodes.iter().map(|n| &n.1.data)
+    pub fn iter_unordered(&self) -> impl Iterator<Item = (NodeIndex, &T)> {
+        self.nodes.iter().map(|n| (NodeIndex(n.0), &n.1.data))
     }
 
     /// Returns the value of the node with the given index.


### PR DESCRIPTION
Also renames `ForkTree::iter` to `iter_unordered`, for clarity.