### PR TITLE
Fix panic in networking regarding receiving notifications

### DIFF
--- a/src/libp2p/connection/established.rs
+++ b/src/libp2p/connection/established.rs
@@ -1300,10 +1300,12 @@ impl<TNow, TRqUd, TNotifUd> Inner<TNow, TRqUd, TNotifUd> {
                         user_data,
                     };
 
-                    return Some(Event::NotificationIn {
-                        id: substream_id,
-                        notification: notification.unwrap(),
-                    });
+                    if let Some(notification) = notification {
+                        return Some(Event::NotificationIn {
+                            id: substream_id,
+                            notification,
+                        });
+                    }
                 }
                 Substream::PingIn(mut payload) => {
                     // Inbound ping substream.


### PR DESCRIPTION
The code will presently panic if notifications are interleaved between yamux frames.
This PR fixes it.