### PR TITLE
Fix transactions::validate to actually work

### DIFF
--- a/src/transactions/validate.rs
+++ b/src/transactions/validate.rs
@@ -18,18 +18,22 @@
 //! Runtime call to obtain the transactions validity status.
 
 use crate::{
-    executor::{host, read_only_runtime_host},
-    util,
+    executor::{host, runtime_host},
+    header, util,
 };
 
 use alloc::{borrow::ToOwned as _, vec::Vec};
 use core::{iter, num::NonZeroU64};
 
 /// Configuration for a transaction validation process.
-pub struct Config<TTx> {
+pub struct Config<'a, TTx> {
     /// Runtime used to get the validate the transaction. Must be built using the Wasm code found
     /// at the `:code` key of the block storage.
     pub runtime: host::HostVmPrototype,
+
+    /// Header of the block to verify the transaction against, in SCALE encoding.
+    /// The runtime of this block must be the one in [`COnfig::runtime`].
+    pub scale_encoded_header: &'a [u8],
 
     /// SCALE-encoded transaction.
     pub scale_encoded_transaction: TTx,
@@ -174,17 +178,26 @@ pub enum UnknownTransaction {
 /// Problem encountered during a call to [`validate_transaction`].
 #[derive(Debug, derive_more::Display)]
 pub enum Error {
+    /// Error while decoding the block header against which to make the call.
+    InvalidHeader(header::Error),
     /// Error while starting the Wasm virtual machine.
     #[display(fmt = "{}", _0)]
     WasmStart(host::StartErr),
     /// Error while running the Wasm virtual machine.
     #[display(fmt = "{}", _0)]
-    WasmVm(read_only_runtime_host::ErrorDetail),
+    WasmVmReadWrite(runtime_host::ErrorDetail),
+    /// Error while running the Wasm virtual machine.
+    #[display(fmt = "{}", _0)]
+    WasmVmReadOnly(runtime_host::ErrorDetail),
     /// Error while decoding the output of the runtime.
-    OutputDecodeError,
+    OutputDecodeError(DecodeError),
     /// The list of provided tags ([`ValidTransaction::provides`]). This is a bug in the runtime.
     EmptyProvidedTags,
 }
+
+/// Error that can happen during the decoding.
+#[derive(Debug, derive_more::Display)]
+pub struct DecodeError();
 
 /// Errors that can occur while checking the validity of a transaction.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -195,31 +208,89 @@ pub enum TransactionValidityError {
     Unknown(UnknownTransaction),
 }
 
+/// Produces the input to pass to the `TaggedTransactionQueue_validate_transaction` runtime call.
+pub fn validate_transaction_runtime_parameters(
+    scale_encoded_transaction: impl Iterator<Item = impl AsRef<[u8]>> + Clone,
+    source: TransactionSource,
+) -> impl Iterator<Item = impl AsRef<[u8]>> + Clone {
+    // The `TaggedTransactionQueue_validate_transaction` function expects a SCALE-encoded
+    // `(source, tx)`. The encoding is performed manually in order to avoid performing
+    // redundant data copies.
+    let source = match source {
+        TransactionSource::InBlock => &[0],
+        TransactionSource::Local => &[1],
+        TransactionSource::External => &[2],
+    };
+
+    iter::once(source)
+        .map(either::Either::Left)
+        .chain(scale_encoded_transaction.map(either::Either::Right))
+}
+
+/// Name of the runtime function to call in order to validate a transaction.
+pub const VALIDATION_FUNCTION_NAME: &str = "TaggedTransactionQueue_validate_transaction";
+
+/// Attempt to decode the return value of the  `TaggedTransactionQueue_validate_transaction`
+/// runtime call.
+pub fn decode_validate_transaction_return_value(
+    scale_encoded: &[u8],
+) -> Result<Result<ValidTransaction, TransactionValidityError>, DecodeError> {
+    match nom::combinator::all_consuming(transaction_validity)(scale_encoded) {
+        Ok((_, data)) => Ok(data),
+        Err(_) => Err(DecodeError()),
+    }
+}
+
 /// Validates a transaction by calling `TaggedTransactionQueue_validate_transaction`.
 pub fn validate_transaction(
     config: Config<impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone> + Clone>,
 ) -> Query {
-    let vm = read_only_runtime_host::run(read_only_runtime_host::Config {
-        virtual_machine: config.runtime,
-        function_to_call: "TaggedTransactionQueue_validate_transaction",
-        parameter: {
-            // The `TaggedTransactionQueue_validate_transaction` function expects a SCALE-encoded
-            // `(source, tx)`. The encoding is performed manually in order to avoid performing
-            // redundant data copies.
-            let source = match config.source {
-                TransactionSource::InBlock => &[0],
-                TransactionSource::Local => &[1],
-                TransactionSource::External => &[2],
-            };
+    // The `Core_initialize_block` function called below expects a partially-initialized
+    // SCALE-encoded header. Importantly, passing the entire header will lead to different code
+    // paths in the runtime and not match what Substrate does.
+    let decoded_header = match header::decode(config.scale_encoded_header) {
+        Ok(h) => h,
+        Err(err) => {
+            return Query::Finished {
+                result: Err(Error::InvalidHeader(err)),
+                virtual_machine: config.runtime,
+            }
+        }
+    };
 
-            iter::once(source)
-                .map(either::Either::Left)
-                .chain(config.scale_encoded_transaction.map(either::Either::Right))
-        },
+    // Start the call to `Core_initialize_block`.
+    let vm = runtime_host::run(runtime_host::Config {
+        virtual_machine: config.runtime,
+        function_to_call: "Core_initialize_block",
+        parameter: header::HeaderRef {
+            parent_hash: decoded_header.parent_hash,
+            number: decoded_header.number,
+            extrinsics_root: &[0; 32],
+            state_root: &[0; 32],
+            digest: header::DigestRef::empty(),
+        }
+        .scale_encoding(),
+        top_trie_root_calculation_cache: None,
+        storage_top_trie_changes: hashbrown::HashMap::with_capacity_and_hasher(
+            64, // Rough estimate.
+            Default::default(),
+        ),
+        offchain_storage_changes: hashbrown::HashMap::default(),
     });
 
+    // Information used later, after `Core_initialize_block` is done.
+    let stage1 = Stage1 {
+        transaction_source: config.source,
+        scale_encoded_transaction: config
+            .scale_encoded_transaction
+            .fold(Vec::new(), |mut a, b| {
+                a.extend_from_slice(b.as_ref());
+                a
+            }),
+    };
+
     match vm {
-        Ok(vm) => Query::from_inner(vm),
+        Ok(vm) => Query::from_step1(vm, stage1),
         Err((err, virtual_machine)) => Query::Finished {
             result: Err(Error::WasmStart(err)),
             virtual_machine,
@@ -244,97 +315,217 @@ pub enum Query {
     StorageGet(StorageGet),
     /// Fetching the key that follows a given one is required in order to continue.
     NextKey(NextKey),
-    /// Fetching the storage trie root is required in order to continue.
-    StorageRoot(StorageRoot),
+    /// Fetching the list of keys with a given prefix from the storage is required in order to
+    /// continue.
+    PrefixKeys(PrefixKeys),
 }
 
 impl Query {
-    fn from_inner(inner: read_only_runtime_host::RuntimeHostVm) -> Self {
-        match inner {
-            read_only_runtime_host::RuntimeHostVm::Finished(Ok(success)) => {
-                // This decoding is done in multiple steps in order to solve borrow checking
-                // errors.
-                let result = {
-                    let output = success.virtual_machine.value();
-                    let decoded =
-                        nom::combinator::all_consuming(transaction_validity)(output.as_ref());
-                    match decoded {
-                        Ok((_, s)) => Ok(s),
-                        Err(_) => Err(Error::OutputDecodeError),
-                    }
-                };
+    /// Cancels execution of the virtual machine and returns back the prototype.
+    pub fn into_prototype(self) -> host::HostVmPrototype {
+        match self {
+            Query::Finished {
+                virtual_machine, ..
+            } => virtual_machine,
+            Query::StorageGet(StorageGet(StorageGetInner::Stage1(inner, _))) => {
+                runtime_host::RuntimeHostVm::StorageGet(inner).into_prototype()
+            }
+            Query::StorageGet(StorageGet(StorageGetInner::Stage2(inner, _))) => {
+                runtime_host::RuntimeHostVm::StorageGet(inner).into_prototype()
+            }
+            Query::NextKey(NextKey(NextKeyInner::Stage1(inner, _))) => {
+                runtime_host::RuntimeHostVm::NextKey(inner).into_prototype()
+            }
+            Query::NextKey(NextKey(NextKeyInner::Stage2(inner, _))) => {
+                runtime_host::RuntimeHostVm::NextKey(inner).into_prototype()
+            }
+            Query::PrefixKeys(PrefixKeys(PrefixKeysInner::Stage1(inner, _))) => {
+                runtime_host::RuntimeHostVm::PrefixKeys(inner).into_prototype()
+            }
+            Query::PrefixKeys(PrefixKeys(PrefixKeysInner::Stage2(inner, _))) => {
+                runtime_host::RuntimeHostVm::PrefixKeys(inner).into_prototype()
+            }
+        }
+    }
 
-                let result = match result {
-                    Ok(res) => {
-                        if let Ok(res) = res.as_ref() {
-                            if res.provides.is_empty() {
-                                return Query::Finished {
-                                    result: Err(Error::EmptyProvidedTags),
-                                    virtual_machine: success.virtual_machine.into_prototype(),
-                                };
+    fn from_step1(inner: runtime_host::RuntimeHostVm, info: Stage1) -> Self {
+        loop {
+            match inner {
+                runtime_host::RuntimeHostVm::Finished(Ok(success)) => {
+                    // No output expected from `Core_initialize_block`.
+                    if !success.virtual_machine.value().as_ref().is_empty() {
+                        return Query::Finished {
+                            result: Err(Error::OutputDecodeError(DecodeError())),
+                            virtual_machine: success.virtual_machine.into_prototype(),
+                        };
+                    }
+
+                    let vm = runtime_host::run(runtime_host::Config {
+                        virtual_machine: success.virtual_machine.into_prototype(),
+                        function_to_call: VALIDATION_FUNCTION_NAME,
+                        parameter: validate_transaction_runtime_parameters(
+                            iter::once(info.scale_encoded_transaction),
+                            info.transaction_source,
+                        ),
+                        storage_top_trie_changes: success.storage_top_trie_changes,
+                        offchain_storage_changes: success.offchain_storage_changes,
+                        top_trie_root_calculation_cache: Some(
+                            success.top_trie_root_calculation_cache,
+                        ),
+                    });
+
+                    match vm {
+                        Ok(vm) => break Query::from_step2(vm, Stage2 {}),
+                        Err((err, virtual_machine)) => {
+                            break Query::Finished {
+                                result: Err(Error::WasmStart(err)),
+                                virtual_machine,
                             }
                         }
-                        res
                     }
-                    Err(err) => {
-                        return Query::Finished {
-                            result: Err(err),
-                            virtual_machine: success.virtual_machine.into_prototype(),
-                        }
+                }
+                runtime_host::RuntimeHostVm::Finished(Err(err)) => {
+                    break Query::Finished {
+                        result: Err(Error::WasmVmReadWrite(err.detail)),
+                        virtual_machine: err.prototype,
                     }
-                };
-
-                Query::Finished {
-                    result: Ok(result),
-                    virtual_machine: success.virtual_machine.into_prototype(),
+                }
+                runtime_host::RuntimeHostVm::StorageGet(i) => {
+                    break Query::StorageGet(StorageGet(StorageGetInner::Stage1(i, info)));
+                }
+                runtime_host::RuntimeHostVm::PrefixKeys(i) => {
+                    break Query::PrefixKeys(PrefixKeys(PrefixKeysInner::Stage1(i, info)));
+                }
+                runtime_host::RuntimeHostVm::NextKey(inner) => {
+                    break Query::NextKey(NextKey(NextKeyInner::Stage1(inner, info)));
                 }
             }
-            read_only_runtime_host::RuntimeHostVm::Finished(Err(err)) => Query::Finished {
-                result: Err(Error::WasmVm(err.detail)),
-                virtual_machine: err.prototype,
-            },
-            read_only_runtime_host::RuntimeHostVm::StorageGet(inner) => {
-                Query::StorageGet(StorageGet(inner))
+        }
+    }
+
+    fn from_step2(inner: runtime_host::RuntimeHostVm, info: Stage2) -> Self {
+        loop {
+            match inner {
+                runtime_host::RuntimeHostVm::Finished(Ok(success)) => {
+                    // This decoding is done in multiple steps in order to solve borrow checking
+                    // errors.
+                    let result = {
+                        let output = success.virtual_machine.value();
+                        decode_validate_transaction_return_value(output.as_ref())
+                            .map_err(Error::OutputDecodeError)
+                    };
+
+                    let result = match result {
+                        Ok(res) => {
+                            if let Ok(res) = res.as_ref() {
+                                if res.provides.is_empty() {
+                                    return Query::Finished {
+                                        result: Err(Error::EmptyProvidedTags),
+                                        virtual_machine: success.virtual_machine.into_prototype(),
+                                    };
+                                }
+                            }
+                            res
+                        }
+                        Err(err) => {
+                            return Query::Finished {
+                                result: Err(err),
+                                virtual_machine: success.virtual_machine.into_prototype(),
+                            }
+                        }
+                    };
+
+                    break Query::Finished {
+                        result: Ok(result),
+                        virtual_machine: success.virtual_machine.into_prototype(),
+                    };
+                }
+                runtime_host::RuntimeHostVm::Finished(Err(err)) => {
+                    break Query::Finished {
+                        result: Err(Error::WasmVmReadOnly(err.detail)),
+                        virtual_machine: err.prototype,
+                    }
+                }
+                runtime_host::RuntimeHostVm::StorageGet(i) => {
+                    break Query::StorageGet(StorageGet(StorageGetInner::Stage2(i, info)));
+                }
+                runtime_host::RuntimeHostVm::PrefixKeys(i) => {
+                    break Query::PrefixKeys(PrefixKeys(PrefixKeysInner::Stage2(i, info)));
+                }
+                runtime_host::RuntimeHostVm::NextKey(inner) => {
+                    break Query::NextKey(NextKey(NextKeyInner::Stage2(inner, info)));
+                }
             }
-            read_only_runtime_host::RuntimeHostVm::StorageRoot(inner) => {
-                Query::StorageRoot(StorageRoot(inner))
-            }
-            read_only_runtime_host::RuntimeHostVm::NextKey(inner) => Query::NextKey(NextKey(inner)),
         }
     }
 }
 
+struct Stage1 {
+    /// Same value as [`Config::source`].
+    transaction_source: TransactionSource,
+    /// Same value as [`Config::scale_encoded_transaction`].
+    scale_encoded_transaction: Vec<u8>,
+}
+
+struct Stage2 {}
+
 /// Loading a storage value is required in order to continue.
 #[must_use]
-pub struct StorageGet(read_only_runtime_host::StorageGet);
+pub struct StorageGet(StorageGetInner);
+
+enum StorageGetInner {
+    Stage1(runtime_host::StorageGet, Stage1),
+    Stage2(runtime_host::StorageGet, Stage2),
+}
 
 impl StorageGet {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
     pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[u8]> + '_> + '_ {
-        self.0.key()
+        match &self.0 {
+            StorageGetInner::Stage1(inner, _) => either::Left(inner.key().map(either::Left)),
+            StorageGetInner::Stage2(inner, _) => either::Right(inner.key().map(either::Right)),
+        }
     }
 
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
     ///
     /// This method is a shortcut for calling `key` and concatenating the returned slices.
     pub fn key_as_vec(&self) -> Vec<u8> {
-        self.0.key_as_vec()
+        match &self.0 {
+            StorageGetInner::Stage1(inner, _) => inner.key_as_vec(),
+            StorageGetInner::Stage2(inner, _) => inner.key_as_vec(),
+        }
     }
 
     /// Injects the corresponding storage value.
     pub fn inject_value(self, value: Option<impl Iterator<Item = impl AsRef<[u8]>>>) -> Query {
-        Query::from_inner(self.0.inject_value(value))
+        match self.0 {
+            StorageGetInner::Stage1(inner, stage) => {
+                Query::from_step1(inner.inject_value(value), stage)
+            }
+            StorageGetInner::Stage2(inner, stage) => {
+                Query::from_step2(inner.inject_value(value), stage)
+            }
+        }
     }
 }
 
 /// Fetching the key that follows a given one is required in order to continue.
 #[must_use]
-pub struct NextKey(read_only_runtime_host::NextKey);
+pub struct NextKey(NextKeyInner);
+
+enum NextKeyInner {
+    Stage1(runtime_host::NextKey, Stage1),
+    Stage2(runtime_host::NextKey, Stage2),
+}
 
 impl NextKey {
     /// Returns the key whose next key must be passed back.
     pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
-        self.0.key()
+        match &self.0 {
+            NextKeyInner::Stage1(inner, _) => either::Left(inner.key()),
+            NextKeyInner::Stage2(inner, _) => either::Right(inner.key()),
+        }
     }
 
     /// Injects the key.
@@ -344,18 +535,42 @@ impl NextKey {
     /// Panics if the key passed as parameter isn't strictly superior to the requested key.
     ///
     pub fn inject_key(self, key: Option<impl AsRef<[u8]>>) -> Query {
-        Query::from_inner(self.0.inject_key(key))
+        match self.0 {
+            NextKeyInner::Stage1(inner, stage1) => Query::from_step1(inner.inject_key(key), stage1),
+            NextKeyInner::Stage2(inner, stage2) => Query::from_step2(inner.inject_key(key), stage2),
+        }
     }
 }
 
-/// Fetching the storage trie root is required in order to continue.
+/// Fetching the list of keys with a given prefix from the parent storage is required in order to
+/// continue.
 #[must_use]
-pub struct StorageRoot(read_only_runtime_host::StorageRoot);
+pub struct PrefixKeys(PrefixKeysInner);
 
-impl StorageRoot {
-    /// Writes the trie root hash to the Wasm VM and prepares it for resume.
-    pub fn resume(self, hash: &[u8; 32]) -> Query {
-        Query::from_inner(self.0.resume(hash))
+enum PrefixKeysInner {
+    Stage1(runtime_host::PrefixKeys, Stage1),
+    Stage2(runtime_host::PrefixKeys, Stage2),
+}
+
+impl PrefixKeys {
+    /// Returns the prefix whose keys to load.
+    pub fn prefix(&'_ self) -> impl AsRef<[u8]> + '_ {
+        match &self.0 {
+            PrefixKeysInner::Stage1(inner, _) => either::Left(inner.prefix()),
+            PrefixKeysInner::Stage2(inner, _) => either::Right(inner.prefix()),
+        }
+    }
+
+    /// Injects the list of keys.
+    pub fn inject_keys(self, keys: impl Iterator<Item = impl AsRef<[u8]>>) -> Query {
+        match self.0 {
+            PrefixKeysInner::Stage1(inner, stage1) => {
+                Query::from_step1(inner.inject_keys(keys), stage1)
+            }
+            PrefixKeysInner::Stage2(inner, stage2) => {
+                Query::from_step2(inner.inject_keys(keys), stage2)
+            }
+        }
     }
 }
 

--- a/src/transactions/validate.rs
+++ b/src/transactions/validate.rs
@@ -32,7 +32,7 @@ pub struct Config<'a, TTx> {
     pub runtime: host::HostVmPrototype,
 
     /// Header of the block to verify the transaction against, in SCALE encoding.
-    /// The runtime of this block must be the one in [`COnfig::runtime`].
+    /// The runtime of this block must be the one in [`Config::runtime`].
     pub scale_encoded_header: &'a [u8],
 
     /// SCALE-encoded transaction.

--- a/src/transactions/validate.rs
+++ b/src/transactions/validate.rs
@@ -263,6 +263,7 @@ pub fn validate_transaction(
         virtual_machine: config.runtime,
         function_to_call: "Core_initialize_block",
         parameter: header::HeaderRef {
+            // TODO: not actually sure if these values match what Substrate passes to the runtime
             parent_hash: decoded_header.parent_hash,
             number: decoded_header.number,
             extrinsics_root: &[0; 32],


### PR DESCRIPTION
Backported change from https://github.com/paritytech/smoldot/pull/845

It turns out that we actually need to make a call to `Core_initialize_block` beforehand, and that the transaction validation function can modify the storage.