### PR TITLE
Add extra checks for string functions

### DIFF
--- a/bin/wasm-node/javascript/src/health.js
+++ b/bin/wasm-node/javascript/src/health.js
@@ -155,8 +155,11 @@ export function healthChecker() {
                         // Need to remove the `extern:` prefix.
                         if (typeof parsedResponse.id === 'string' && !parsedResponse.id.startsWith('extern:'))
                             throw new Error('State inconsistency in health checker');
-                        const newId = JSON.parse(typeof parsedResponse.id === 'string' ? parsedResponse.id.slice('extern:'.length) : parsedResponse.id);
-                        console.log('newId is', newId);
+                        const newId = JSON.parse(
+                          typeof parsedResponse.id === 'string' ?
+                          parsedResponse.id.slice('extern:'.length) :
+                          parsedResponse.id
+                        );
                         parsedResponse.id = newId;
                     }
 

--- a/bin/wasm-node/javascript/src/health.js
+++ b/bin/wasm-node/javascript/src/health.js
@@ -153,9 +153,10 @@ export function healthChecker() {
                     // Response doesn't concern us.
                     if (parsedResponse.id) {
                         // Need to remove the `extern:` prefix.
-                        if (!parsedResponse.id.startsWith('extern:'))
+                        if (typeof parsedResponse.id === 'string' && !parsedResponse.id.startsWith('extern:'))
                             throw new Error('State inconsistency in health checker');
-                        const newId = JSON.parse(parsedResponse.id.slice('extern:'.length));
+                        const newId = JSON.parse(typeof parsedResponse.id === 'string' ? parsedResponse.id.slice('extern:'.length) : parsedResponse.id);
+                        console.log('newId is', newId);
                         parsedResponse.id = newId;
                     }
 


### PR DESCRIPTION
Add check for parsedResponse type before executing string functions.
Without these - in case that parsedResponse.id is not a string the following error occurs:
`parsedResponse.id.startsWith is not a function` and `parsedResponse.id.slice is not a function`