### PR TITLE
Properly select requests to start

### DIFF
--- a/bin/wasm-node/rust/src/sync_service.rs
+++ b/bin/wasm-node/rust/src/sync_service.rs
@@ -35,7 +35,6 @@ use futures::{
     lock::Mutex,
     prelude::*,
 };
-use rand::seq::IteratorRandom as _;
 use smoldot::{
     chain,
     executor::{host, read_only_runtime_host},
@@ -732,19 +731,17 @@ async fn start_relay_chain(
 
         // Main loop of the syncing logic.
         loop {
-            // Drain the content of `requests_to_start` to actually start the requests that have
-            // been queued by the previous iteration of the main loop.
-            //
-            // Note that the code below assumes that the `source_id`s found in `requests_to_start`
-            // still exist. This is only guaranteed to be case because we process
-            // `requests_to_start` as soon as an entry is added and before disconnect events can
-            // remove sources from the state machine.
             loop {
-                let (source_id, mut request_detail) =
-                    match sync.desired_requests().choose(&mut rand::thread_rng()) {
-                        Some(v) => v,
-                        None => break,
-                    };
+                // `desired_requests()` returns, in decreasing order of priority, the requests
+                // that should be started in order for the syncing to proceed. We simply pick the
+                // first request, but enforce one ongoing request per source.
+                let (source_id, _, mut request_detail) = match sync
+                    .desired_requests()
+                    .find(|(source_id, _, _)| sync.source_num_ongoing_requests(*source_id) == 0)
+                {
+                    Some(v) => v,
+                    None => break,
+                };
 
                 // Before notifying the syncing of the request, clamp the number of blocks to the
                 // number of blocks we expect to receive.

--- a/src/sync/all_forks/pending_blocks.rs
+++ b/src/sync/all_forks/pending_blocks.rs
@@ -388,6 +388,21 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
         self.sources.best_block(source_id)
     }
 
+    /// Returns the number of ongoing requests that concern this source.
+    ///
+    /// # Panic
+    ///
+    /// Panics if the [`SourceId`] is invalid.
+    ///
+    pub fn source_num_ongoing_requests(&self, source_id: SourceId) -> usize {
+        self.source_occupations
+            .range(
+                (source_id, RequestId(usize::min_value()))
+                    ..=(source_id, RequestId(usize::max_value())),
+            )
+            .count()
+    }
+
     /// Returns the list of sources for which [`PendingBlocks::source_knows_non_finalized_block`]
     /// would return `true`.
     ///
@@ -928,13 +943,6 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
 
                         DesiredRequest {
                             source_id,
-                            source_num_existing_requests: self
-                                .source_occupations
-                                .range(
-                                    (source_id, RequestId(usize::min_value()))
-                                        ..=(source_id, RequestId(usize::max_value())),
-                                )
-                                .count(),
                             request_params: RequestParams {
                                 first_block_hash: *unknown_block_hash,
                                 first_block_height: unknown_block_height,
@@ -954,8 +962,6 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
 pub struct DesiredRequest {
     /// Source onto which to start this request.
     pub source_id: SourceId,
-    /// Number of requests that the source is already performing.
-    pub source_num_existing_requests: usize,
     /// Details of the request.
     pub request_params: RequestParams,
 }

--- a/src/sync/optimistic.rs
+++ b/src/sync/optimistic.rs
@@ -415,6 +415,26 @@ impl<TRq, TSrc, TBl> OptimisticSync<TRq, TSrc, TBl> {
         &mut self.inner.sources.get_mut(&source_id).unwrap().user_data
     }
 
+    /// Returns the number of ongoing requests that concern this source.
+    ///
+    /// # Panic
+    ///
+    /// Panics if the [`SourceId`] is invalid.
+    ///
+    pub fn source_num_ongoing_requests(&self, source_id: SourceId) -> usize {
+        let num_obsolete = self
+            .inner
+            .obsolete_requests
+            .values()
+            .filter(|(id, _)| *id == source_id)
+            .count();
+        let num_regular = self
+            .inner
+            .verification_queue
+            .source_num_ongoing_requests(source_id);
+        num_obsolete + num_regular
+    }
+
     /// Returns an iterator that yields all the requests whose outcome is no longer desired.
     pub fn obsolete_requests(&'_ self) -> impl Iterator<Item = (RequestId, &'_ TRq)> + '_ {
         self.inner

--- a/src/sync/optimistic/verification_queue.rs
+++ b/src/sync/optimistic/verification_queue.rs
@@ -374,6 +374,17 @@ impl<TRq, TBl> VerificationQueue<TRq, TBl> {
             source_id,
         }
     }
+
+    /// Returns the number of ongoing requests that concern this source.
+    pub fn source_num_ongoing_requests(&self, source_id: SourceId) -> usize {
+        self.verification_queue
+            .iter()
+            .filter(|elem| match elem.ty {
+                VerificationQueueEntryTy::Requested { source, .. } if source == source_id => true,
+                _ => false,
+            })
+            .count()
+    }
 }
 
 /// See [`VerificationQueue::drain_source`].


### PR DESCRIPTION
Close https://github.com/paritytech/smoldot/issues/306

After this PR, neither `all_forks` nor `optimistic` enforce one request per peer. Instead, it is the `sync_service` that does that by calling a new `source_num_ongoing_requests` method.
