### PR TITLE
Revert "Properly return only the peers belonging to the chain (#1318)"

### DIFF
--- a/bin/wasm-node/rust/src/network_service.rs
+++ b/bin/wasm-node/rust/src/network_service.rs
@@ -605,7 +605,7 @@ impl NetworkService {
 
         // TODO: keep track of which peer knows about which transaction, and don't send it again
 
-        for target in self.peers_list(chain_index).await {
+        for target in self.peers_list().await {
             if self
                 .network
                 .announce_transaction(&target, chain_index, &transaction)
@@ -621,8 +621,8 @@ impl NetworkService {
 
     /// Returns an iterator to the list of [`PeerId`]s that we have an established connection
     /// with.
-    pub async fn peers_list(&self, chain_index: usize) -> impl Iterator<Item = PeerId> {
-        self.network.peers_list(chain_index).await
+    pub async fn peers_list(&self) -> impl Iterator<Item = PeerId> {
+        self.network.peers_list().await
     }
 }
 

--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -318,12 +318,7 @@ impl SyncService {
 
         // TODO: better peers selection ; don't just take the first 3
         // TODO: must only ask the peers that know about this block
-        for target in self
-            .network_service
-            .peers_list(self.network_chain_index)
-            .await
-            .take(NUM_ATTEMPTS)
-        {
+        for target in self.network_service.peers_list().await.take(NUM_ATTEMPTS) {
             let mut result = match self
                 .network_service
                 .clone()
@@ -403,12 +398,7 @@ impl SyncService {
 
         // TODO: better peers selection ; don't just take the first 3
         // TODO: must only ask the peers that know about this block
-        for target in self
-            .network_service
-            .peers_list(self.network_chain_index)
-            .await
-            .take(NUM_ATTEMPTS)
-        {
+        for target in self.network_service.peers_list().await.take(NUM_ATTEMPTS) {
             let result = self
                 .network_service
                 .clone()

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -1206,27 +1206,18 @@ where
             .into_iter()
     }
 
-    /// Returns an iterator to the list of [`PeerId`]s we have an outgoing notifications
-    /// substream with.
-    ///
-    /// > **Note**: This method is subject to race conditions if other methods, such as
-    /// >           [`Peers::read_write`], are called simultaneously.
-    pub async fn outgoing_substreams(
-        &self,
-        notifications_protocol_index: usize,
-    ) -> impl Iterator<Item = PeerId> {
+    /// Returns the number of connections we have a substream with.
+    pub async fn num_outgoing_substreams(&self, notifications_protocol_index: usize) -> usize {
         let guarded = self.guarded.lock().await;
         // TODO: O(n)
-        let list = guarded
+        guarded
             .peers_notifications_out
             .iter()
             .filter(|((_, idx), state)| {
                 *idx == notifications_protocol_index
                     && matches!(state.open, NotificationsOutOpenState::Open(_, _))
             })
-            .map(|((peer_index, _), _)| guarded.peers[*peer_index].peer_id.clone())
-            .collect::<Vec<_>>();
-        list.into_iter()
+            .count()
     }
 
     /// Picks the connection to use to send requests or notifications to the given peer.

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -437,28 +437,13 @@ where
     // TODO: note about race
     pub async fn num_established_connections(&self) -> usize {
         // TODO: better impl
-        self.inner.peers_list().await.count()
+        self.peers_list().await.count()
     }
 
     /// Returns the number of peers we have a substream with.
-    ///
-    /// > **Note**: This method is subject to race conditions if other methods, such as
-    /// >           [`ChainNetwork::read_write`], are called simultaneously.
     pub async fn num_peers(&self, chain_index: usize) -> usize {
         self.inner
-            .outgoing_substreams(self.protocol_index(chain_index, 0))
-            .await
-            .count()
-    }
-
-    /// Returns an iterator to the list of [`PeerId`]s that we have a chain connection
-    /// with.
-    ///
-    /// > **Note**: This method is subject to race conditions if other methods, such as
-    /// >           [`ChainNetwork::read_write`], are called simultaneously.
-    pub async fn peers_list(&self, chain_index: usize) -> impl Iterator<Item = PeerId> {
-        self.inner
-            .outgoing_substreams(self.protocol_index(chain_index, 0))
+            .num_outgoing_substreams(self.protocol_index(chain_index, 0))
             .await
     }
 
@@ -1491,6 +1476,12 @@ where
         read_write: &'_ mut ReadWrite<'_, TNow>,
     ) -> Result<(), peers::ConnectionError> {
         self.inner.read_write(connection_id, read_write).await
+    }
+
+    /// Returns an iterator to the list of [`PeerId`]s that we have an established connection
+    /// with.
+    pub async fn peers_list(&self) -> impl Iterator<Item = PeerId> {
+        self.inner.peers_list().await
     }
 }
 


### PR DESCRIPTION
This reverts commit 65d5ddac4c0305fee031cf738bc3d432f8963c4f.

There are connectivity issues that first need to be solved.