### PR TITLE
Allow enabling/disabling connection types

### DIFF
--- a/bin/wasm-node/javascript/src/bindings-smoldot-js.js
+++ b/bin/wasm-node/javascript/src/bindings-smoldot-js.js
@@ -133,8 +133,8 @@ export default (config) => {
                     };
 
                 } else if (tcpParsed != null) {
+                    // `net` module will be missing when we're not in NodeJS.
                     if (!net || config.forbidTcp) {
-                        // `net` module not available, most likely because we're not in NodeJS.
                         throw new Error('TCP connections not available');
                     }
 

--- a/bin/wasm-node/javascript/src/bindings-smoldot-js.js
+++ b/bin/wasm-node/javascript/src/bindings-smoldot-js.js
@@ -104,6 +104,9 @@ export default (config) => {
                     if (wsParsed[4] == 'ws') {
                         proto = 'ws';
                     }
+                    if ((proto == 'ws' && config.forbidWs) || (proto == 'wss' && config.forbidWss)) {
+                        throw new Error('Connection type not allowed');
+                    }
                     if (wsParsed[1] == 'ip6') {
                         connection = new Websocket.w3cwebsocket(proto + "://[" + wsParsed[2] + "]:" + wsParsed[3]);
                     } else {
@@ -130,9 +133,9 @@ export default (config) => {
                     };
 
                 } else if (tcpParsed != null) {
-                    if (!net) {
+                    if (!net || config.forbidTcp) {
                         // `net` module not available, most likely because we're not in NodeJS.
-                        return 1;
+                        throw new Error('TCP connections not available');
                     }
 
                     connection = net.createConnection({
@@ -164,7 +167,7 @@ export default (config) => {
                     });
 
                 } else {
-                    return 1;
+                    throw new Error('Unrecognized multiaddr format');
                 }
 
                 connections[id] = connection;

--- a/bin/wasm-node/javascript/src/index.d.ts
+++ b/bin/wasm-node/javascript/src/index.d.ts
@@ -33,6 +33,9 @@ export interface SmoldotOptions {
   chainSpecs: string[];
   jsonRpcCallback?: SmoldotJsonRpcCallback;
   logCallback?: SmoldotLogCallback;
+  forbidTcp?: boolean;
+  forbidWs?: boolean;
+  forbidWss?: boolean;
 }
 
 export interface Smoldot {

--- a/bin/wasm-node/javascript/src/index.js
+++ b/bin/wasm-node/javascript/src/index.js
@@ -117,7 +117,10 @@ export async function start(config) {
     chainSpecs: config.chainSpecs,
     // Maximum level of log entries sent by the client.
     // 0 = Logging disabled, 1 = Error, 2 = Warn, 3 = Info, 4 = Debug, 5 = Trace
-    maxLogLevel: config.maxLogLevel || 5
+    maxLogLevel: config.maxLogLevel || 5,
+    forbidTcp: config.forbidTcp,
+    forbidWs: config.forbidWs,
+    forbidWss: config.forbidWss,
   });
 
   // Initialization happens asynchronous, both because we have a worker, but also asynchronously

--- a/bin/wasm-node/javascript/src/index.test-d.ts
+++ b/bin/wasm-node/javascript/src/index.test-d.ts
@@ -12,6 +12,9 @@ let sp = smoldot.start({
   chainSpecs: [''],
   jsonRpcCallback: (resp, chainIndex, userData) => { },
   logCallback: (level, target, message) => { },
+  forbidTcp: false,
+  forbidWs: false,
+  forbidWss: false,
 });
 
 // Test when not supplying optional options and optional params

--- a/bin/wasm-node/javascript/src/worker.js
+++ b/bin/wasm-node/javascript/src/worker.js
@@ -48,6 +48,9 @@ const startInstance = async (config) => {
       // `compat.postMessage` is the same as `postMessage`, but works across environments.
       compat.postMessage({ kind: 'jsonrpc', data, chainIndex, userData });
     },
+    forbidTcp: config.forbidTcp,
+    forbidWs: config.forbidWs,
+    forbidWss: config.forbidWss,
   };
 
   const { bindings: smoldotJsBindings } = smoldot_js_builder(smoldotJsConfig);

--- a/bin/wasm-node/javascript/test/demo.js
+++ b/bin/wasm-node/javascript/test/demo.js
@@ -34,7 +34,10 @@ smoldot.start({
     maxLogLevel: 3,  // Can be increased for more verbosity
     jsonRpcCallback: (resp, chainIndex, connectionId) => {
         wsConnections[connectionId].sendUTF(resp);
-    }
+    },
+    forbidTcp: false,
+    forbidWs: false,
+    forbidWss: false,
 })
     .then((c) => {
         client = c;


### PR DESCRIPTION
Fix #921 

Adds `forbidTcp`, `forbidWs` and `forbidWss` options to the configuration of smoldot, to ask to disable certain connection types.

I called the options `forbid*` instead of `allow*` because in JavaScript it can be confusing/error-prone to distinguish between `undefined`, `null` and `false`. Having options that default to `false` when they're missing seems like a good idea.

Also, importantly fixes some erroneous `return 1`s that weren't writing back any error message.
