### PR TITLE
Remove randomness from health checker

### DIFF
--- a/bin/wasm-node/javascript/demo/demo.js
+++ b/bin/wasm-node/javascript/demo/demo.js
@@ -69,13 +69,20 @@ wsServer.on('request', function (request) {
     let chain;
     if (request.resource == '/relay') {
         chain = client.then(async client => {
+            const healthChecker = smoldot.healthChecker();
+            const relay = await client.addChain({
+                chainSpec,
+                jsonRpcCallback: (resp) => {
+                    const newResp = healthChecker.responsePassThrough(resp);
+                    if (newResp)
+                        connection.sendUTF(newResp);
+                },
+            });
+            healthChecker.setSendJsonRpc(relay.sendJsonRpc);
+            healthChecker.start((health) => console.log(health));
             return {
-                relay: await client.addChain({
-                    chainSpec,
-                    jsonRpcCallback: (resp) => {
-                        connection.sendUTF(resp);
-                    },
-                })
+                healthChecker,
+                relay,
             };
         });
 
@@ -117,7 +124,7 @@ wsServer.on('request', function (request) {
                     if (chain.para)
                         chain.para.sendJsonRpc(message.utf8Data);
                     else
-                        chain.relay.sendJsonRpc(message.utf8Data);
+                        chain.healthChecker.sendJsonRpc(message.utf8Data);
                 })
                 .catch((error) => {
                     console.error("Error during JSON-RPC request: " + error);
@@ -132,6 +139,7 @@ wsServer.on('request', function (request) {
     connection.on('close', function (reasonCode, description) {
         console.log((new Date()) + ' Peer ' + connection.remoteAddress + ' disconnected.');
         chain.then(chain => {
+            chain.healthChecker.stop();
             chain.relay.remove();
             if (chain.para)
                 chain.para.remove();

--- a/bin/wasm-node/javascript/src/health.js
+++ b/bin/wasm-node/javascript/src/health.js
@@ -15,16 +15,18 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import randombytes from 'randombytes';
-
 // Creates a new health checker.
 //
 // The role of the health checker is to report to the user the health of a smoldot chain.
 //
-// In order to use it, start by creating a health checker. The health checker is disabled by
-// default. Use `start()` in order to start the health checks. The `start()` function must be
-// passed a function that the health checker can use to send JSON-RPC requests to the chain, and
-// a callback called when an update to the health of the node is available.
+// In order to use it, start by creating a health checker, and call `setSendJsonRpc` to set the
+// way to send a JSON-RPC request to a chain. The health checker is disabled by default. Use
+// `start()` in order to start the health checks. The `start()` function must be passed a function
+// that the health checker can use to send JSON-RPC requests to the chain, and a callback called
+// when an update to the health of the node is available.
+//
+// In order to send a JSON-RPC request to the chain, you **must** use the `sendJsonRpc` function
+// of the health checker. The health checker rewrites the `id` of the requests it receives.
 //
 // When the chain send a JSON-RPC response, it must be passed to `responsePassThrough()`. This
 // function intercepts the responses destined to the requests that have been emitted by the health
@@ -47,11 +49,18 @@ import randombytes from 'randombytes';
 export function healthChecker() {
     // `null` if health checker is not started.
     let checker = null;
+    let sendJsonRpc = null;
 
     return {
-        start: (sendJsonRpc, healthCallback) => {
+        setSendJsonRpc: (cb) => {
+            sendJsonRpc = cb;
+        },
+
+        start: (healthCallback) => {
             if (checker !== null)
                 throw new Error("Can't start the health checker multiple times in parallel");
+            if (!sendJsonRpc)
+                throw new Error("setSendJsonRpc must be called before starting the health checks");
 
             checker = {
                 healthCallback,
@@ -60,6 +69,24 @@ export function healthChecker() {
                 currentSubunsubRequestId: null,
                 currentSubscriptionId: null,
                 isSyncing: false,
+                nextRequestId: 0,
+
+                sendJsonRpc: function (request) {
+                    // Replace the `id` in the request to prefix the request ID with `extern:`.
+                    let parsedRequest;
+                    try {
+                        parsedRequest = JSON.parse(request);
+                    } catch (err) {
+                        return;
+                    };
+
+                    if (parsedRequest.id) {
+                        const newId = 'extern:' + JSON.stringify(parsedRequest.id);
+                        parsedRequest.id = newId;
+                    }
+
+                    sendJsonRpc(JSON.stringify(parsedRequest));
+                },
 
                 responsePassThrough: function (jsonRpcResponse) {
                     let parsedResponse;
@@ -124,7 +151,15 @@ export function healthChecker() {
                     }
 
                     // Response doesn't concern us.
-                    return jsonRpcResponse;
+                    if (parsedResponse.id) {
+                        // Need to remove the `extern:` prefix.
+                        if (!parsedResponse.id.startsWith('extern:'))
+                            throw new Error('State inconsistency in health checker');
+                        const newId = JSON.parse(parsedResponse.id.slice('extern:'.length));
+                        parsedResponse.id = newId;
+                    }
+
+                    return JSON.stringify(parsedResponse);
                 },
 
                 update: function () {
@@ -148,7 +183,8 @@ export function healthChecker() {
                         clearTimeout(this.currentHealthTimeout);
                         this.currentHealthTimeout = null;
                     }
-                    this.currentHealthCheckId = randombytes(32).toString('base64');
+                    this.currentHealthCheckId = "health-checker:" + this.nextRequestId;
+                    this.nextRequestId += 1;
                     sendJsonRpc(JSON.stringify({
                         jsonrpc: "2.0",
                         id: this.currentHealthCheckId,
@@ -160,7 +196,8 @@ export function healthChecker() {
                 startSubscription: function () {
                     if (this.currentSubunsubRequestId || this.currentSubscriptionId)
                         throw new Error('Internal error in health checker');
-                    this.currentSubunsubRequestId = randombytes(32).toString('base64');
+                    this.currentSubunsubRequestId = "health-checker:" + this.nextRequestId;
+                    this.nextRequestId += 1;
                     sendJsonRpc(JSON.stringify({
                         jsonrpc: "2.0",
                         id: this.currentSubunsubRequestId,
@@ -172,7 +209,8 @@ export function healthChecker() {
                 endSubscription: function () {
                     if (this.currentSubunsubRequestId || !this.currentSubscriptionId)
                         throw new Error('Internal error in health checker');
-                    this.currentSubunsubRequestId = randombytes(32).toString('base64');
+                    this.currentSubunsubRequestId = "health-checker:" + this.nextRequestId;
+                    this.nextRequestId += 1;
                     sendJsonRpc(JSON.stringify({
                         jsonrpc: "2.0",
                         id: this.currentSubunsubRequestId,
@@ -196,6 +234,14 @@ export function healthChecker() {
                 return; // Already stopped.
             checker.destroy();
             checker = null;
+        },
+        sendJsonRpc: (request) => {
+            if (!sendJsonRpc)
+                throw new Error("setSendJsonRpc must be called before sending requests");
+            if (checker === null)
+                sendJsonRpc(request);
+            else
+                checker.sendJsonRpc(request);
         },
         responsePassThrough: (jsonRpcResponse) => {
             if (checker === null)

--- a/bin/wasm-node/javascript/src/index.d.ts
+++ b/bin/wasm-node/javascript/src/index.d.ts
@@ -53,8 +53,10 @@ export interface SmoldotHealth {
 }
 
 export interface HealthChecker {
-  start(sendRequest: (request: string) => void, healthCallback: (health: SmoldotHealth) => void): void;
+  setSendJsonRpc(sendRequest: (request: string) => void): void;
+  start(healthCallback: (health: SmoldotHealth) => void): void;
   stop(): void;
+  sendJsonRpc(request: string): void;
   responsePassThrough(response: string): string | null;
 }
 


### PR DESCRIPTION
Apparently, importing `randombytes` from the health checker causes issues with some JS thing somewhere, so for the sake of making things move we'll remove this import.

Consequently, the API of the health checker needs to change:

- You no longer need to pass the `sendJsonRpc` function to the `start()` method, but instead pass it to a new `setSendJsonRpc()` method. Call `setSendJsonRpc()` right after initializing the health checker.
- You **must** now use `sendJsonRpc` on the health checker, which modifies it and propagates it to the callback that you passed to `setSendJsonRpc`. Do **not** call `sendJsonRpc` directly on the smoldot chain.

The rest stays the same.

**I also would like to remind that the health checker is documented** as comments to the `healthChecker` function.

I modified `demo.js` in the first commit, in order to showcase how to use the API. The second commit reverts these changes.
