### PR TITLE
Add a ValidChainInformation type

### DIFF
--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -36,9 +36,10 @@
 
 use crate::chain::chain_information::{
     BabeEpochInformation, ChainInformation, ChainInformationConsensus, ChainInformationFinality,
+    ValidChainInformation,
 };
 use alloc::{string::String, vec::Vec};
-use core::num::NonZeroU64;
+use core::{convert::TryInto as _, num::NonZeroU64};
 
 mod light_sync_state;
 mod structs;
@@ -68,7 +69,7 @@ fn convert_epoch(epoch: &light_sync_state::BabeEpoch) -> BabeEpochInformation {
 }
 
 impl LightSyncState {
-    pub fn as_chain_information(&self) -> ChainInformation {
+    pub fn as_chain_information(&self) -> ValidChainInformation {
         // Create a sorted list of all regular epochs that haven't been pruned from the sync state.
         let mut epochs: Vec<_> = self
             .inner
@@ -116,6 +117,8 @@ impl LightSyncState {
                 finalized_scheduled_change: None, // TODO: unimplemented
             },
         }
+        .try_into()
+        .unwrap() // TODO: don't unwrap /!\ should fail when parsing the chain spec instead
     }
 }
 

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -100,7 +100,7 @@ pub use pending_blocks::{RequestId, RequestParams, SourceId};
 #[derive(Debug)]
 pub struct Config {
     /// Information about the latest finalized block and its ancestors.
-    pub chain_information: chain_information::ChainInformation,
+    pub chain_information: chain_information::ValidChainInformation,
 
     /// Pre-allocated capacity for the number of block sources.
     pub sources_capacity: usize,
@@ -177,7 +177,11 @@ struct Block<TBl> {
 impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     /// Initializes a new [`AllForksSync`].
     pub fn new(config: Config) -> Self {
-        let finalized_block_height = config.chain_information.finalized_block_header.number;
+        let finalized_block_height = config
+            .chain_information
+            .as_ref()
+            .finalized_block_header
+            .number;
 
         let chain = blocks_tree::NonFinalizedTree::new(blocks_tree::Config {
             chain_information: config.chain_information,
@@ -201,13 +205,16 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
 
     /// Builds a [`chain_information::ChainInformationRef`] struct corresponding to the current
     /// latest finalized block. Can later be used to reconstruct a chain.
-    pub fn as_chain_information(&self) -> chain_information::ChainInformationRef {
+    pub fn as_chain_information(&self) -> chain_information::ValidChainInformationRef {
         self.chain.as_chain_information()
     }
 
     /// Returns the header of the finalized block.
     pub fn finalized_block_header(&self) -> header::HeaderRef {
-        self.chain.as_chain_information().finalized_block_header
+        self.chain
+            .as_chain_information()
+            .as_ref()
+            .finalized_block_header
     }
 
     /// Returns the header of the best block.

--- a/src/sync/optimistic.rs
+++ b/src/sync/optimistic.rs
@@ -73,7 +73,7 @@ use rand::{seq::IteratorRandom as _, SeedableRng as _};
 #[derive(Debug)]
 pub struct Config {
     /// Information about the latest finalized block and its ancestors.
-    pub chain_information: chain_information::ChainInformation,
+    pub chain_information: chain_information::ValidChainInformation,
 
     /// Pre-allocated capacity for the number of block sources.
     pub sources_capacity: usize,
@@ -288,18 +288,17 @@ impl<TRq, TSrc, TBl> OptimisticSync<TRq, TSrc, TBl> {
 
     /// Builds a [`chain_information::ChainInformationRef`] struct corresponding to the current
     /// latest finalized block. Can later be used to reconstruct a chain.
-    pub fn as_chain_information(&self) -> chain_information::ChainInformationRef {
+    pub fn as_chain_information(&self) -> chain_information::ValidChainInformationRef {
         self.chain.as_chain_information()
     }
 
     /// Returns the header of the finalized block.
     pub fn finalized_block_header(&self) -> header::HeaderRef {
-        (&self
-            .inner
+        self.inner
             .finalized_chain_information
             .chain_information
-            .finalized_block_header)
-            .into()
+            .as_ref()
+            .finalized_block_header
     }
 
     /// Returns the header of the best block.
@@ -1531,7 +1530,7 @@ pub enum ResetCause {
 #[derive(Debug)]
 pub struct Disassemble<TRq, TSrc> {
     /// Information about the latest finalized block and its ancestors.
-    pub chain_information: chain_information::ChainInformation,
+    pub chain_information: chain_information::ValidChainInformation,
 
     /// List of sources that were within the state machine.
     pub sources: Vec<DisassembleSource<TSrc>>,


### PR DESCRIPTION
Adds new `ValidChainInformation` and `ValidChainInformationRef` types in `chain_information`.
These represent chain information whose coherence has been checked.

The consequence of this change to the logic of the code is that GrandPa warp sync and loading from a database now verify the coherence of the information rather than blindly assuming that it is correct (which would have caused the node to later panic if it turned out to not be true).
