### PR TITLE
Silence a state mismatch in established.rs

### DIFF
--- a/src/libp2p/connection/established.rs
+++ b/src/libp2p/connection/established.rs
@@ -784,7 +784,7 @@ where
                     user_data,
                 }
             }
-            _ => panic!(),
+            _ => return, // TODO: too defensive, should be panic!()
         }
     }
 


### PR DESCRIPTION
This ignores a panic in established.rs. The higher level API needs adjustments to fix this properly.