### PR TITLE
smoldot light improvements

### DIFF
--- a/bin/wasm-node/javascript/src/compat-browser.js
+++ b/bin/wasm-node/javascript/src/compat-browser.js
@@ -21,5 +21,6 @@ export const net = null;
 export const Worker = typeof window != 'undefined' ? window.Worker : null;
 export const workerOnMessage = (worker, callback) => { worker.onmessage = (event) => callback(event.data) };
 export const workerOnError = (worker, callback) => { worker.onerror = callback; };  // TODO: unclear if the parameter of the callback is same as with NodeJS
+export const workerTerminate = (worker) => { worker.terminate(); return Promise.resolve(); };
 export const postMessage = (msg) => self.postMessage(msg);
 export const setOnMessage = (callback) => { self.onmessage = (event) => callback(event.data) };

--- a/bin/wasm-node/javascript/src/compat-nodejs.js
+++ b/bin/wasm-node/javascript/src/compat-nodejs.js
@@ -26,5 +26,6 @@ export { Worker } from 'worker_threads';
 
 export const workerOnMessage = (worker, callback) => worker.on('message', callback);
 export const workerOnError = (worker, callback) => worker.on('error', callback);
+export const workerTerminate = (worker) => worker.terminate().then(() => {});
 export const postMessage = (msg) => parentPort.postMessage(msg);
 export const setOnMessage = (callback) => parentPort.on('message', callback);

--- a/bin/wasm-node/javascript/src/index.d.ts
+++ b/bin/wasm-node/javascript/src/index.d.ts
@@ -80,7 +80,7 @@ export interface Client {
    * @throws {AlreadyDestroyedError} If the client has already been terminated earlier.
    * @throws {CrashError} If the background client has crashed.
    */
-  terminate(): void;
+  terminate(): Promise<void>;
 }
 
 /**

--- a/bin/wasm-node/javascript/src/index.d.ts
+++ b/bin/wasm-node/javascript/src/index.d.ts
@@ -18,21 +18,21 @@
 /**
  * Thrown in case of a problem when initializing the chain.
  */
-declare class AddChainError extends Error {
+export class AddChainError extends Error {
   constructor(message: string);
 }
 
 /**
  * Thrown in case the API user tries to use a chain or client that has already been destroyed.
  */
-declare class AlreadyDestroyedError extends Error {
+export class AlreadyDestroyedError extends Error {
 }
 
 /**
  * Thrown when trying to send a JSON-RPC message to a chain whose JSON-RPC system hasn't been
  * enabled.
  */
-declare class JsonRpcDisabledError extends Error {
+export class JsonRpcDisabledError extends Error {
 }
 
 /**
@@ -40,7 +40,7 @@ declare class JsonRpcDisabledError extends Error {
  *
  * This is always an internal bug in smoldot and is never supposed to happen.
  */
-declare class CrashError extends Error {
+export class CrashError extends Error {
   constructor(message: string);
 }
 
@@ -256,18 +256,12 @@ export interface SmoldotHealth {
   shouldHavePeers: boolean;
 }
 
-export interface Smoldot {
-  /**
-   * Initializes a new client. This is a pre-requisite to connecting to a blockchain.
-   *
-   * Can never fail.
-   *
-   * @param options Configuration of the client. Defaults to `{}`.
-   */
-  start(options?: ClientOptions): Client;
-  healthChecker(): HealthChecker;
-}
-
-export const smoldot: Smoldot;
-
-export default smoldot;
+/**
+ * Initializes a new client. This is a pre-requisite to connecting to a blockchain.
+ *
+ * Can never fail.
+ *
+ * @param options Configuration of the client. Defaults to `{}`.
+ */
+export function start(options?: ClientOptions): Client;
+export function healthChecker(): HealthChecker;

--- a/bin/wasm-node/javascript/src/index.test-d.ts
+++ b/bin/wasm-node/javascript/src/index.test-d.ts
@@ -1,13 +1,9 @@
-import smoldot, { Smoldot, Client } from 'smoldot';
-
-// Test the export type
-
-// smoldot;  // $ExpectType Smoldot
+import { start, Client } from 'smoldot';
 
 // Test when supplying all options and all params to logCallback
 
 // $ExpectType Client
-let sm = smoldot.start({
+let sm = start({
   maxLogLevel: 3,
   logCallback: (level, target, message) => { },
   forbidTcp: false,
@@ -19,7 +15,7 @@ let sm = smoldot.start({
 
 (async () => {
   // $ExpectType Client
-  sm = smoldot.start();
+  sm = start();
   // $ExpectType Promise<Chain>
   const chain1 = sm.addChain({ chainSpec: '' });
   // $ExpectType Promise<Chain>

--- a/bin/wasm-node/javascript/src/index.test-d.ts
+++ b/bin/wasm-node/javascript/src/index.test-d.ts
@@ -26,6 +26,6 @@ let sm = start({
   chain2.sendJsonRpc('{"id":8,"jsonrpc":"2.0","method":"system_health","params":[]}');
   // $ExpectType void
   chain2.remove();
-  // $ExpectType void
+  // $ExpectType Promise<void>
   sm.terminate();
 })();


### PR DESCRIPTION
As I was trying to understand why there is a test that's not working on the PR that tries to [upgrade `smoldot-light` on `substrate-connect`](https://github.com/paritytech/substrate-connect/pull/555), I've noticed 2 issues on `smoldot-light`:

- The type definitions exported on the `index.d.ts` file don't actually match what's being exported. This must have been the case for quite some time now, since [substrate-connect is abusing `any` in order to use `smoldot-light`](https://github.com/paritytech/substrate-connect/blob/master/projects/extension/src/background/ConnectionManager.ts#L219), which pretty much defeats the purpose of the typings file. The first commit addresses that.
- The second commit improves the behavior of `client.terminate`, because the current behavior causes weird memory-leaks and race conditions on some tests (because jest has to force-quite some tasks). That was happening mainly because `worker.terminate()` behaves differently between NodeJS (where it returns a Promise) and the DOM (where it returns `undefined`). I've also taken that opportunity to cleanup a possible timeout callback.