### PR TITLE
Update package-lock.json

### DIFF
--- a/bin/wasm-node/javascript/package-lock.json
+++ b/bin/wasm-node/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "smoldot",
-  "version": "0.3.6",
+  "name": "@substrate/smoldot-light",
+  "version": "0.3.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "smoldot",
-      "version": "0.3.6",
+      "name": "@substrate/smoldot-light",
+      "version": "0.3.7",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "buffer": "^6.0.1",


### PR DESCRIPTION
Update the `package-lock.json` file after https://github.com/paritytech/smoldot/pull/1099 

We're using https://docs.npmjs.com/cli/v6/commands/npm-ci#description, so I was expecting CI to fail because of the mismatch, but it doesn't. If someone who happens to see that can open an issue on NPM, because I'm not bothered.
