### PR TITLE
Remove TODO in validate.rs about initialize_block

### DIFF
--- a/src/transactions/validate.rs
+++ b/src/transactions/validate.rs
@@ -263,7 +263,6 @@ pub fn validate_transaction(
         virtual_machine: config.runtime,
         function_to_call: "Core_initialize_block",
         parameter: header::HeaderRef {
-            // TODO: not actually sure if these values match what Substrate passes to the runtime
             parent_hash: decoded_header.parent_hash,
             number: decoded_header.number,
             extrinsics_root: &[0; 32],


### PR DESCRIPTION
Here's what Substrate actually does: https://github.com/paritytech/substrate/blob/d6c33e7ec313f9bd5e319dc0a5a3ace5543f9617/client/service/src/client/client.rs#L1207
Consequently, the smoldot code is confirmed to be correct.