### PR TITLE
Refactor collection.rs to identify notif substreams by id

### DIFF
--- a/src/libp2p/connection/established.rs
+++ b/src/libp2p/connection/established.rs
@@ -829,6 +829,18 @@ where
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SubstreamId(yamux::SubstreamId);
 
+impl SubstreamId {
+    /// Returns the value that compares inferior or equal to all possible values.
+    pub fn min_value() -> Self {
+        Self(yamux::SubstreamId::min_value())
+    }
+
+    /// Returns the value that compares superior or equal to all possible values.
+    pub fn max_value() -> Self {
+        Self(yamux::SubstreamId::max_value())
+    }
+}
+
 /// Event that happened on the connection. See [`Established::read_write`].
 #[must_use]
 #[derive(Debug)]

--- a/src/libp2p/connection/yamux.rs
+++ b/src/libp2p/connection/yamux.rs
@@ -1054,6 +1054,18 @@ impl AsRef<[u8]> for VecWithOffset {
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, derive_more::From)]
 pub struct SubstreamId(NonZeroU32);
 
+impl SubstreamId {
+    /// Returns the value that compares inferior or equal to all possible values.
+    pub fn min_value() -> Self {
+        Self(NonZeroU32::new(1).unwrap())
+    }
+
+    /// Returns the value that compares superior or equal to all possible values.
+    pub fn max_value() -> Self {
+        Self(NonZeroU32::new(u32::max_value()).unwrap())
+    }
+}
+
 #[must_use]
 #[derive(Debug)]
 pub struct IncomingDataOutcome<T> {

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -596,7 +596,11 @@ where
                         .peers_notifications_in
                         .insert((peer_index, notifications_protocol_index))
                     {
-                        todo!() // TODO:
+                        // TODO: future cancellation issue
+                        let _ = self
+                            .inner
+                            .reject_notifications_in(connection_id, substream_id)
+                            .await;
                     }
 
                     let desired_notif_id =


### PR DESCRIPTION
At the moment, collection.rs's API identifies substreams by `(ConnectionId, notif protocol)` and enforces that only a single substream is open per connection per protocol.
However the implementation of `peers.rs` already enforces this, making the check in collection.rs redundant.

After this PR, collection.rs now accepts multiple substreams per connection per protocol.

This also fixes a race condition regarding `in_notification_accept` in collection.rs that could be ambiguous, and adds `in_notification_reject`, which wasn't possible to do properly before.
