### PR TITLE
Remove weird `One` structs

### DIFF
--- a/src/executor/runtime_host.rs
+++ b/src/executor/runtime_host.rs
@@ -205,13 +205,7 @@ impl StorageGet {
                 if let calculate_root::RootMerkleValueCalculation::StorageValue(value_request) =
                     self.inner.root_calculation.as_ref().unwrap()
                 {
-                    struct One(u8);
-                    impl AsRef<[u8]> for One {
-                        fn as_ref(&self) -> &[u8] {
-                            slice::from_ref(&self.0)
-                        }
-                    }
-                    either::Right(value_request.key().map(One).map(either::Right))
+                    either::Right(value_request.key().map(|v| [v]).map(either::Right))
                 } else {
                     // We only create a `StorageGet` if the state is `StorageValue`.
                     panic!()

--- a/src/header/aura.rs
+++ b/src/header/aura.rs
@@ -53,18 +53,10 @@ impl<'a> AuraConsensusLogRef<'a> {
     pub fn scale_encoding(
         &self,
     ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
-        #[derive(Clone)]
-        struct One([u8; 1]);
-        impl AsRef<[u8]> for One {
-            fn as_ref(&self) -> &[u8] {
-                &self.0[..]
-            }
-        }
-
-        let index = iter::once(One(match self {
+        let index = iter::once(match self {
             AuraConsensusLogRef::AuthoritiesChange(_) => [1],
             AuraConsensusLogRef::OnDisabled(_) => [2],
-        }));
+        });
 
         let body = match self {
             AuraConsensusLogRef::AuthoritiesChange(list) => {

--- a/src/header/babe.rs
+++ b/src/header/babe.rs
@@ -66,19 +66,11 @@ impl<'a> BabeConsensusLogRef<'a> {
     pub fn scale_encoding(
         &self,
     ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
-        #[derive(Clone)]
-        struct One([u8; 1]);
-        impl AsRef<[u8]> for One {
-            fn as_ref(&self) -> &[u8] {
-                &self.0[..]
-            }
-        }
-
-        let index = iter::once(One(match self {
+        let index = iter::once(match self {
             BabeConsensusLogRef::NextEpochData(_) => [1],
             BabeConsensusLogRef::OnDisabled(_) => [2],
             BabeConsensusLogRef::NextConfigData(_) => [3],
-        }));
+        });
 
         let body = match self {
             BabeConsensusLogRef::NextEpochData(digest) => either::Left(either::Left(
@@ -88,7 +80,7 @@ impl<'a> BabeConsensusLogRef<'a> {
                 either::Left(either::Right(digest.to_le_bytes())),
             ))),
             BabeConsensusLogRef::NextConfigData(digest) => either::Right(
-                iter::once(either::Right(either::Left(One([1])))).chain(
+                iter::once(either::Right(either::Left([1]))).chain(
                     digest
                         .scale_encoding()
                         .map(either::Right)
@@ -400,19 +392,11 @@ impl BabeAllowedSlots {
     /// Returns an iterator to list of buffers which, when concatenated, produces the SCALE
     /// encoding of that object.
     pub fn scale_encoding(&self) -> impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone {
-        #[derive(Clone)]
-        struct One([u8; 1]);
-        impl AsRef<[u8]> for One {
-            fn as_ref(&self) -> &[u8] {
-                &self.0[..]
-            }
-        }
-
-        iter::once(One(match self {
+        iter::once(match self {
             BabeAllowedSlots::PrimarySlots => [0],
             BabeAllowedSlots::PrimaryAndSecondaryPlainSlots => [1],
             BabeAllowedSlots::PrimaryAndSecondaryVrfSlots => [2],
-        }))
+        })
     }
 }
 
@@ -464,19 +448,11 @@ impl<'a> BabePreDigestRef<'a> {
     pub fn scale_encoding(
         &self,
     ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
-        #[derive(Clone)]
-        struct One([u8; 1]);
-        impl AsRef<[u8]> for One {
-            fn as_ref(&self) -> &[u8] {
-                &self.0[..]
-            }
-        }
-
-        let index = iter::once(One(match self {
+        let index = iter::once(match self {
             BabePreDigestRef::Primary(_) => [1],
             BabePreDigestRef::SecondaryPlain(_) => [2],
             BabePreDigestRef::SecondaryVRF(_) => [3],
-        }));
+        });
 
         let body = match self {
             BabePreDigestRef::Primary(digest) => either::Left(either::Left(

--- a/src/header/grandpa.rs
+++ b/src/header/grandpa.rs
@@ -86,21 +86,13 @@ impl<'a> GrandpaConsensusLogRef<'a> {
     pub fn scale_encoding(
         &self,
     ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
-        #[derive(Clone)]
-        struct One([u8; 1]);
-        impl AsRef<[u8]> for One {
-            fn as_ref(&self) -> &[u8] {
-                &self.0[..]
-            }
-        }
-
-        let index = iter::once(One(match self {
+        let index = iter::once(match self {
             GrandpaConsensusLogRef::ScheduledChange(_) => [1],
             GrandpaConsensusLogRef::ForcedChange { .. } => [2],
             GrandpaConsensusLogRef::OnDisabled(_) => [3],
             GrandpaConsensusLogRef::Pause(_) => [4],
             GrandpaConsensusLogRef::Resume(_) => [5],
-        }));
+        });
 
         let body = match self {
             GrandpaConsensusLogRef::ScheduledChange(change) => either::Left(either::Left(

--- a/src/libp2p/connection/multistream_select.rs
+++ b/src/libp2p/connection/multistream_select.rs
@@ -587,15 +587,7 @@ where
             MessageOut::ProtocolNa => 3,
         };
 
-        let length_prefix = leb128::encode_usize(len).map(|n| {
-            struct One(u8);
-            impl AsRef<[u8]> for One {
-                fn as_ref(&self) -> &[u8] {
-                    slice::from_ref(&self.0)
-                }
-            }
-            One(n)
-        });
+        let length_prefix = leb128::encode_usize(len).map(|n| [n]);
 
         let mut n = 0;
         let body = iter::from_fn(move || {


### PR DESCRIPTION
Thanks to the stabilization of `impl<T, const N: usize> AsRef<[T]> for [T; N]`, these structs are no longer necessary.