### PR TITLE
Clarify JSON-RPC pub-sub system

### DIFF
--- a/bin/wasm-node/javascript/README.md
+++ b/bin/wasm-node/javascript/README.md
@@ -23,7 +23,7 @@ const chain = await client.addChain({
   chainSpec,
   jsonRpcCallback: (jsonRpcResponse) => {
       // Called whenever the client emits a response to a JSON-RPC request,
-      // or a JSON-RPC pub-sub notification.
+      // or an incoming JSON-RPC notification.
       console.log(jsonRpcResponse)
   }
 });

--- a/bin/wasm-node/rust/src/ffi/bindings.rs
+++ b/bin/wasm-node/rust/src/ffi/bindings.rs
@@ -306,17 +306,17 @@ pub extern "C" fn chain_error_ptr(chain_id: u32) -> u32 {
     super::chain_error_ptr(chain_id)
 }
 
-/// Emit a JSON-RPC request towards the given chain previously added using [`add_chain`].
+/// Emit a JSON-RPC request or notification towards the given chain previously added using
+/// [`add_chain`].
 ///
-/// A buffer containing a UTF-8 JSON-RPC request must be passed as parameter. The format of the
-/// JSON-RPC requests is described in
-/// [the standard JSON-RPC 2.0 specification](https://www.jsonrpc.org/specification). A pub-sub
-/// extension is supported.
+/// A buffer containing a UTF-8 JSON-RPC request or notification must be passed as parameter. The
+/// format of the JSON-RPC requests and notifications is described in
+/// [the standard JSON-RPC 2.0 specification](https://www.jsonrpc.org/specification).
 ///
 /// The buffer passed as parameter **must** have been allocated with [`alloc`]. It is freed when
 /// this function is called.
 ///
-/// Responses and subscriptions notifications are sent back using [`json_rpc_respond`].
+/// Responses and notifications are sent back using [`json_rpc_respond`].
 #[no_mangle]
 pub extern "C" fn json_rpc_send(text_ptr: u32, text_len: u32, chain_id: u32) {
     super::json_rpc_send(text_ptr, text_len, chain_id)

--- a/src/json_rpc.rs
+++ b/src/json_rpc.rs
@@ -49,12 +49,14 @@
 //!
 //! # JSON-RPC protocol
 //!
-//! The protocol used is the JSON-RPC v2.0 protocol described [here](https://www.jsonrpc.org/),
-//! with two extensions:
+//! The protocol used is the JSON-RPC v2.0 protocol described [here](https://www.jsonrpc.org/).
 //!
-//! - The pub-sub extension, as described
-//!   [here](https://besu.hyperledger.org/en/stable/HowTo/Interact/APIs/RPC-PubSub/).
-//! - The method named `rpc_methods` returns a list of all methods available.
+//! As specified in the JSON-RPC v2.0 protocol, both sides of the TCP/IP connection may send
+//! requests and/or notifications to the other side.
+//!
+//! In practice, the listening side of the connection should be capable of serving the various
+//! JSON-RPC functions described in the [`methods`] submodule. As part of the logic of these
+//! functions, the listening side might send notifications to the initiator of the connection.
 //!
 
 // TODO: write docs about usage ^


### PR DESCRIPTION
The pub-sub system isn't actually an extension to the specification. It just makes use of the fact that the listening side of the connection can send notifications to the dialing side.