### PR TITLE
Simplify all.rs

### DIFF
--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -856,7 +856,6 @@ async fn start_relay_chain(
                             );
                         }
                     }
-                    all::ProcessOne::VerifyHeaderBody(_) => unreachable!(),
                     all::ProcessOne::VerifyHeader(verify) => {
                         let verified_hash = verify.hash();
 

--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -567,8 +567,8 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
 
     /// Returns the details of a request to start towards a source.
     ///
-    /// This method doesn't modify the state machine in any way. [`AllForksSync::add_request`]
-    /// must be called in order for the request to actually be marked as started.
+    /// This method doesn't modify the state machine in any way. [`AllSync::add_request`] must be
+    /// called in order for the request to actually be marked as started.
     pub fn desired_requests(&'_ self) -> impl Iterator<Item = (SourceId, RequestDetail)> + '_ {
         match &self.inner {
             AllSyncInner::AllForks(sync) => {
@@ -638,7 +638,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     /// Inserts a new request in the data structure.
     ///
     /// > **Note**: The request doesn't necessarily have to match a request returned by
-    /// >           [`AllForksSync::desired_requests`].
+    /// >           [`AllSync::desired_requests`].
     ///
     /// # Panic
     ///
@@ -983,7 +983,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     }
 }
 
-/// See [`Action::Start::detail`].
+/// See [`AllSync::desired_requests`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[must_use]
 pub enum RequestDetail {

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -445,7 +445,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     ///
     /// > **Note**: It is in no way mandatory to actually call this function and cancel the
     /// >           requests that are returned.
-    pub fn obsolete_requests(&'_ self) -> impl Iterator<Item = RequestId> + '_ {
+    pub fn obsolete_requests(&'_ self) -> impl Iterator<Item = (RequestId, &'_ TRq)> + '_ {
         self.inner.blocks.obsolete_requests()
     }
 

--- a/src/sync/all_forks/pending_blocks.rs
+++ b/src/sync/all_forks/pending_blocks.rs
@@ -740,14 +740,14 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     ///
     /// > **Note**: It is in no way mandatory to actually call this function and cancel the
     /// >           requests that are returned.
-    pub fn obsolete_requests(&'_ self) -> impl Iterator<Item = RequestId> + '_ {
+    pub fn obsolete_requests(&'_ self) -> impl Iterator<Item = (RequestId, &'_ TRq)> + '_ {
         // TODO: more than that?
         self.requests
             .iter()
             .filter(move |(_, rq)| {
                 rq.detail.first_block_height <= self.sources.finalized_block_height()
             })
-            .map(|(id, _)| RequestId(id))
+            .map(|(id, rq)| (RequestId(id), &rq.user_data))
     }
 
     /// Returns the details of a request to start towards a source.


### PR DESCRIPTION
This PR modifies the public API of the `AllSync` state machine to mimic the one of `AllForks`.
This was previously using an API based on returning the diff between two state changes. This turned out to be way too complicated to use.

This PR doesn't update `optimistic.rs` to have a similar API. As a consequence, this PR breaks the full node, which will now panic on startup.

An issue should be opened about updating `optimistic.rs` after this PR is merged.
