### PR TITLE
Publish NPM packet as public

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./bin/wasm-node/javascript/package.json
+          access: public
 
   # TODO: this stage is planned to be removed once smoldot is published on crates.io and its doc available on docs.rs
   deploy-gh-pages:


### PR DESCRIPTION
Hopefully fix the deploy CI failure: https://github.com/paritytech/smoldot/runs/3269769250