### PR TITLE
Include runtime spec in runtime service notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2481,6 +2481,7 @@ dependencies = [
  "derive_more",
  "fnv",
  "futures",
+ "hashbrown 0.11.2",
  "hex",
  "itertools",
  "log",

--- a/bin/light-base/Cargo.toml
+++ b/bin/light-base/Cargo.toml
@@ -13,6 +13,7 @@ blake2-rfc = { version = "0.2.18", default-features = false }
 derive_more = "0.99.17"
 fnv = { version = "1.0.7", default-features = false }
 futures = "0.3.18"
+hashbrown = { version = "0.11.2", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 itertools = "0.10.1"
 log = { version = "0.4.14", default-features = false }

--- a/bin/light-base/src/json_rpc_service.rs
+++ b/bin/light-base/src/json_rpc_service.rs
@@ -1529,7 +1529,7 @@ impl<TPlat: Platform> Background<TPlat> {
             stream::iter(subscribe_all.non_finalized_blocks_ancestry_order)
                 .chain(subscribe_all.new_blocks.filter_map(|notif| {
                     future::ready(match notif {
-                        sync_service::Notification::Block(b) => Some(b),
+                        runtime_service::Notification::Block(b) => Some(b),
                         _ => None,
                     })
                 }))


### PR DESCRIPTION
Alright, this is likely to break some behaviors, but we're finally close to a feature-complete `runtime_service` which can then be cleaned up.