### PR TITLE
Change network functions to accept &mut ReadWrite

### DIFF
--- a/bin/full-node/src/network_service.rs
+++ b/bin/full-node/src/network_service.rs
@@ -35,6 +35,7 @@ use smoldot::{
         async_rw_with_buffers, connection,
         multiaddr::{Multiaddr, Protocol},
         peer_id::PeerId,
+        read_write::ReadWrite,
     },
     network::{protocol, service},
 };
@@ -505,9 +506,18 @@ async fn connection_task(
 
         let now = Instant::now();
 
-        let read_write = match network_service
+        let mut read_write = ReadWrite {
+            now,
+            incoming_buffer: read_buffer.map(|b| b.0),
+            outgoing_buffer: write_buffer,
+            read_bytes: 0,
+            written_bytes: 0,
+            wake_up_after: None,
+        };
+
+        let connection_ready_future = match network_service
             .network
-            .read_write(id, now, read_buffer.map(|b| b.0), write_buffer.unwrap())
+            .read_write(id, &mut read_write)
             .await
         {
             Ok(rw) => rw,
@@ -517,17 +527,20 @@ async fn connection_task(
             }
         };
 
-        if read_write.read_bytes != 0 || read_write.written_bytes != 0 || read_write.write_close {
+        if read_write.read_bytes != 0
+            || read_write.written_bytes != 0
+            || read_write.outgoing_buffer.is_none()
+        {
             tracing::event!(
                 tracing::Level::TRACE,
                 read = read_write.read_bytes,
                 written = read_write.written_bytes,
                 "wake-up" = ?read_write.wake_up_after,  // TODO: ugly display
-                "write-close" = read_write.write_close,
+                "write-close" = read_write.outgoing_buffer.is_none(),
             );
         }
 
-        if read_write.write_close && read_buffer.is_none() {
+        if read_write.outgoing_buffer.is_none() && read_buffer.is_none() {
             // Make sure to finish closing the TCP socket.
             tcp_socket
                 .flush_close()
@@ -537,14 +550,19 @@ async fn connection_task(
             return;
         }
 
-        if read_write.write_close && !tcp_socket.is_closed() {
+        let read_bytes = read_write.read_bytes;
+        let written_bytes = read_write.written_bytes;
+        let write_closed = read_write.outgoing_buffer.is_none();
+        let wake_up_after = read_write.wake_up_after;
+
+        if write_closed && !tcp_socket.is_closed() {
             tcp_socket.close();
             tracing::info!("write-closed");
         }
 
-        tcp_socket.advance(read_write.read_bytes, read_write.written_bytes);
+        tcp_socket.advance(read_bytes, written_bytes);
 
-        let mut poll_after = if let Some(wake_up) = read_write.wake_up_after {
+        let mut poll_after = if let Some(wake_up) = wake_up_after {
             if wake_up > now {
                 let dur = wake_up - now;
                 future::Either::Left(futures_timer::Delay::new(dur))
@@ -563,7 +581,7 @@ async fn connection_task(
                     "socket-ready"
                 );
             },
-            _ = read_write.wake_up_future.fuse() => {},
+            _ = connection_ready_future.fuse() => {},
             () = poll_after => {
                 // Nothing to do, but guarantees that we loop again.
                 tracing::event!(

--- a/bin/wasm-node/rust/src/network_service.rs
+++ b/bin/wasm-node/rust/src/network_service.rs
@@ -689,9 +689,10 @@ async fn connection_task(
             read_bytes: 0,
             written_bytes: 0,
             wake_up_after: None,
+            wake_up_future: None,
         };
 
-        let wake_up_future = match network_service
+        match network_service
             .network
             .read_write(id, &mut read_write)
             .await
@@ -737,6 +738,12 @@ async fn connection_task(
         let read_bytes = read_write.read_bytes;
         let written_bytes = read_write.written_bytes;
         let wake_up_after = read_write.wake_up_after;
+
+        let wake_up_future = if let Some(wake_up_future) = read_write.wake_up_future.take() {
+            future::Either::Left(wake_up_future)
+        } else {
+            future::Either::Right(future::pending())
+        };
 
         drop(read_write);
 

--- a/src/libp2p.rs
+++ b/src/libp2p.rs
@@ -23,6 +23,7 @@ pub mod connection;
 pub mod discovery;
 pub mod peer_id;
 pub mod peers;
+pub mod read_write;
 
 pub use multiaddr::Multiaddr;
 #[doc(inline)]

--- a/src/libp2p/collection.rs
+++ b/src/libp2p/collection.rs
@@ -1167,20 +1167,19 @@ where
                 mut handshake,
                 randomness_seed,
             } => {
-                let incoming_buffer = match read_write.incoming_buffer {
-                    Some(b) => b,
-                    None => {
-                        debug_assert_eq!(read_write.read_bytes, 0);
-                        read_write.close_write();
-                        debug_assert!(self.pending_event.is_none());
-                        self.pending_event = Some(PendingEvent::Disconnect);
-                        return Ok(());
-                    }
-                };
-
                 // TODO: check timeout
 
                 loop {
+                    let incoming_buffer = match read_write.incoming_buffer {
+                        Some(b) => b,
+                        None => {
+                            read_write.close_write();
+                            debug_assert!(self.pending_event.is_none());
+                            self.pending_event = Some(PendingEvent::Disconnect);
+                            return Ok(());
+                        }
+                    };
+
                     let (result, num_read, num_written) = match handshake.read_write(
                         incoming_buffer,
                         match read_write.outgoing_buffer.as_mut() {

--- a/src/libp2p/connection/established.rs
+++ b/src/libp2p/connection/established.rs
@@ -211,25 +211,15 @@ impl<TNow, TRqUd, TNotifUd> Established<TNow, TRqUd, TNotifUd>
 where
     TNow: Clone + Add<Duration, Output = TNow> + Sub<TNow, Output = Duration> + Ord,
 {
-    /// Reads data coming from the socket from `incoming_data`, updates the internal state machine,
-    /// and writes data destined to the socket to `outgoing_buffer`.
+    /// Reads data coming from the socket, updates the internal state machine, and writes data
+    /// destined to the socket through the [`ReadWrite`].
     ///
-    /// `incoming_data` should be `None` if the remote has closed their writing side.
-    ///
-    /// The returned structure contains the number of bytes read and written from/to the two
-    /// buffers. In order to avoid unnecessary memory allocations, only one [`Event`] is returned
-    /// at a time. Consequently, this method returns as soon as an event is available, even if the
-    /// buffers haven't finished being read. Call this method in a loop until these two values are
-    /// both 0 and the returned [`Event`] is `None`.
-    ///
-    /// If the remote isn't ready to accept new data, pass an empty slice as `outgoing_buffer`.
-    ///
-    /// The current time must be passed via the `now` parameter. This is used internally in order
-    /// to keep track of ping times and timeouts. The returned structure optionally contains a
-    /// `TNow` representing the moment after which this method should be called again.
+    /// In order to avoid unnecessary memory allocations, only one [`Event`] is returned at a time.
+    /// Consequently, this method returns as soon as an event is available, even if the buffers
+    /// haven't finished being read. Call this method in a loop until the number of bytes read and
+    /// written are both 0, and the returned [`Event`] is `None`.
     ///
     /// If an error is returned, the socket should be entirely shut down.
-    // TODO: should take the in and out buffers as iterators, to allow for vectored reads/writes; tricky because an impl Iterator<Item = &mut [u8]> + Clone is impossible to build
     // TODO: in case of error, we're supposed to first send a yamux goaway frame
     pub fn read_write<'a>(
         mut self,

--- a/src/libp2p/connection/established.rs
+++ b/src/libp2p/connection/established.rs
@@ -220,7 +220,7 @@ where
     /// buffers. In order to avoid unnecessary memory allocations, only one [`Event`] is returned
     /// at a time. Consequently, this method returns as soon as an event is available, even if the
     /// buffers haven't finished being read. Call this method in a loop until these two values are
-    /// both 0 and [`ReadWrite::event`] is `None`.
+    /// both 0 and the returned [`Event`] is `None`.
     ///
     /// If the remote isn't ready to accept new data, pass an empty slice as `outgoing_buffer`.
     ///
@@ -1353,7 +1353,7 @@ where
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SubstreamId(yamux::SubstreamId);
 
-/// Event that happened on the connection. See [`ReadWrite::event`].
+/// Event that happened on the connection. See [`Established::read_write`].
 #[must_use]
 #[derive(Debug)]
 pub enum Event<TRqUd, TNotifUd> {

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -994,7 +994,7 @@ where
         &self,
         connection_id: ConnectionId,
         read_write: &'_ mut ReadWrite<'_, TNow>,
-    ) -> Result<ConnectionReadyFuture, collection::ConnectionError> {
+    ) -> Result<(), collection::ConnectionError> {
         self.inner.read_write(connection_id, read_write).await
     }
 

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -67,7 +67,7 @@ use rand::{Rng as _, SeedableRng as _};
 
 pub use collection::{
     ConfigRequestResponse, ConfigRequestResponseIn, ConnectionError, ConnectionReadyFuture,
-    NotificationProtocolConfig,
+    NotificationProtocolConfig, ReadWrite,
 };
 
 /// Configuration for a [`Peers`].
@@ -990,16 +990,12 @@ where
     /// Panics if `connection_id` isn't a valid connection.
     ///
     // TODO: document
-    pub async fn read_write<'a>(
+    pub async fn read_write(
         &self,
         connection_id: ConnectionId,
-        now: TNow,
-        incoming_buffer: Option<&[u8]>,
-        outgoing_buffer: (&'a mut [u8], &'a mut [u8]),
-    ) -> Result<collection::ReadWrite<TNow>, collection::ConnectionError> {
-        self.inner
-            .read_write(connection_id, now, incoming_buffer, outgoing_buffer)
-            .await
+        read_write: &'_ mut ReadWrite<'_, TNow>,
+    ) -> Result<ConnectionReadyFuture, collection::ConnectionError> {
+        self.inner.read_write(connection_id, read_write).await
     }
 
     /// Returns an iterator to the list of [`PeerId`]s that we have an established connection

--- a/src/libp2p/read_write.rs
+++ b/src/libp2p/read_write.rs
@@ -1,0 +1,129 @@
+// Copyright 2019-2021 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use core::{cmp, mem};
+
+#[must_use]
+pub struct ReadWrite<'a, TNow> {
+    pub now: TNow,
+
+    /// Pointer to a buffer of socket data ready to be processed.
+    ///
+    /// Contains `None` if the remote has closed their writing side of the socket.
+    pub incoming_buffer: Option<&'a [u8]>,
+
+    /// Pointer to two consecutive buffers of uninitialized data. Can be written to in order to
+    /// write data out towards the socket.
+    ///
+    /// Contains `None` if the writing side of the socket has been closed or must be closed.
+    pub outgoing_buffer: Option<(&'a mut [u8], &'a mut [u8])>,
+
+    /// Total number of bytes that have been read from [`ReadWrite::incoming_buffer`].
+    ///
+    /// [`ReadWrite::incoming_buffer`] must have been advanced after these bytes.
+    pub read_bytes: usize,
+
+    /// Total number of bytes that have been written to [`ReadWrite::outgoing_buffer`].
+    ///
+    /// [`ReadWrite::outgoing_buffer`] must have been advanced after these bytes.
+    pub written_bytes: usize,
+
+    /// If `Some`, the socket must be waken up after the given `TNow` is reached.
+    pub wake_up_after: Option<TNow>,
+    // TODO: what about pub wake_up_future: ConnectionReadyFuture,
+}
+
+impl<'a, TNow> ReadWrite<'a, TNow> {
+    /// Returns true if the connection should be considered dead. That is, both
+    /// [`ReadWrite::incoming_buffer`] and [`ReadWrite::outgoing_buffer`] are `None`.
+    pub fn is_dead(&self) -> bool {
+        self.incoming_buffer.is_none() && self.outgoing_buffer.is_none()
+    }
+
+    /// Discards the first `num` bytes of [`ReadWrite::incoming_buffer`] and adds them to
+    /// [`ReadWrite::read_bytes`].
+    ///
+    /// # Panic
+    ///
+    /// Panics if `num` is superior to the size of the available buffer.
+    ///
+    pub fn advance_read(&mut self, num: usize) {
+        self.read_bytes += num;
+        if let Some(ref mut incoming_buffer) = self.incoming_buffer {
+            *incoming_buffer = &incoming_buffer[num..];
+        } else {
+            assert_eq!(num, 0);
+        }
+    }
+
+    /// Discards the first `num` bytes of [`ReadWrite::outgoing_buffer`] and adds them to
+    /// [`ReadWrite::written_bytes`].
+    ///
+    /// # Panic
+    ///
+    /// Panics if `num` is superior to the size of the available buffer.
+    ///
+    pub fn advance_write(&mut self, num: usize) {
+        if let Some(ref mut outgoing_buffer) = self.outgoing_buffer {
+            self.written_bytes += num;
+
+            let out_buf_0_len = outgoing_buffer.0.len();
+            advance_buf(&mut outgoing_buffer.0, cmp::min(num, out_buf_0_len));
+            advance_buf(&mut outgoing_buffer.1, num.saturating_sub(out_buf_0_len));
+            if outgoing_buffer.0.is_empty() {
+                mem::swap(&mut outgoing_buffer.0, &mut outgoing_buffer.1);
+            }
+        } else {
+            assert_ne!(num, 0);
+        }
+    }
+
+    /// Sets the writing side of the connection to closed.
+    ///
+    /// This is simply a shortcut for setting [`ReadWrite::outgoing_buffer`] to `None`.
+    pub fn close_write(&mut self) {
+        self.outgoing_buffer = None;
+    }
+
+    /// Returns the size of the available outgoing buffer.
+    pub fn outgoing_buffer_available(&self) -> usize {
+        self.outgoing_buffer
+            .as_ref()
+            .map(|(a, b)| a.len() + b.len())
+            .unwrap_or(0)
+    }
+
+    /// Sets [`ReadWrite::wake_up_after`] to `min(wake_up_after, after)`.
+    pub fn wake_up_after(&mut self, after: &TNow)
+    where
+        TNow: Clone + Ord,
+    {
+        match self.wake_up_after {
+            Some(ref mut t) if *t < *after => {}
+            Some(ref mut t) => *t = after.clone(),
+            ref mut t @ None => *t = Some(after.clone()),
+        }
+    }
+}
+
+fn advance_buf(buf: &mut &mut [u8], n: usize) {
+    let tmp = mem::take(buf);
+    *buf = &mut tmp[n..];
+}

--- a/src/libp2p/read_write.rs
+++ b/src/libp2p/read_write.rs
@@ -127,6 +127,7 @@ impl<'a, TNow> ReadWrite<'a, TNow> {
         }
     }
 
+    /// Sets [`ReadWrite::wake_up_future`] to `select(wake_up_future, when)`.
     pub fn wake_up_when(&mut self, when: impl Future<Output = ()> + Send + 'static) {
         let current = match self.wake_up_future.take() {
             Some(f) => f,

--- a/src/libp2p/read_write.rs
+++ b/src/libp2p/read_write.rs
@@ -65,8 +65,8 @@ impl<'a, TNow> ReadWrite<'a, TNow> {
     /// Panics if `num` is superior to the size of the available buffer.
     ///
     pub fn advance_read(&mut self, num: usize) {
-        self.read_bytes += num;
         if let Some(ref mut incoming_buffer) = self.incoming_buffer {
+            self.read_bytes += num;
             *incoming_buffer = &incoming_buffer[num..];
         } else {
             assert_eq!(num, 0);

--- a/src/libp2p/read_write.rs
+++ b/src/libp2p/read_write.rs
@@ -91,7 +91,7 @@ impl<'a, TNow> ReadWrite<'a, TNow> {
                 mem::swap(&mut outgoing_buffer.0, &mut outgoing_buffer.1);
             }
         } else {
-            assert_ne!(num, 0);
+            assert_eq!(num, 0);
         }
     }
 

--- a/src/libp2p/read_write.rs
+++ b/src/libp2p/read_write.rs
@@ -20,6 +20,8 @@
 
 use core::{cmp, mem};
 
+// TODO: documentation
+
 #[must_use]
 pub struct ReadWrite<'a, TNow> {
     pub now: TNow,

--- a/src/libp2p/read_write.rs
+++ b/src/libp2p/read_write.rs
@@ -88,7 +88,7 @@ impl<'a, TNow> ReadWrite<'a, TNow> {
             advance_buf(&mut outgoing_buffer.0, cmp::min(num, out_buf_0_len));
             advance_buf(&mut outgoing_buffer.1, num.saturating_sub(out_buf_0_len));
             if outgoing_buffer.0.is_empty() {
-                mem::swap(&mut outgoing_buffer.0, &mut outgoing_buffer.1);
+                mem::swap::<&mut [u8]>(&mut outgoing_buffer.0, &mut outgoing_buffer.1);
             }
         } else {
             assert_eq!(num, 0);

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -1214,16 +1214,12 @@ where
     ///
     /// Panics if `connection_id` isn't a valid connection.
     ///
-    pub async fn read_write<'a>(
+    pub async fn read_write(
         &self,
         connection_id: ConnectionId,
-        now: TNow,
-        incoming_buffer: Option<&[u8]>,
-        outgoing_buffer: (&'a mut [u8], &'a mut [u8]),
-    ) -> Result<ReadWrite<TNow>, peers::ConnectionError> {
-        self.inner
-            .read_write(connection_id, now, incoming_buffer, outgoing_buffer)
-            .await
+        read_write: &'_ mut ReadWrite<'_, TNow>,
+    ) -> Result<peers::ConnectionReadyFuture, peers::ConnectionError> {
+        self.inner.read_write(connection_id, read_write).await
     }
 
     /// Returns an iterator to the list of [`PeerId`]s that we have an established connection

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -1218,7 +1218,7 @@ where
         &self,
         connection_id: ConnectionId,
         read_write: &'_ mut ReadWrite<'_, TNow>,
-    ) -> Result<peers::ConnectionReadyFuture, peers::ConnectionError> {
+    ) -> Result<(), peers::ConnectionError> {
         self.inner.read_write(connection_id, read_write).await
     }
 


### PR DESCRIPTION
Attempt to simplify the logic of the network code by accepting a `&mut ReadWrite` as parameter everywhere, rather than splitting that logic between the function parameter and the return value.

Opening as draft because it panics right now.