### PR TITLE
Show warning if state_getMetadata returns error

### DIFF
--- a/bin/wasm-node/rust/src/json_rpc_service.rs
+++ b/bin/wasm-node/rust/src/json_rpc_service.rs
@@ -675,11 +675,19 @@ impl JsonRpcService {
                         methods::Response::state_getMetadata(methods::HexString(metadata))
                             .to_json_response(request_id)
                     }
-                    Err(error) => json_rpc::parse::build_error_response(
-                        request_id,
-                        json_rpc::parse::ErrorResponse::ServerError(-32000, &error.to_string()),
-                        None,
-                    ),
+                    Err(error) => {
+                        log::warn!(
+                            target: "json-rpc",
+                            "Returning error from `state_getMetadata`. \
+                            API user might not function properly. Error: {}",
+                            error
+                        );
+                        json_rpc::parse::build_error_response(
+                            request_id,
+                            json_rpc::parse::ErrorResponse::ServerError(-32000, &error.to_string()),
+                            None,
+                        )
+                    }
                 };
 
                 self.send_back(&response, user_data);


### PR DESCRIPTION
This warning is maybe questionable in the absolute, but it is right now a major pain point when `state_getMetadata` returns an error.