### PR TITLE
Make full node use the "all" syncing strategy

### DIFF
--- a/bin/full-node/src/network_service.rs
+++ b/bin/full-node/src/network_service.rs
@@ -91,6 +91,7 @@ pub enum Event {
         chain_index: usize,
         peer_id: PeerId,
         best_block_number: u64,
+        best_block_hash: [u8; 32],
     },
     Disconnected {
         chain_index: usize,
@@ -285,12 +286,14 @@ impl NetworkService {
                                 peer_id,
                                 chain_index,
                                 best_number,
+                                best_hash,
                                 ..
                             } => {
                                 break Event::Connected {
                                     peer_id,
                                     chain_index,
                                     best_block_number: best_number,
+                                    best_block_hash: best_hash,
                                 };
                             }
                             service::Event::ChainDisconnected {

--- a/bin/full-node/src/sync_service.rs
+++ b/bin/full-node/src/sync_service.rs
@@ -328,6 +328,7 @@ fn start_sync(
                                     is_new_best,
                                     is_new_finalized,
                                     next_actions,
+                                    storage_top_trie_changes,
                                     ..
                                 } => {
                                     // TODO: restore this code

--- a/bin/wasm-node/rust/src/runtime_service.rs
+++ b/bin/wasm-node/rust/src/runtime_service.rs
@@ -19,9 +19,30 @@
 //!
 //! This service plugs on top of a [`sync_service`], listens for new best blocks and checks
 //! whether the runtime has changed in any way. Its objective is to always provide an up-to-date
-//! [`executor::host::HostVmPrototype`] ready to be called to other services.
+//! [`executor::host::HostVmPrototype`] ready to be called by other services.
+//!
+//! # Usage
+//!
+//! The runtime service lets user subscribe to best and finalized block updates, similar to
+//! the [`sync_service`]. These subscriptions are implemented by subscribing to the underlying
+//! [`sync_service`] and, for each notification, downloading the runtime code of the best or
+//! finalized block. Therefore, these notifications always come with a delay compared to directly
+//! using the [`sync_service`].
+//!
+//! Furthermore, if it isn't possible to download the runtime code of a block (for example because
+//! peers refuse to answer or have already pruned the block) or if the runtime service already has
+//! too many pending downloads, this block is simply skipped and not reported on the
+//! subscriptions.
+//!
+//! Consequently, you are strongly encouraged to not use both the [`sync_service`] *and* the
+//! [`RuntimeService`] of the same chain. They each provide a consistent view of the chain, but
+//! this view isn't necessarily the same on both services.
+//!
+//! The main service offered by the runtime service is
+//! [`RuntimeService::recent_best_block_runtime_call`], that performs a runtime call on the latest
+//! reported best block or more recent.
 
-// TODO: doc
+// TODO: the doc above mentions that you can subscribe to the finalized block, but this is isn't implemented yet ^
 
 use crate::{ffi, lossy_channel, sync_service};
 

--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -1271,6 +1271,17 @@ async fn start_parachain(
             },
 
             _relay_best_block = relay_best_blocks.next().fuse() => {
+                // This block is triggered on a new best block, but it is only used to detect when
+                // to refresh the local state, and the content of the block itself isn't important.
+                // Purging any other pending block from the best block subscription so as to not
+                // accidentally call this block multiple times.
+                while let Some(_) = relay_best_blocks.next().now_or_never() {}
+
+                // Determine if the call to `recent_best_block_runtime_call` below applies to a
+                // block that is near the head of the chain.
+                let relay_sync_near_head_of_chain =
+                    parachain_config.relay_chain_sync.is_near_head_of_chain_heuristic().await;
+
                 // For each relay chain block, call `ParachainHost_persisted_validation_data` in
                 // order to know where the parachains are.
                 let pvd_result = parachain_config.relay_chain_sync.recent_best_block_runtime_call(
@@ -1304,8 +1315,13 @@ async fn start_parachain(
                     match para::decode_persisted_validation_data_return_value(&encoded_pvd) {
                         Ok(Some(pvd)) => pvd.parent_head,
                         Ok(None) => {
-                            log::warn!(
+                            // `Ok(None)` indicates that the parachain doesn't occupy any core
+                            // on the relay chain at the latest block that the relay chain syncing
+                            // has synced. It might have occupied a core before, or might occupy
+                            // a core in the future, and as such this is not a fatal error.
+                            log::log!(
                                 target: "sync-verify",
+                                if relay_sync_near_head_of_chain { log::Level::Warn } else { log::Level::Debug },
                                 "Couldn't find the parachain head from relay chain. \
                                 The parachain likely doesn't occupy a core."
                             );

--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -1349,9 +1349,14 @@ async fn start_parachain(
                 match header::decode(&head_data) {
                     Ok(header) => {
                         current_best_block = header.into();
-                        for sender in &mut best_subscriptions {
-                            // TODO: remove senders if they're closed
-                            let _ = sender.send(head_data.to_vec());
+
+                        // Elements in `best_subscriptions` are removed one by one and inserted
+                        // back if the channel is still open.
+                        for index in (0..best_subscriptions.len()).rev() {
+                            let mut sender = best_subscriptions.swap_remove(index);
+                            if sender.send(head_data.to_vec()).is_ok() {
+                                best_subscriptions.push(sender);
+                            }
                         }
                     }
                     Err(_) => {

--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -827,6 +827,7 @@ async fn start_relay_chain(
                             );
                         }
                     }
+                    all::ProcessOne::VerifyHeaderBody(_) => unreachable!(),
                     all::ProcessOne::VerifyHeader(verify) => {
                         let verified_hash = verify.hash();
 

--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -684,10 +684,20 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                     self.inner = AllSyncInner::Optimistic(sync);
                     ProcessOne::AllSync(self)
                 }
-                optimistic::ProcessOne::Verify(verify) => ProcessOne::VerifyHeader(HeaderVerify {
-                    inner: HeaderVerifyInner::Optimistic(verify),
-                    shared: self.shared,
-                }),
+                optimistic::ProcessOne::Verify(verify) => {
+                    if verify.is_full_verification() {
+                        ProcessOne::VerifyHeaderBody(HeaderBodyVerify {
+                            inner: HeaderBodyVerifyInner::Optimistic(verify),
+                            shared: self.shared,
+                            marker: core::marker::PhantomData,
+                        })
+                    } else {
+                        ProcessOne::VerifyHeader(HeaderVerify {
+                            inner: HeaderVerifyInner::Optimistic(verify),
+                            shared: self.shared,
+                        })
+                    }
+                }
             },
             AllSyncInner::AllForks(sync) => match sync.process_one() {
                 all_forks::ProcessOne::AllSync { sync } => {
@@ -1182,6 +1192,9 @@ pub enum ProcessOne<TRq, TSrc, TBl> {
     /// Ready to start verifying a header.
     VerifyHeader(HeaderVerify<TRq, TSrc, TBl>),
 
+    /// Ready to start verifying a header and body.
+    VerifyHeaderBody(HeaderBodyVerify<TRq, TSrc, TBl>),
+
     /// Ready to start verifying a warp sync fragment.
     VerifyWarpSyncFragment(WarpSyncFragmentVerify<TRq, TSrc, TBl>),
 }
@@ -1393,6 +1406,196 @@ pub enum HeaderVerifyOutcome<TRq, TSrc, TBl> {
         /// Next requests that must be started.
         next_actions: Vec<Action>,
     },
+}
+
+pub struct HeaderBodyVerify<TRq, TSrc, TBl> {
+    inner: HeaderBodyVerifyInner<TSrc, TBl>,
+    shared: Shared,
+    marker: core::marker::PhantomData<TRq>,
+}
+
+enum HeaderBodyVerifyInner<TSrc, TBl> {
+    Optimistic(optimistic::Verify<(), OptimisticSourceExtra<TSrc>, TBl>),
+}
+
+impl<TRq, TSrc, TBl> HeaderBodyVerify<TRq, TSrc, TBl> {
+    /// Returns the height of the block to be verified.
+    pub fn height(&self) -> u64 {
+        match &self.inner {
+            HeaderBodyVerifyInner::Optimistic(verify) => verify.height(),
+        }
+    }
+
+    /// Returns the hash of the block to be verified.
+    pub fn hash(&self) -> [u8; 32] {
+        match &self.inner {
+            HeaderBodyVerifyInner::Optimistic(verify) => verify.hash(),
+        }
+    }
+
+    /// Start the verification process.
+    pub fn start(
+        self,
+        now_from_unix_epoch: Duration,
+        user_data: TBl,
+    ) -> BlockVerification<TRq, TSrc, TBl> {
+        match self.inner {
+            HeaderBodyVerifyInner::Optimistic(verify) => {
+                BlockVerification::from_inner(verify.start(now_from_unix_epoch), self.shared)
+            }
+        }
+    }
+}
+
+/// State of the processing of blocks.
+pub enum BlockVerification<TRq, TSrc, TBl> {
+    /// Block has been successfully verified.
+    Success {
+        /// True if the newly-verified block is considered the new best block.
+        is_new_best: bool,
+        /// True if the newly-verified block is considered the latest finalized block.
+        is_new_finalized: bool,
+        /// State machine yielded back. Use to continue the processing.
+        sync: AllSync<TRq, TSrc, TBl>,
+        /// Next requests that must be started.
+        next_actions: Vec<Action>,
+    },
+
+    /// Block verification failed.
+    Error {
+        /// State machine yielded back. Use to continue the processing.
+        sync: AllSync<TRq, TSrc, TBl>,
+        /// Error that happened.
+        error: verify::header_only::Error,
+        /// User data that was passed to [`HeaderVerify::perform`] and is unused.
+        user_data: TBl,
+        /// Next requests that must be started.
+        next_actions: Vec<Action>,
+    },
+
+    /// Loading a storage value of the finalized block is required in order to continue.
+    FinalizedStorageGet(StorageGet<TRq, TSrc, TBl>),
+
+    /// Fetching the list of keys of the finalized block with a given prefix is required in order
+    /// to continue.
+    FinalizedStoragePrefixKeys(StoragePrefixKeys<TRq, TSrc, TBl>),
+
+    /// Fetching the key of the finalized block storage that follows a given one is required in
+    /// order to continue.
+    FinalizedStorageNextKey(StorageNextKey<TRq, TSrc, TBl>),
+}
+
+impl<TRq, TSrc, TBl> BlockVerification<TRq, TSrc, TBl> {
+    fn from_inner(
+        inner: optimistic::BlockVerification<(), OptimisticSourceExtra<TSrc>, TBl>,
+        shared: Shared,
+    ) -> Self {
+        match inner {
+            //optimistic::BlockVerification::NewBest { sync, .. } => {}
+            optimistic::BlockVerification::Reset { sync, reason, .. } => {
+                todo!()
+            }
+            optimistic::BlockVerification::FinalizedStorageGet(inner) => {
+                BlockVerification::FinalizedStorageGet(StorageGet {
+                    inner,
+                    shared,
+                    marker: core::marker::PhantomData,
+                })
+            }
+            optimistic::BlockVerification::FinalizedStoragePrefixKeys(inner) => {
+                BlockVerification::FinalizedStoragePrefixKeys(StoragePrefixKeys {
+                    inner,
+                    shared,
+                    marker: core::marker::PhantomData,
+                })
+            }
+            optimistic::BlockVerification::FinalizedStorageNextKey(inner) => {
+                BlockVerification::FinalizedStorageNextKey(StorageNextKey {
+                    inner,
+                    shared,
+                    marker: core::marker::PhantomData,
+                })
+            }
+            _ => todo!(), // TODO:
+        }
+    }
+}
+
+/// Loading a storage value is required in order to continue.
+#[must_use]
+pub struct StorageGet<TRq, TSrc, TBl> {
+    inner: optimistic::StorageGet<(), OptimisticSourceExtra<TSrc>, TBl>,
+    shared: Shared,
+    marker: core::marker::PhantomData<TRq>,
+}
+
+impl<TRq, TSrc, TBl> StorageGet<TRq, TSrc, TBl> {
+    /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
+    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[u8]> + '_> + '_ {
+        self.inner.key()
+    }
+
+    /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
+    ///
+    /// This method is a shortcut for calling `key` and concatenating the returned slices.
+    pub fn key_as_vec(&self) -> Vec<u8> {
+        self.inner.key_as_vec()
+    }
+
+    /// Injects the corresponding storage value.
+    pub fn inject_value(self, value: Option<&[u8]>) -> BlockVerification<TRq, TSrc, TBl> {
+        let inner = self.inner.inject_value(value);
+        BlockVerification::from_inner(inner, self.shared)
+    }
+}
+
+/// Fetching the list of keys with a given prefix is required in order to continue.
+#[must_use]
+pub struct StoragePrefixKeys<TRq, TSrc, TBl> {
+    inner: optimistic::StoragePrefixKeys<(), OptimisticSourceExtra<TSrc>, TBl>,
+    shared: Shared,
+    marker: core::marker::PhantomData<TRq>,
+}
+
+impl<TRq, TSrc, TBl> StoragePrefixKeys<TRq, TSrc, TBl> {
+    /// Returns the prefix whose keys to load.
+    pub fn prefix(&'_ self) -> impl AsRef<[u8]> + '_ {
+        self.inner.prefix()
+    }
+
+    /// Injects the list of keys.
+    pub fn inject_keys(
+        self,
+        keys: impl Iterator<Item = impl AsRef<[u8]>>,
+    ) -> BlockVerification<TRq, TSrc, TBl> {
+        let inner = self.inner.inject_keys(keys);
+        BlockVerification::from_inner(inner, self.shared)
+    }
+}
+
+/// Fetching the key that follows a given one is required in order to continue.
+#[must_use]
+pub struct StorageNextKey<TRq, TSrc, TBl> {
+    inner: optimistic::StorageNextKey<(), OptimisticSourceExtra<TSrc>, TBl>,
+    shared: Shared,
+    marker: core::marker::PhantomData<TRq>,
+}
+
+impl<TRq, TSrc, TBl> StorageNextKey<TRq, TSrc, TBl> {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
+        self.inner.key()
+    }
+
+    /// Injects the key.
+    ///
+    /// # Panic
+    ///
+    /// Panics if the key passed as parameter isn't strictly superior to the requested key.
+    ///
+    pub fn inject_key(self, key: Option<impl AsRef<[u8]>>) -> BlockVerification<TRq, TSrc, TBl> {
+        let inner = self.inner.inject_key(key);
+        BlockVerification::from_inner(inner, self.shared)
+    }
 }
 
 pub struct WarpSyncFragmentVerify<TRq, TSrc, TBl> {

--- a/src/sync/optimistic.rs
+++ b/src/sync/optimistic.rs
@@ -704,7 +704,7 @@ impl<TRq, TSrc, TBl> Verify<TRq, TSrc, TBl> {
 
     /// Returns true if [`Config::full`] was `Some` at initialization.
     pub fn is_full_verification(&self) -> bool {
-        self.inner.finalized_runtime.is_some() 
+        self.inner.finalized_runtime.is_some()
     }
 
     /// Returns the SCALE-encoded header of the block about to be verified.

--- a/src/sync/optimistic.rs
+++ b/src/sync/optimistic.rs
@@ -703,6 +703,11 @@ impl<TRq, TSrc, TBl> Verify<TRq, TSrc, TBl> {
         header::hash_from_scale_encoded_header(self.header())
     }
 
+    /// Returns true if [`Config::full`] was `Some` at initialization.
+    pub fn is_full_verification(&self) -> bool {
+        self.inner.finalized_runtime.is_some() 
+    }
+
     /// Returns the SCALE-encoded header of the block about to be verified.
     fn header(&self) -> &[u8] {
         &self


### PR DESCRIPTION
The full node would now use the same syncing code as the wasm node, allowing further clean ups, in particular in `optimistic.rs`.