### PR TITLE
Don't report `isSyncing: false` until after the runtime has changed

### DIFF
--- a/bin/wasm-node/javascript/src/health.js
+++ b/bin/wasm-node/javascript/src/health.js
@@ -38,12 +38,15 @@
 // the health of the chain.
 //
 // In addition to this, as long as the health check reports that `isSyncing` is `true`, the
-// health checker also maintains a subscription to new best blocks using `chain_subscribeNewHeads`.
-// Whenever a new block is notified, a health check is performed immediately in order to determine
-// whether `isSyncing` has changed to `false`.
+// health checker also maintains a subscription to new best blocks and to runtime version changes
+// using `chain_subscribeNewHeads` and `state_subscribeRuntimeVersion`.
+// Whenever a new block or runtime version is notified, a health check is performed immediately
+// in order to determine whether `isSyncing` has changed to `false`.
 //
 // Thanks to this subscription, the latency of the report of the switch from `isSyncing: true` to
-// `isSyncing: false` is very low.
+// `isSyncing: false` is usually very low. It is, however, not completely robust: if the runtime
+// version isn't modified after the chain has finished syncing, then it will take until the next
+// best block to detect to end of the syncing.
 //
 export function healthChecker() {
     // `null` if health checker is not started.
@@ -65,8 +68,10 @@ export function healthChecker() {
                 healthCallback,
                 currentHealthCheckId: null,
                 currentHealthTimeout: null,
-                currentSubunsubRequestId: null,
-                currentSubscriptionId: null,
+                currentBestSubunsubRequestId: null,
+                currentBestSubscriptionId: null,
+                currentRuntimeSubunsubRequestId: null,
+                currentRuntimeSubscriptionId: null,
                 isSyncing: false,
                 nextRequestId: 0,
 
@@ -112,9 +117,10 @@ export function healthChecker() {
                         return null;
                     }
 
-                    // Check whether response is a response to the subscription or unsubscription.
-                    if (parsedResponse.id && this.currentSubunsubRequestId == parsedResponse.id) {
-                        this.currentSubunsubRequestId = null;
+                    // Check whether response is a response to the best block subscription or
+                    // unsubscription.
+                    if (parsedResponse.id && this.currentBestSubunsubRequestId == parsedResponse.id) {
+                        this.currentBestSubunsubRequestId = null;
 
                         // Check whether query was successful. It is possible for queries to fail for
                         // various reasons, such as the client being overloaded.
@@ -123,18 +129,44 @@ export function healthChecker() {
                             return null;
                         }
 
-                        if (this.currentSubscriptionId)
-                            this.currentSubscriptionId = null;
+                        if (this.currentBestSubscriptionId)
+                            this.currentBestSubscriptionId = null;
                         else
-                            this.currentSubscriptionId = parsedResponse.result;
+                            this.currentBestSubscriptionId = parsedResponse.result;
+
+                        this.update();
+                        return null;
+                    }
+
+                    // Check whether response is a response to the runtime version subscription or
+                    // unsubscription.
+                    if (parsedResponse.id && this.currentRuntimeSubunsubRequestId == parsedResponse.id) {
+                        this.currentRuntimeSubunsubRequestId = null;
+
+                        // Check whether query was successful. It is possible for queries to fail for
+                        // various reasons, such as the client being overloaded.
+                        if (!parsedResponse.result) {
+                            this.update();
+                            return null;
+                        }
+
+                        if (this.currentRuntimeSubscriptionId)
+                            this.currentRuntimeSubscriptionId = null;
+                        else
+                            this.currentRuntimeSubscriptionId = parsedResponse.result;
 
                         this.update();
                         return null;
                     }
 
                     // Check whether response is a notification to a subscription.
-                    if (parsedResponse.params && this.currentSubscriptionId &&
-                        parsedResponse.params.subscription == this.currentSubscriptionId) {
+                    if (parsedResponse.params && (
+                        (this.currentBestSubscriptionId &&
+                            parsedResponse.params.subscription == this.currentBestSubscriptionId)
+                        ||
+                        (this.currentRuntimeSubscriptionId &&
+                            parsedResponse.params.subscription == this.currentRuntimeSubscriptionId)
+                    )) {
                         // Note that after a successful subscription, a notification containing
                         // the current best block is always returned. Considering that a
                         // subscription is performed in response to a health check, calling
@@ -169,10 +201,14 @@ export function healthChecker() {
                         }, 10000);
                     }
 
-                    if (this.isSyncing && !this.currentSubscriptionId && !this.currentSubunsubRequestId)
-                        this.startSubscription();
-                    if (!this.isSyncing && this.currentSubscriptionId && !this.currentSubunsubRequestId)
-                        this.endSubscription();
+                    if (this.isSyncing && !this.currentBestSubscriptionId && !this.currentBestSubunsubRequestId)
+                        this.startBestSubscription();
+                    if (this.isSyncing && !this.currentRuntimeSubscriptionId && !this.currentRuntimeSubunsubRequestId)
+                        this.startRuntimeSubscription();
+                    if (!this.isSyncing && this.currentBestSubscriptionId && !this.currentBestSubunsubRequestId)
+                        this.endBestSubscription();
+                    if (!this.isSyncing && this.currentRuntimeSubscriptionId && !this.currentRuntimeSubunsubRequestId)
+                        this.endRuntimeSubscription();
                 },
 
                 startHealthCheck: function () {
@@ -192,29 +228,55 @@ export function healthChecker() {
                     }));
                 },
 
-                startSubscription: function () {
-                    if (this.currentSubunsubRequestId || this.currentSubscriptionId)
+                startBestSubscription: function () {
+                    if (this.currentBestSubunsubRequestId || this.currentBestSubscriptionId)
                         throw new Error('Internal error in health checker');
-                    this.currentSubunsubRequestId = "health-checker:" + this.nextRequestId;
+                    this.currentBestSubunsubRequestId = "health-checker:" + this.nextRequestId;
                     this.nextRequestId += 1;
                     sendJsonRpc(JSON.stringify({
                         jsonrpc: "2.0",
-                        id: this.currentSubunsubRequestId,
+                        id: this.currentBestSubunsubRequestId,
                         method: 'chain_subscribeNewHeads',
                         params: [],
                     }));
                 },
 
-                endSubscription: function () {
-                    if (this.currentSubunsubRequestId || !this.currentSubscriptionId)
+                endBestSubscription: function () {
+                    if (this.currentBestSubunsubRequestId || !this.currentBestSubscriptionId)
                         throw new Error('Internal error in health checker');
-                    this.currentSubunsubRequestId = "health-checker:" + this.nextRequestId;
+                    this.currentBestSubunsubRequestId = "health-checker:" + this.nextRequestId;
                     this.nextRequestId += 1;
                     sendJsonRpc(JSON.stringify({
                         jsonrpc: "2.0",
-                        id: this.currentSubunsubRequestId,
+                        id: this.currentBestSubunsubRequestId,
                         method: 'chain_unsubscribeNewHeads',
-                        params: [this.currentSubscriptionId],
+                        params: [this.currentBestSubscriptionId],
+                    }));
+                },
+
+                startRuntimeSubscription: function () {
+                    if (this.currentRuntimeSubunsubRequestId || this.currentRuntimeSubscriptionId)
+                        throw new Error('Internal error in health checker');
+                    this.currentRuntimeSubunsubRequestId = "health-checker:" + this.nextRequestId;
+                    this.nextRequestId += 1;
+                    sendJsonRpc(JSON.stringify({
+                        jsonrpc: "2.0",
+                        id: this.currentRuntimeSubunsubRequestId,
+                        method: 'state_subscribeRuntimeVersion',
+                        params: [],
+                    }));
+                },
+
+                endRuntimeSubscription: function () {
+                    if (this.currentRuntimeSubunsubRequestId || !this.currentRuntimeSubscriptionId)
+                        throw new Error('Internal error in health checker');
+                    this.currentRuntimeSubunsubRequestId = "health-checker:" + this.nextRequestId;
+                    this.nextRequestId += 1;
+                    sendJsonRpc(JSON.stringify({
+                        jsonrpc: "2.0",
+                        id: this.currentRuntimeSubunsubRequestId,
+                        method: 'state_unsubscribeRuntimeVersion',
+                        params: [this.currentRuntimeSubscriptionId],
                     }));
                 },
 

--- a/bin/wasm-node/rust/src/json_rpc_service.rs
+++ b/bin/wasm-node/rust/src/json_rpc_service.rs
@@ -1022,6 +1022,30 @@ impl Background {
                     }))
                     .unwrap();
             }
+            methods::MethodCall::state_unsubscribeRuntimeVersion { subscription } => {
+                let invalid = if let Some(cancel_tx) = self
+                    .subscriptions
+                    .lock()
+                    .await
+                    .remove(&(subscription.to_owned(), SubscriptionTy::RuntimeSpec))
+                {
+                    cancel_tx.send(request_id.to_owned()).is_err()
+                } else {
+                    true
+                };
+
+                if invalid {
+                    let _ = self
+                        .responses_sender
+                        .lock()
+                        .await
+                        .send(
+                            methods::Response::state_unsubscribeRuntimeVersion(false)
+                                .to_json_response(request_id),
+                        )
+                        .await;
+                }
+            }
             methods::MethodCall::state_subscribeStorage { list } => {
                 if list.is_empty() {
                     // When the list of keys is empty, that means we want to subscribe to *all*
@@ -1150,9 +1174,16 @@ impl Background {
                     // is finished and that the block notifications report blocks that are
                     // believed to be near the head of the chain.
                     // Note that since it is the `sync_service` that is used for block
-                    // subscriptions (as opposed to the `runtime_service`), it is also the
-                    // `sync_service` that is used to determine `is_syncing`.
-                    is_syncing: !self.sync_service.is_near_head_of_chain_heuristic().await,
+                    // subscriptions (as opposed to the `runtime_service`), it would also make
+                    // sense for the `sync_service` that is used to determine `is_syncing`.
+                    // Unfortunately, this means that the runtime version will likely change
+                    // *after* `isSyncing` becomes `false`, which causes issues in PolkadotJS
+                    // Because of this, we report `isSyncing` equal to `false` only after the
+                    // runtime service has obtained the runtime of the best block.
+                    // Additionally, using the `runtime_service` instead of the `sync_service`
+                    // means that, when it comes to parachains, `isSyncing` will be `true` for as
+                    // long as we haven't found any peer.
+                    is_syncing: !self.runtime_service.is_near_head_of_chain_heuristic().await,
                     peers: u64::try_from(self.sync_service.syncing_peers().await.len())
                         .unwrap_or(u64::max_value()),
                     should_have_peers: self.chain_is_live,


### PR DESCRIPTION
Right now, the following scenario happens every time a chain is added:

- The Grandpa warp sync is performed, and a new best block is reported through the JSON-RPC layer.
- The health checker detects this, realizes that `isSyncing` has become `false`, and substrate-connect tells PolkadotJS that we're now connected.
- In the meanwhile, smoldot started downloading the runtime code of the block we warp synced to. After the download is complete, it potentially detects a change in the runtime spec and reports it to PolkadotJS.

This, unfortunately, seems to confuse PolkadotJS for an unclear reason. I think that PolkadotJS simply isn't very much tested against runtime upgrades.
In order to solve this problem, we now report `isSyncing` equal to `true` for as long as the runtime code of the block we warp sync to hasn't been downloaded and checked.
The health checker has also been adjusted to subscribe to the runtime version in order to detect when `isSyncing` might have become `false`.
