### PR TITLE
Allow more ASCII characters in chain name

### DIFF
--- a/bin/wasm-node/rust/src/lib.rs
+++ b/bin/wasm-node/rust/src/lib.rs
@@ -349,7 +349,7 @@ impl Client {
             let base = chain_spec
                 .id()
                 .chars()
-                .filter(|c| c.is_ascii_alphanumeric())
+                .filter(|c| c.is_ascii_graphic())
                 .collect::<String>();
             let mut suffix = None;
 


### PR DESCRIPTION
Important for `rococo_v1_8` to not be printed as `rococov18`