### PR TITLE
Increase JS tests timeout to 2 minutes

### DIFF
--- a/bin/wasm-node/javascript/package.json
+++ b/bin/wasm-node/javascript/package.json
@@ -19,7 +19,7 @@
     "prepublishOnly": "node prepare.js --release",
     "build": "node prepare.js --release",
     "start": "node prepare.js --debug && node demo/demo.js",
-    "test": "node prepare.js --debug && dtslint src/ && ava"
+    "test": "node prepare.js --debug && dtslint src/ && ava --timeout=2m"
   },
   "browser": {
     "./src/compat-nodejs.js": "./src/compat-browser.js"


### PR DESCRIPTION
The tests seem to time out quite often on CI, so let's increase the timeout.