### PR TITLE
Pin Rust versions on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   test-64bits:
     runs-on: ubuntu-latest
     container:
-      image: rust
+      image: rust:1.57
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: Swatinem/rust-cache@v1   # See also the `cache-fill` workflow.
@@ -33,7 +33,7 @@ jobs:
   test-32bits:
     runs-on: ubuntu-latest
     container:
-      image: rust
+      image: rust:1.57
     steps:
     - uses: actions/checkout@v2.4.0
     - run: apt-get update && apt-get install -y libc6-dev-i386
@@ -44,7 +44,7 @@ jobs:
   wasm-node-check:
     runs-on: ubuntu-latest
     container:
-      image: rust
+      image: rust:1.57
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: Swatinem/rust-cache@v1
@@ -57,7 +57,7 @@ jobs:
   wasm-node-size-diff:
     runs-on: ubuntu-latest
     container:
-      image: rust
+      image: rust:1.57
     steps:
     - uses: actions/checkout@v2.4.0
       with:
@@ -88,7 +88,7 @@ jobs:
   check-features:
     runs-on: ubuntu-latest
     container:
-      image: rust
+      image: rust:1.57
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: Swatinem/rust-cache@v1
@@ -100,7 +100,7 @@ jobs:
   check-rustdoc-links:
     runs-on: ubuntu-latest
     container:
-      image: rust
+      image: rust:1.57
     steps:
     - uses: actions/checkout@v2.4.0
     - run: cargo doc --verbose --workspace --all-features --no-deps --document-private-items

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
   npm-publish:
     runs-on: ubuntu-latest
     container:
-      image: rust
+      image: rust:1.57
     steps:
       - uses: actions/checkout@v2.4.0
       - uses: actions/setup-node@v2.5.0

--- a/src/chain_spec/light_sync_state.rs
+++ b/src/chain_spec/light_sync_state.rs
@@ -38,7 +38,6 @@ impl LightSyncState {
         let babe_epoch_changes_slice = &self.babe_epoch_changes.0[..];
 
         let decoded = DecodedLightSyncState {
-            babe_finalized_block_weight: self.babe_finalized_block_weight,
             finalized_block_header: crate::header::decode(&self.finalized_block_header.0[..])
                 .map_err(|_| ParseError(ParseErrorInner::Other))?
                 .into(),
@@ -55,7 +54,6 @@ impl LightSyncState {
 #[derive(Debug)]
 pub(super) struct DecodedLightSyncState {
     pub(super) babe_epoch_changes: EpochChanges,
-    babe_finalized_block_weight: u32,
     pub(super) finalized_block_header: crate::header::Header,
     pub(super) grandpa_authority_set: AuthoritySet,
 }

--- a/src/chain_spec/structs.rs
+++ b/src/chain_spec/structs.rs
@@ -60,6 +60,7 @@ pub(super) struct ClientSpec {
     pub(super) bad_blocks: Option<HashSet<HashHexString, FnvBuildHasher>>,
     // Unused but for some reason still part of the chain specs.
     #[serde(default, skip_serializing)]
+    #[allow(unused)]
     pub(super) consensus_engine: (),
     pub(super) genesis: Genesis,
     pub(super) light_sync_state: Option<LightSyncState>,


### PR DESCRIPTION
Note that this pins Rust versions only in the situations where the Rust compiler output is important.
In particular, we don't pin any version for the `cache-fill` jobs, as filling the cache is secondary. We also don't pin the version for the audits check.