### PR TITLE
Implement ext_storage_clear_prefix_version_2

### DIFF
--- a/bin/full-node/src/sync_service.rs
+++ b/bin/full-node/src/sync_service.rs
@@ -407,7 +407,7 @@ fn start_sync(
                                         .range(req.prefix().as_ref().to_vec()..)
                                         .take_while(|(k, _)| k.starts_with(&prefix))
                                         .map(|(k, _)| k);
-                                    verify = req.inject_keys(keys);
+                                    verify = req.inject_keys_ordered(keys);
                                 }
                             }
                         }

--- a/bin/wasm-node/rust/src/runtime_service.rs
+++ b/bin/wasm-node/rust/src/runtime_service.rs
@@ -514,8 +514,10 @@ impl<'a> RuntimeCallLock<'a> {
     ///
     /// Returns an error if not all the keys could be found in the proof, meaning that the proof
     /// is invalid.
+    ///
+    /// The keys returned are ordered lexicographically.
     // TODO: if proof is invalid, we should give the option to fetch another call proof
-    pub fn storage_prefix_keys(
+    pub fn storage_prefix_keys_ordered(
         &'_ self,
         prefix: &[u8],
     ) -> Result<impl Iterator<Item = impl AsRef<[u8]> + '_>, RuntimeCallError> {
@@ -557,6 +559,8 @@ impl<'a> RuntimeCallLock<'a> {
             }
         }
 
+        // TODO: maybe we could iterate over the proof in an ordered way rather than sorting at the end
+        output.sort();
         Ok(output.into_iter())
     }
 

--- a/bin/wasm-node/rust/src/transactions_service.rs
+++ b/bin/wasm-node/rust/src/transactions_service.rs
@@ -925,10 +925,10 @@ async fn validate_transaction(
                 // TODO: lots of allocations because I couldn't figure how to make this annoying borrow checker happy
                 let rq_prefix = prefix.prefix().as_ref().to_owned();
                 let result = runtime_call_lock
-                    .storage_prefix_keys(&rq_prefix)
+                    .storage_prefix_keys_ordered(&rq_prefix)
                     .map(|i| i.map(|v| v.as_ref().to_owned()).collect::<Vec<_>>());
                 match result {
-                    Ok(v) => validation_in_progress = prefix.inject_keys(v.into_iter()),
+                    Ok(v) => validation_in_progress = prefix.inject_keys_ordered(v.into_iter()),
                     Err(err) => {
                         runtime_call_lock
                             .unlock(validate::Query::PrefixKeys(prefix).into_prototype());

--- a/src/author/build.rs
+++ b/src/author/build.rs
@@ -310,9 +310,12 @@ impl PrefixKeys {
         self.0.prefix()
     }
 
-    /// Injects the list of keys.
-    pub fn inject_keys(self, keys: impl Iterator<Item = impl AsRef<[u8]>>) -> BuilderAuthoring {
-        self.1.with_runtime_inner(self.0.inject_keys(keys))
+    /// Injects the list of keys ordered lexicographically.
+    pub fn inject_keys_ordered(
+        self,
+        keys: impl Iterator<Item = impl AsRef<[u8]>>,
+    ) -> BuilderAuthoring {
+        self.1.with_runtime_inner(self.0.inject_keys_ordered(keys))
     }
 }
 

--- a/src/author/runtime.rs
+++ b/src/author/runtime.rs
@@ -691,9 +691,9 @@ impl PrefixKeys {
         self.0.prefix()
     }
 
-    /// Injects the list of keys.
-    pub fn inject_keys(self, keys: impl Iterator<Item = impl AsRef<[u8]>>) -> BlockBuild {
-        BlockBuild::from_inner(self.0.inject_keys(keys), self.1)
+    /// Injects the list of keys ordered lexicographically.
+    pub fn inject_keys_ordered(self, keys: impl Iterator<Item = impl AsRef<[u8]>>) -> BlockBuild {
+        BlockBuild::from_inner(self.0.inject_keys_ordered(keys), self.1)
     }
 }
 

--- a/src/author/runtime/tests.rs
+++ b/src/author/runtime/tests.rs
@@ -85,7 +85,7 @@ fn block_building_works() {
                     .genesis_storage()
                     .filter(move |(k, _)| k.starts_with(&p))
                     .map(|(k, _)| k);
-                builder = prefix.inject_keys(list)
+                builder = prefix.inject_keys_ordered(list)
             }
         }
     }

--- a/src/chain/blocks_tree/verify.rs
+++ b/src/chain/blocks_tree/verify.rs
@@ -853,9 +853,12 @@ impl<T> StoragePrefixKeys<T> {
         .unwrap()
     }
 
-    /// Injects the list of keys.
-    pub fn inject_keys(self, keys: impl Iterator<Item = impl AsRef<[u8]>>) -> BodyVerifyStep2<T> {
-        let inner = self.inner.inject_keys(keys);
+    /// Injects the list of keys ordered lexicographically.
+    pub fn inject_keys_ordered(
+        self,
+        keys: impl Iterator<Item = impl AsRef<[u8]>>,
+    ) -> BodyVerifyStep2<T> {
+        let inner = self.inner.inject_keys_ordered(keys);
         self.context.with_body_verify(inner)
     }
 }

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -580,6 +580,7 @@ impl ReadyToRun {
                 HostFunction::ext_storage_clear_version_1 => 1,
                 HostFunction::ext_storage_exists_version_1 => 1,
                 HostFunction::ext_storage_clear_prefix_version_1 => 1,
+                HostFunction::ext_storage_clear_prefix_version_2 => 2,
                 HostFunction::ext_storage_root_version_1 => 0,
                 HostFunction::ext_storage_changes_root_version_1 => 1,
                 HostFunction::ext_storage_next_key_version_1 => 1,
@@ -871,6 +872,28 @@ impl ReadyToRun {
                         prefix_ptr,
                         prefix_size,
                         inner: self.inner,
+                        max_keys_to_remove: None,
+                    });
+                }
+                HostFunction::ext_storage_clear_prefix_version_2 => {
+                    let (prefix_ptr, prefix_size) = expect_pointer_size_raw!(0);
+                    let limit_encoded = expect_pointer_size!(1);
+
+                    let max_keys_to_remove = match Option::<u32>::decode_all(&limit_encoded) {
+                        Ok(l) => l,
+                        Err(err) => {
+                            return HostVm::Error {
+                                error: Error::ParamDecodeError(err),
+                                prototype: self.inner.into_prototype(),
+                            };
+                        }
+                    };
+
+                    return HostVm::ExternalStorageClearPrefix(ExternalStorageClearPrefix {
+                        prefix_ptr,
+                        prefix_size,
+                        inner: self.inner,
+                        max_keys_to_remove,
                     });
                 }
                 HostFunction::ext_storage_root_version_1 => {
@@ -1809,7 +1832,9 @@ impl fmt::Debug for ExternalStorageAppend {
     }
 }
 
-/// Must remove from the storage all keys which start with a certain prefix.
+/// Must remove from the storage keys which start with a certain prefix. Use
+/// [`ExternalStorageClearPrefix::max_keys_to_remove`] to determine the maximum number of keys
+/// to remove.
 pub struct ExternalStorageClearPrefix {
     inner: Inner,
 
@@ -1817,6 +1842,9 @@ pub struct ExternalStorageClearPrefix {
     prefix_ptr: u32,
     /// Size of the prefix to remove. Guaranteed to be in range.
     prefix_size: u32,
+
+    /// Maximum number of keys to remove.
+    max_keys_to_remove: Option<u32>,
 }
 
 impl ExternalStorageClearPrefix {
@@ -1828,7 +1856,12 @@ impl ExternalStorageClearPrefix {
             .unwrap()
     }
 
-    /// Resumes execution after having set the value.
+    /// Returns the maximum number of keys to remove. `None` means "infinity".
+    pub fn max_keys_to_remove(&self) -> Option<u32> {
+        self.max_keys_to_remove
+    }
+
+    /// Resumes execution after having cleared the values.
     pub fn resume(self) -> HostVm {
         HostVm::ReadyToRun(ReadyToRun {
             inner: self.inner,
@@ -2437,6 +2470,7 @@ externalities! {
     ext_storage_clear_version_1,
     ext_storage_exists_version_1,
     ext_storage_clear_prefix_version_1,
+    ext_storage_clear_prefix_version_2,
     ext_storage_root_version_1,
     ext_storage_changes_root_version_1,
     ext_storage_next_key_version_1,

--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -1662,12 +1662,12 @@ impl<TRq, TSrc, TBl> StoragePrefixKeys<TRq, TSrc, TBl> {
         self.inner.prefix()
     }
 
-    /// Injects the list of keys.
-    pub fn inject_keys(
+    /// Injects the list of keys ordered lexicographically.
+    pub fn inject_keys_ordered(
         self,
         keys: impl Iterator<Item = impl AsRef<[u8]>>,
     ) -> BlockVerification<TRq, TSrc, TBl> {
-        let inner = self.inner.inject_keys(keys);
+        let inner = self.inner.inject_keys_ordered(keys);
         BlockVerification::from_inner(inner, self.shared, self.user_data)
     }
 }

--- a/src/sync/optimistic.rs
+++ b/src/sync/optimistic.rs
@@ -1244,8 +1244,8 @@ impl<TRq, TSrc, TBl> StoragePrefixKeys<TRq, TSrc, TBl> {
         self.inner.prefix()
     }
 
-    /// Injects the list of keys.
-    pub fn inject_keys(
+    /// Injects the list of keys ordered lexicographically.
+    pub fn inject_keys_ordered(
         self,
         keys: impl Iterator<Item = impl AsRef<[u8]>>,
     ) -> BlockVerification<TRq, TSrc, TBl> {
@@ -1270,7 +1270,7 @@ impl<TRq, TSrc, TBl> StoragePrefixKeys<TRq, TSrc, TBl> {
             }
         }
 
-        let inner = self.inner.inject_keys(keys.iter());
+        let inner = self.inner.inject_keys_ordered(keys.iter());
         BlockVerification::from(Inner::Step2(inner), self.shared)
     }
 }

--- a/src/transactions/validate.rs
+++ b/src/transactions/validate.rs
@@ -549,14 +549,14 @@ impl PrefixKeys {
         }
     }
 
-    /// Injects the list of keys.
-    pub fn inject_keys(self, keys: impl Iterator<Item = impl AsRef<[u8]>>) -> Query {
+    /// Injects the list of keys ordered lexicographically.
+    pub fn inject_keys_ordered(self, keys: impl Iterator<Item = impl AsRef<[u8]>>) -> Query {
         match self.0 {
             PrefixKeysInner::Stage1(inner, stage1) => {
-                Query::from_step1(inner.inject_keys(keys), stage1)
+                Query::from_step1(inner.inject_keys_ordered(keys), stage1)
             }
             PrefixKeysInner::Stage2(inner, stage2) => {
-                Query::from_step2(inner.inject_keys(keys), stage2)
+                Query::from_step2(inner.inject_keys_ordered(keys), stage2)
             }
         }
     }

--- a/src/verify/execute_block.rs
+++ b/src/verify/execute_block.rs
@@ -209,9 +209,9 @@ impl PrefixKeys {
         self.0.prefix()
     }
 
-    /// Injects the list of keys.
-    pub fn inject_keys(self, keys: impl Iterator<Item = impl AsRef<[u8]>>) -> Verify {
-        Verify::from_inner(self.0.inject_keys(keys))
+    /// Injects the list of keys ordered lexicographically.
+    pub fn inject_keys_ordered(self, keys: impl Iterator<Item = impl AsRef<[u8]>>) -> Verify {
+        Verify::from_inner(self.0.inject_keys_ordered(keys))
     }
 }
 

--- a/src/verify/header_body.rs
+++ b/src/verify/header_body.rs
@@ -435,10 +435,10 @@ impl StoragePrefixKeys {
         self.inner.prefix()
     }
 
-    /// Injects the list of keys.
-    pub fn inject_keys(self, keys: impl Iterator<Item = impl AsRef<[u8]>>) -> Verify {
+    /// Injects the list of keys ordered lexicographically.
+    pub fn inject_keys_ordered(self, keys: impl Iterator<Item = impl AsRef<[u8]>>) -> Verify {
         VerifyInner {
-            inner: self.inner.inject_keys(keys),
+            inner: self.inner.inject_keys_ordered(keys),
             consensus_success: self.consensus_success,
         }
         .run()


### PR DESCRIPTION
Fix #1010 

This turned out to be slightly trickier than expected, as the keys returned by `inject_keys` now need to be ordered, while this wasn't the case before.