### PR TITLE
Use a BTreeMap for the storage diffs

### DIFF
--- a/src/author/runtime.rs
+++ b/src/author/runtime.rs
@@ -54,7 +54,7 @@ use crate::{
     util,
 };
 
-use alloc::{borrow::ToOwned as _, string::String, vec::Vec};
+use alloc::{borrow::ToOwned as _, collections::BTreeMap, string::String, vec::Vec};
 use core::{iter, mem};
 use hashbrown::HashMap;
 
@@ -102,7 +102,7 @@ pub struct Success {
     /// Runtime that was passed by [`Config`].
     pub parent_runtime: host::HostVmPrototype,
     /// List of changes to the storage top trie that the block performs.
-    pub storage_top_trie_changes: HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
+    pub storage_top_trie_changes: BTreeMap<Vec<u8>, Option<Vec<u8>>>,
     /// List of changes to the offchain storage that this block performs.
     pub offchain_storage_changes: HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
     /// Cache used for calculating the top trie root of the new block.
@@ -472,7 +472,7 @@ enum Stage {
 pub struct InherentExtrinsics {
     shared: Shared,
     parent_runtime: host::HostVmPrototype,
-    storage_top_trie_changes: HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
+    storage_top_trie_changes: BTreeMap<Vec<u8>, Option<Vec<u8>>>,
     offchain_storage_changes: HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
     top_trie_root_calculation_cache: calculate_root::CalculationCache,
 }
@@ -607,7 +607,7 @@ pub enum InherentDataConsensus {
 pub struct ApplyExtrinsic {
     shared: Shared,
     parent_runtime: host::HostVmPrototype,
-    storage_top_trie_changes: HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
+    storage_top_trie_changes: BTreeMap<Vec<u8>, Option<Vec<u8>>>,
     offchain_storage_changes: HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
     top_trie_root_calculation_cache: calculate_root::CalculationCache,
 }

--- a/src/chain/blocks_tree/verify.rs
+++ b/src/chain/blocks_tree/verify.rs
@@ -30,6 +30,7 @@ use crate::{
 
 use super::*;
 
+use alloc::collections::BTreeMap;
 use core::cmp::Ordering;
 
 impl<T> NonFinalizedTree<T> {
@@ -697,7 +698,7 @@ pub enum BodyVerifyStep2<T> {
         /// been modified. Contains the new runtime.
         new_runtime: Option<host::HostVmPrototype>,
         /// List of changes to the storage top trie that the block performs.
-        storage_top_trie_changes: HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
+        storage_top_trie_changes: BTreeMap<Vec<u8>, Option<Vec<u8>>>,
         /// List of changes to the offchain storage that this block performs.
         offchain_storage_changes: HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
         /// Cache of calculation for the storage trie of the best block.

--- a/src/sync/optimistic.rs
+++ b/src/sync/optimistic.rs
@@ -217,7 +217,7 @@ pub struct Block<TBl> {
     pub justification: Option<Vec<u8>>,
 
     /// Changes to the storage made by this block compared to its parent.
-    pub storage_top_trie_changes: HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
+    pub storage_top_trie_changes: BTreeMap<Vec<u8>, Option<Vec<u8>>>,
 
     /// List of changes to the offchain storage that this block performs.
     pub offchain_storage_changes: HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,

--- a/src/transactions/validate.rs
+++ b/src/transactions/validate.rs
@@ -22,7 +22,7 @@ use crate::{
     header, util,
 };
 
-use alloc::{borrow::ToOwned as _, vec::Vec};
+use alloc::{borrow::ToOwned as _, collections::BTreeMap, vec::Vec};
 use core::{iter, num::NonZeroU64};
 
 /// Configuration for a transaction validation process.
@@ -322,10 +322,7 @@ pub fn validate_transaction(
                 }
                 .scale_encoding(),
                 top_trie_root_calculation_cache: None,
-                storage_top_trie_changes: hashbrown::HashMap::with_capacity_and_hasher(
-                    64, // Rough estimate.
-                    Default::default(),
-                ),
+                storage_top_trie_changes: BTreeMap::new(),
                 offchain_storage_changes: hashbrown::HashMap::default(),
             });
 
@@ -361,7 +358,7 @@ pub fn validate_transaction(
                     &header::hash_from_scale_encoded_header(config.scale_encoded_header),
                 ),
                 top_trie_root_calculation_cache: None,
-                storage_top_trie_changes: hashbrown::HashMap::default(),
+                storage_top_trie_changes: BTreeMap::default(),
                 offchain_storage_changes: hashbrown::HashMap::default(),
             });
 

--- a/src/verify/execute_block.rs
+++ b/src/verify/execute_block.rs
@@ -46,7 +46,7 @@ use crate::{
     util,
 };
 
-use alloc::{string::String, vec::Vec};
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
 use core::iter;
 use hashbrown::HashMap;
 
@@ -77,7 +77,7 @@ pub struct Success {
     /// Runtime that was passed by [`Config`].
     pub parent_runtime: host::HostVmPrototype,
     /// List of changes to the storage top trie that the block performs.
-    pub storage_top_trie_changes: HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
+    pub storage_top_trie_changes: BTreeMap<Vec<u8>, Option<Vec<u8>>>,
     /// List of changes to the offchain storage that this block performs.
     pub offchain_storage_changes: HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
     /// Cache used for calculating the top trie root.

--- a/src/verify/header_body.rs
+++ b/src/verify/header_body.rs
@@ -24,7 +24,7 @@ use crate::{
     verify::{aura, babe},
 };
 
-use alloc::{string::String, vec::Vec};
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
 use core::{num::NonZeroU64, time::Duration};
 use hashbrown::HashMap;
 
@@ -116,7 +116,7 @@ pub struct Success {
     pub consensus: SuccessConsensus,
 
     /// List of changes to the storage top trie that the block performs.
-    pub storage_top_trie_changes: HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
+    pub storage_top_trie_changes: BTreeMap<Vec<u8>, Option<Vec<u8>>>,
 
     /// List of changes to the offchain storage that this block performs.
     pub offchain_storage_changes: HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,


### PR DESCRIPTION
Before this PR, the full node syncing is stuck at block 4876134 because block 4876135 does a lot of `NextKey` requests, which have a crazy `O(n)` complexity (`n` being the size of the storage diff, which increases over time during execution of block 4876135).

This slows down the rest of the syncing quite a bit, but it makes block 4876135 sync almost instantaneously while before it would be stuck for hours.
