### PR TITLE
Bump number of allowed parallel JSON-RPC requests

### DIFF
--- a/bin/wasm-node/rust/src/lib.rs
+++ b/bin/wasm-node/rust/src/lib.rs
@@ -398,8 +398,8 @@ impl Client {
                         chain_spec,
                         genesis_block_hash,
                         genesis_block_state_root,
-                        max_parallel_requests: NonZeroU32::new(12).unwrap(),
-                        max_pending_requests: NonZeroU32::new(48).unwrap(),
+                        max_parallel_requests: NonZeroU32::new(32).unwrap(),
+                        max_pending_requests: NonZeroU32::new(64).unwrap(),
                         max_subscriptions: 64,
                     }))
                 };


### PR DESCRIPTION
PolkadotJS seems a bit greedy, so let's increase these values.