### PR TITLE
Run fetching para heads in parallel from service

### DIFF
--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -112,19 +112,30 @@ impl SyncService {
         let (to_background, from_foreground) = mpsc::channel(16);
 
         if let Some(config_parachain) = config.parachain {
+            let (send_new_best, para_new_best) = mpsc::channel(0);
+
             (config.tasks_executor)(
-                "sync-relay".into(),
+                "sync-para-fetch".into(),
+                Box::pin(fetch_paraheads(
+                    config_parachain.relay_chain_sync.clone(),
+                    config_parachain.parachain_id,
+                    send_new_best,
+                )),
+            );
+
+            (config.tasks_executor)(
+                "sync-para".into(),
                 Box::pin(start_parachain(
                     config.chain_information,
                     from_foreground,
                     config.network_service.1,
                     config.network_events_receiver,
-                    config_parachain,
+                    para_new_best,
                 )),
             );
         } else {
             (config.tasks_executor)(
-                "sync-para".into(),
+                "sync-relay".into(),
                 Box::pin(
                     start_relay_chain(
                         config.chain_information,
@@ -1300,16 +1311,9 @@ async fn start_parachain(
     mut from_foreground: mpsc::Receiver<ToBackground>,
     network_chain_index: usize,
     mut from_network_service: mpsc::Receiver<network_service::Event>,
-    parachain_config: ConfigParachain,
+    mut para_new_best: mpsc::Receiver<(header::Header, bool)>,
 ) {
     // TODO: handle finality as well; this is semi-complicated because the runtime service needs to provide a way to call a function on the finalized block's runtime
-
-    let relay_best_blocks = {
-        let (relay_best_block_header, relay_best_blocks_subscription) =
-            parachain_config.relay_chain_sync.subscribe_best().await;
-        stream::once(future::ready(relay_best_block_header)).chain(relay_best_blocks_subscription)
-    };
-    futures::pin_mut!(relay_best_blocks);
 
     let current_finalized_block: header::Header =
         chain_information.as_ref().finalized_block_header.into(); // TODO: finality not implemented
@@ -1318,16 +1322,16 @@ async fn start_parachain(
     // List of senders that get notified when the best block is modified.
     let mut best_subscriptions = Vec::<lossy_channel::Sender<_>>::new();
 
-    // Hash of the head data of the best block of the parachain. `None` if no head data obtained
-    // yet. Used to avoid sending out notifications if the head data hasn't changed.
-    let mut previous_best_head_data_hash = None::<[u8; 32]>;
-
     // State machine that tracks the list of sources and their blocks.
     // TODO: need to call sync_sources.set_finalized_block_height once finalization is implemented
     let mut sync_sources =
         sources::AllForksSources::<PeerId>::new(40, current_finalized_block.number);
     // Maps `PeerId`s to their indices within `sync_sources`.
     let mut sync_sources_map = HashMap::new();
+
+    // `true` after a parachain block has been fetched from the parachain.
+    // TODO: logic not really correct, as need to check whether relay chain is near head of chain too
+    let mut is_near_head_of_chain = false;
 
     loop {
         futures::select! {
@@ -1345,8 +1349,7 @@ async fn start_parachain(
 
                 match message {
                     ToBackground::IsNearHeadOfChainHeuristic { send_back } => {
-                        // TODO: that doesn't seem totally correct
-                        let _ = send_back.send(previous_best_head_data_hash.is_some());
+                        let _ = send_back.send(is_near_head_of_chain);
                     },
                     ToBackground::SubscribeFinalized { send_back } => {
                         let (tx, rx) = lossy_channel::channel();
@@ -1427,103 +1430,138 @@ async fn start_parachain(
                         // Uninteresting message or irrelevant chain index.
                     }
                 }
-
-                continue;
             }
 
-            _relay_best_block = relay_best_blocks.next().fuse() => {
-                // This block is triggered on a new best block, but it is only used to detect when
-                // to refresh the local state, and the content of the block itself isn't important.
-                // Purging any other pending block from the best block subscription so as to not
-                // accidentally call this block multiple times.
-                while let Some(_) = relay_best_blocks.next().now_or_never() {}
+            para_new_best = para_new_best.next().fuse() => {
+                let (para_new_best, relay_sync_near_head_of_chain) = para_new_best.unwrap();
+                is_near_head_of_chain = relay_sync_near_head_of_chain;
+                current_best_block = para_new_best.clone();
 
-                // Determine if the call to `recent_best_block_runtime_call` in the `parahead`
-                // function applies to a block that is near the head of the chain.
-                let relay_sync_near_head_of_chain =
-                    parachain_config.relay_chain_sync.is_near_head_of_chain_heuristic().await;
-
-                // Do the actual runtime call to obtain the parahead.
-                // Even if there isn't any bug, the runtime call can likely fail because the relay
-                // chain block has already been pruned from the network. This isn't a severe
-                // error.
-                let encoded_head_data = match parahead(&parachain_config.relay_chain_sync, parachain_config.parachain_id).await {
-                    Ok(v) => v,
-                    Err(err) => {
-                        previous_best_head_data_hash = None;
-                        if err.is_network_problem() {
-                            log::debug!(target: "sync-verify", "Failed to get chain heads: {}", err);
-                        } else {
-                            log::warn!(target: "sync-verify", "Failed to get chain heads: {}", err);
-                        }
-                        continue;
-                    }
-                };
-
-                // Try decode the result of the runtime call.
-                // If this fails, it indicates an incompatibility between smoldot and the relay
-                // chain.
-                let head_data =
-                    match para::decode_persisted_validation_data_return_value(&encoded_head_data) {
-                        Ok(Some(pvd)) => pvd.parent_head,
-                        Ok(None) => {
-                            // `Ok(None)` indicates that the parachain doesn't occupy any core
-                            // on the relay chain at the latest block that the relay chain syncing
-                            // has synced. It might have occupied a core before, or might occupy
-                            // a core in the future, and as such this is not a fatal error.
-                            log::log!(
-                                target: "sync-verify",
-                                if relay_sync_near_head_of_chain { log::Level::Warn }
-                                    else { log::Level::Debug },
-                                "Couldn't find the parachain head from relay chain. \
-                                The parachain likely doesn't occupy a core."
-                            );
-                            continue;
-                        }
-                        Err(error) => {
-                            // Only a debug line is printed if not near the head of the chain,
-                            // to handle chains that have been upgraded later on to support
-                            // parachains later.
-                            log::log!(
-                                target: "sync-verify",
-                                if relay_sync_near_head_of_chain { log::Level::Error }
-                                    else { log::Level::Debug },
-                                "Failed to fetch the parachain head from relay chain: {}",
-                                error
-                            );
-                            continue;
-                        }
-                    };
-
-                // Don't do anything more if the head data matches
-                // `previous_best_head_data_hash`.
-                match (&mut previous_best_head_data_hash, blake2b(32, &[], &head_data)) {
-                    (&mut Some(ref mut h1), h2) if *h1 == h2.as_bytes() => continue,
-                    (h1 @ _, h2) => *h1 = Some(<[u8; 32]>::try_from(h2.as_bytes()).unwrap()),
-                };
-
-                // The meaning of `head_data` depends on the parachain. It can represent
-                // anything. In practice, however, it is most of the time a block header.
-                match header::decode(&head_data) {
-                    Ok(header) => {
-                        current_best_block = header.into();
-
-                        // Elements in `best_subscriptions` are removed one by one and inserted
-                        // back if the channel is still open.
-                        for index in (0..best_subscriptions.len()).rev() {
-                            let mut sender = best_subscriptions.swap_remove(index);
-                            if sender.send(head_data.to_vec()).is_ok() {
-                                best_subscriptions.push(sender);
-                            }
-                        }
-                    }
-                    Err(_) => {
-                        log::warn!(
-                            target: "sync-verify",
-                            "Head data is not a block header. This isn't supported by smoldot."
-                        );
+                // Elements in `best_subscriptions` are removed one by one and inserted
+                // back if the channel is still open.
+                for index in (0..best_subscriptions.len()).rev() {
+                    let mut sender = best_subscriptions.swap_remove(index);
+                    if sender.send(para_new_best.scale_encoding_vec()).is_ok() {
+                        best_subscriptions.push(sender);
                     }
                 }
+            }
+        }
+    }
+}
+
+async fn fetch_paraheads(
+    relay_chain_sync: Arc<runtime_service::RuntimeService>,
+    parachain_id: u32,
+    mut send_new_best: mpsc::Sender<(header::Header, bool)>,
+) {
+    // Stream of new best blocks of the relay chain this parachain is registered on.
+    let relay_best_blocks = {
+        let (relay_best_block_header, relay_best_blocks_subscription) =
+            relay_chain_sync.subscribe_best().await;
+        stream::once(future::ready(relay_best_block_header)).chain(relay_best_blocks_subscription)
+    };
+    futures::pin_mut!(relay_best_blocks);
+
+    // Hash of the head data of the best block of the parachain. `None` if no head data obtained
+    // yet. Used to avoid sending out notifications if the head data hasn't changed.
+    let mut previous_best_head_data_hash = None::<[u8; 32]>;
+
+    loop {
+        // Wait for a new best block before continuing.
+        match relay_best_blocks.next().await {
+            Some(_) => {}
+            None => break,
+        };
+
+        // This block is triggered on a new best block, but it is only used to detect when
+        // to refresh the local state, and the content of the block itself isn't important.
+        // Purging any other pending block from the best block subscription so as to not
+        // accidentally call this block multiple times.
+        while let Some(_) = relay_best_blocks.next().now_or_never() {}
+
+        // Determine if the call to `recent_best_block_runtime_call` in the `parahead`
+        // function applies to a block that is near the head of the chain.
+        let relay_sync_near_head_of_chain =
+            relay_chain_sync.is_near_head_of_chain_heuristic().await;
+
+        // Do the actual runtime call to obtain the parahead.
+        // Even if there isn't any bug, the runtime call can likely fail because the relay
+        // chain block has already been pruned from the network. This isn't a severe
+        // error.
+        let encoded_head_data = match parahead(&relay_chain_sync, parachain_id).await {
+            Ok(v) => v,
+            Err(err) => {
+                previous_best_head_data_hash = None;
+                if err.is_network_problem() {
+                    log::debug!(target: "sync-verify", "Failed to get chain heads: {}", err);
+                } else {
+                    log::warn!(target: "sync-verify", "Failed to get chain heads: {}", err);
+                }
+                continue;
+            }
+        };
+
+        // Try decode the result of the runtime call.
+        // If this fails, it indicates an incompatibility between smoldot and the relay
+        // chain.
+        let head_data =
+            match para::decode_persisted_validation_data_return_value(&encoded_head_data) {
+                Ok(Some(pvd)) => pvd.parent_head,
+                Ok(None) => {
+                    // `Ok(None)` indicates that the parachain doesn't occupy any core
+                    // on the relay chain at the latest block that the relay chain syncing
+                    // has synced. It might have occupied a core before, or might occupy
+                    // a core in the future, and as such this is not a fatal error.
+                    log::log!(
+                        target: "sync-verify",
+                        if relay_sync_near_head_of_chain { log::Level::Warn }
+                            else { log::Level::Debug },
+                        "Couldn't find the parachain head from relay chain. \
+                        The parachain likely doesn't occupy a core."
+                    );
+                    continue;
+                }
+                Err(error) => {
+                    // Only a debug line is printed if not near the head of the chain,
+                    // to handle chains that have been upgraded later on to support
+                    // parachains later.
+                    log::log!(
+                        target: "sync-verify",
+                        if relay_sync_near_head_of_chain { log::Level::Error }
+                            else { log::Level::Debug },
+                        "Failed to fetch the parachain head from relay chain: {}",
+                        error
+                    );
+                    continue;
+                }
+            };
+
+        // Don't do anything more if the head data matches
+        // `previous_best_head_data_hash`.
+        match (
+            &mut previous_best_head_data_hash,
+            blake2b(32, &[], &head_data),
+        ) {
+            (&mut Some(ref mut h1), h2) if *h1 == h2.as_bytes() => continue,
+            (h1 @ _, h2) => *h1 = Some(<[u8; 32]>::try_from(h2.as_bytes()).unwrap()),
+        };
+
+        // The meaning of `head_data` depends on the parachain. It can represent
+        // anything. In practice, however, it is most of the time a block header.
+        match header::decode(&head_data) {
+            Ok(header) => match send_new_best
+                .send((header.into(), relay_sync_near_head_of_chain))
+                .await
+            {
+                Ok(()) => {}
+                Err(_) => return,
+            },
+            Err(_) => {
+                log::warn!(
+                    target: "sync-verify",
+                    "Head data is not a block header. This isn't supported by smoldot."
+                );
             }
         }
     }


### PR DESCRIPTION
Before this PR, answering `system_health` and `system_peers` can take several seconds because the sync service is stuck waiting for a networking response.