### PR TITLE
Avoid an allocation in CallRuntimeVersion::resume

### DIFF
--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -1982,13 +1982,23 @@ impl CallRuntimeVersion {
     /// If an error happened during the execution (such as an invalid Wasm binary code), pass
     /// an `Err`.
     pub fn resume(self, scale_encoded_runtime_version: Result<&[u8], ()>) -> HostVm {
-        // TODO: don't allocate a Vec here
-        let scale_encoded_runtime_version =
-            parity_scale_codec::Encode::encode(&scale_encoded_runtime_version.ok());
-        self.inner.alloc_write_and_return_pointer_size(
-            HostFunction::ext_misc_runtime_version_version_1.name(),
-            iter::once(scale_encoded_runtime_version),
-        )
+        if let Ok(scale_encoded_runtime_version) = scale_encoded_runtime_version {
+            self.inner.alloc_write_and_return_pointer_size(
+                HostFunction::ext_misc_runtime_version_version_1.name(),
+                iter::once(either::Left([1]))
+                    .chain(iter::once(either::Right(either::Left(
+                        util::encode_scale_compact_usize(scale_encoded_runtime_version.len()),
+                    ))))
+                    .chain(iter::once(either::Right(either::Right(
+                        scale_encoded_runtime_version,
+                    )))),
+            )
+        } else {
+            self.inner.alloc_write_and_return_pointer_size(
+                HostFunction::ext_misc_runtime_version_version_1.name(),
+                iter::once([0]),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
This PR is ready for merging, but I'd like to test it first. But to test it, we first need to fix https://github.com/paritytech/smoldot/issues/1061.