### PR TITLE
Fix timeout too short in the StartConnect

### DIFF
--- a/bin/full-node/src/run/network_service.rs
+++ b/bin/full-node/src/run/network_service.rs
@@ -550,7 +550,7 @@ impl NetworkService {
                 let mut connec_tx = connec_tx.clone();
                 let future = async move {
                     loop {
-                        let start_connect = inner.network.next_start_connect(Instant::now()).await;
+                        let start_connect = inner.network.next_start_connect(|| Instant::now()).await;
 
                         let span = tracing::debug_span!("start-connect", ?start_connect.id, %start_connect.multiaddr);
                         let _enter = span.enter();

--- a/bin/full-node/src/run/network_service.rs
+++ b/bin/full-node/src/run/network_service.rs
@@ -550,7 +550,8 @@ impl NetworkService {
                 let mut connec_tx = connec_tx.clone();
                 let future = async move {
                     loop {
-                        let start_connect = inner.network.next_start_connect(|| Instant::now()).await;
+                        let start_connect =
+                            inner.network.next_start_connect(|| Instant::now()).await;
 
                         let span = tracing::debug_span!("start-connect", ?start_connect.id, %start_connect.multiaddr);
                         let _enter = span.enter();

--- a/bin/light-base/src/network_service.rs
+++ b/bin/light-base/src/network_service.rs
@@ -371,7 +371,7 @@ impl<TPlat: Platform> NetworkService<TPlat> {
                         loop {
                             let start_connect = network_service
                                 .network
-                                .next_start_connect(TPlat::now())
+                                .next_start_connect(|| TPlat::now())
                                 .await;
 
                             let is_important_peer = network_service

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -1961,7 +1961,8 @@ where
     ///
     /// If no outgoing connection is desired, the method waits until there is one.
     // TODO: give more control, with number of slots and node choice
-    pub async fn next_start_connect<'a>(&self, now: TNow) -> StartConnect<TNow> {
+    // TODO: this API with now is a bit hacky?
+    pub async fn next_start_connect<'a>(&self, now: impl FnOnce() -> TNow) -> StartConnect<TNow> {
         loop {
             let mut pending_lock = self.ephemeral_guarded.lock().await;
             let pending = &mut *pending_lock; // Prevents borrow checker issues.
@@ -2001,6 +2002,7 @@ where
                     }
                 }
 
+                let now = now();
                 let pending_id = PendingId(pending.pending_ids.insert((
                     entry.key().clone(),
                     multiaddr.clone(),


### PR DESCRIPTION
Right now the `now` parameter is passed to the function, but since this function can sleep, the `now` will no longer be up-to-date.