### PR TITLE
Rename grandpa_warp_sync to warp_sync

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -50,6 +50,6 @@
 
 pub mod all;
 pub mod all_forks;
-pub mod grandpa_warp_sync;
 pub mod optimistic;
 pub mod para;
+pub mod warp_sync;

--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -34,7 +34,7 @@ use crate::{
     chain::{blocks_tree, chain_information},
     executor::{host, vm::ExecHint},
     header,
-    sync::{all_forks, warp_sync, optimistic},
+    sync::{all_forks, optimistic, warp_sync},
     verify,
 };
 
@@ -337,9 +337,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                     warp_sync::InProgressWarpSync::WaitingForSources(_) => {
                         unreachable!()
                     }
-                    warp_sync::InProgressWarpSync::Verifier(sync) => {
-                        sync.add_source(source_extra)
-                    }
+                    warp_sync::InProgressWarpSync::Verifier(sync) => sync.add_source(source_extra),
                     warp_sync::InProgressWarpSync::WarpSyncRequest(sync) => {
                         sync.add_source(source_extra)
                     }
@@ -349,9 +347,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                     warp_sync::InProgressWarpSync::StorageGet(sync) => {
                         sync.add_source(source_extra)
                     }
-                    warp_sync::InProgressWarpSync::NextKey(sync) => {
-                        sync.add_source(source_extra)
-                    }
+                    warp_sync::InProgressWarpSync::NextKey(sync) => sync.add_source(source_extra),
                 };
 
                 outer_source_id_entry.insert(SourceMapping::GrandpaWarpSync(inner_source_id));
@@ -833,17 +829,15 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                             keys: vec![get.key_as_vec()],
                         },
                     )),
-                    warp_sync::InProgressWarpSync::VirtualMachineParamsGet(rq) => {
-                        Some((
-                            rq.warp_sync_source().1.outer_source_id,
-                            &rq.warp_sync_source().1.user_data,
-                            RequestDetail::StorageGet {
-                                block_hash: rq.warp_sync_header().hash(),
-                                state_trie_root: *rq.warp_sync_header().state_root,
-                                keys: vec![b":code".to_vec(), b":heappages".to_vec()],
-                            },
-                        ))
-                    }
+                    warp_sync::InProgressWarpSync::VirtualMachineParamsGet(rq) => Some((
+                        rq.warp_sync_source().1.outer_source_id,
+                        &rq.warp_sync_source().1.user_data,
+                        RequestDetail::StorageGet {
+                            block_hash: rq.warp_sync_header().hash(),
+                            state_trie_root: *rq.warp_sync_header().state_root,
+                            keys: vec![b":code".to_vec(), b":heappages".to_vec()],
+                        },
+                    )),
                     _ => None,
                 };
 
@@ -1297,8 +1291,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         ) {
             (
                 AllSyncInner::GrandpaWarpSync {
-                    inner:
-                        warp_sync::InProgressWarpSync::VirtualMachineParamsGet(sync),
+                    inner: warp_sync::InProgressWarpSync::VirtualMachineParamsGet(sync),
                 },
                 Ok(mut response),
             ) => {
@@ -1343,8 +1336,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
             }
             (
                 AllSyncInner::GrandpaWarpSync {
-                    inner:
-                        warp_sync::InProgressWarpSync::VirtualMachineParamsGet(sync),
+                    inner: warp_sync::InProgressWarpSync::VirtualMachineParamsGet(sync),
                 },
                 Err(_),
             ) => {

--- a/src/sync/warp_sync.rs
+++ b/src/sync/warp_sync.rs
@@ -38,7 +38,7 @@
 //!
 //! # Usage
 //!
-//! Use the [`warp_sync`] function to start a Grandpa warp syncing state machine.
+//! Use the [`warp_sync()`] function to start a Grandpa warp syncing state machine.
 //!
 //! At any given moment, this state machine holds a list of *sources* that it might use to
 //! download the warp sync proof or the runtime code. Sources must be added and removed by the API
@@ -74,7 +74,7 @@ use alloc::vec::Vec;
 
 pub use warp_sync::Error as FragmentError;
 
-/// Problem encountered during a call to [`warp_sync`].
+/// Problem encountered during a call to [`warp_sync()`].
 #[derive(Debug, derive_more::Display)]
 pub enum Error {
     #[display(fmt = "Missing :code")]
@@ -90,7 +90,7 @@ pub enum Error {
     InvalidChain(chain_information::ValidityError),
 }
 
-/// The configuration for [`warp_sync`].
+/// The configuration for [`warp_sync()`].
 pub struct Config {
     /// The chain information of the starting point of the warp syncing.
     pub start_chain_information: ValidChainInformation,

--- a/src/sync/warp_sync.rs
+++ b/src/sync/warp_sync.rs
@@ -197,18 +197,21 @@ impl<TSrc> WarpSync<TSrc> {
                             },
                         }) {
                             Ok(ci) => ci,
-                            Err(err) => return (
-                                Self::InProgress(
-                                    InProgressWarpSync::warp_sync_request_from_next_source(
-                                        state.sources,
-                                        PreVerificationState {
-                                            start_chain_information: state.start_chain_information,
-                                        },
-                                        None,
+                            Err(err) => {
+                                return (
+                                    Self::InProgress(
+                                        InProgressWarpSync::warp_sync_request_from_next_source(
+                                            state.sources,
+                                            PreVerificationState {
+                                                start_chain_information: state
+                                                    .start_chain_information,
+                                            },
+                                            None,
+                                        ),
                                     ),
-                                ),
-                                Some(Error::InvalidChain(err)),
-                            ),
+                                    Some(Error::InvalidChain(err)),
+                                )
+                            }
                         };
 
                     return (
@@ -245,15 +248,13 @@ impl<TSrc> WarpSync<TSrc> {
                     _,
                 ) => {
                     return (
-                        Self::InProgress(
-                            InProgressWarpSync::warp_sync_request_from_next_source(
-                                state.sources,
-                                PreVerificationState {
-                                    start_chain_information: state.start_chain_information,
-                                },
-                                None,
-                            ),
-                        ),
+                        Self::InProgress(InProgressWarpSync::warp_sync_request_from_next_source(
+                            state.sources,
+                            PreVerificationState {
+                                start_chain_information: state.start_chain_information,
+                            },
+                            None,
+                        )),
                         Some(Error::BabeFetchEpoch(error)),
                     )
                 }
@@ -513,15 +514,13 @@ impl<TSrc> StorageGet<TSrc> {
 
     /// Injects a failure to retrieve the storage value.
     pub fn inject_error(self) -> WarpSync<TSrc> {
-        WarpSync::InProgress(
-            InProgressWarpSync::warp_sync_request_from_next_source(
-                self.state.sources,
-                PreVerificationState {
-                    start_chain_information: self.state.start_chain_information,
-                },
-                None,
-            ),
-        )
+        WarpSync::InProgress(InProgressWarpSync::warp_sync_request_from_next_source(
+            self.state.sources,
+            PreVerificationState {
+                start_chain_information: self.state.start_chain_information,
+            },
+            None,
+        ))
     }
 }
 
@@ -570,10 +569,7 @@ impl<TSrc> NextKey<TSrc> {
     ///
     /// Panics if the key passed as parameter isn't strictly superior to the requested key.
     ///
-    pub fn inject_key(
-        self,
-        key: Option<impl AsRef<[u8]>>,
-    ) -> (WarpSync<TSrc>, Option<Error>) {
+    pub fn inject_key(self, key: Option<impl AsRef<[u8]>>) -> (WarpSync<TSrc>, Option<Error>) {
         WarpSync::from_babe_fetch_epoch_query(
             self.inner.inject_key(key),
             self.fetched_current_epoch,
@@ -657,17 +653,15 @@ impl<TSrc> Verifier<TSrc> {
 
                 if self.final_set_of_fragments {
                     (
-                        InProgressWarpSync::VirtualMachineParamsGet(
-                            VirtualMachineParamsGet {
-                                state: PostVerificationState {
-                                    header,
-                                    chain_information_finality,
-                                    start_chain_information: self.state.start_chain_information,
-                                    sources: self.sources,
-                                    warp_sync_source_id: self.warp_sync_source_id,
-                                },
+                        InProgressWarpSync::VirtualMachineParamsGet(VirtualMachineParamsGet {
+                            state: PostVerificationState {
+                                header,
+                                chain_information_finality,
+                                start_chain_information: self.state.start_chain_information,
+                                sources: self.sources,
+                                warp_sync_source_id: self.warp_sync_source_id,
                             },
-                        ),
+                        }),
                         Ok(()),
                     )
                 } else {
@@ -872,15 +866,13 @@ impl<TSrc> VirtualMachineParamsGet<TSrc> {
 
     /// Injects a failure to retrieve the parameters.
     pub fn inject_error(self) -> WarpSync<TSrc> {
-        WarpSync::InProgress(
-            InProgressWarpSync::warp_sync_request_from_next_source(
-                self.state.sources,
-                PreVerificationState {
-                    start_chain_information: self.state.start_chain_information,
-                },
-                None,
-            ),
-        )
+        WarpSync::InProgress(InProgressWarpSync::warp_sync_request_from_next_source(
+            self.state.sources,
+            PreVerificationState {
+                start_chain_information: self.state.start_chain_information,
+            },
+            None,
+        ))
     }
 
     /// Set the code and heappages from storage using the keys `:code` and `:heappages`
@@ -895,15 +887,13 @@ impl<TSrc> VirtualMachineParamsGet<TSrc> {
             Some(code) => code,
             None => {
                 return (
-                    WarpSync::InProgress(
-                        InProgressWarpSync::warp_sync_request_from_next_source(
-                            self.state.sources,
-                            PreVerificationState {
-                                start_chain_information: self.state.start_chain_information,
-                            },
-                            None,
-                        ),
-                    ),
+                    WarpSync::InProgress(InProgressWarpSync::warp_sync_request_from_next_source(
+                        self.state.sources,
+                        PreVerificationState {
+                            start_chain_information: self.state.start_chain_information,
+                        },
+                        None,
+                    )),
                     Some(Error::MissingCode),
                 )
             }
@@ -945,15 +935,13 @@ impl<TSrc> VirtualMachineParamsGet<TSrc> {
                 (warp_sync, error)
             }
             Err(error) => (
-                WarpSync::InProgress(
-                    InProgressWarpSync::warp_sync_request_from_next_source(
-                        self.state.sources,
-                        PreVerificationState {
-                            start_chain_information: self.state.start_chain_information,
-                        },
-                        None,
-                    ),
-                ),
+                WarpSync::InProgress(InProgressWarpSync::warp_sync_request_from_next_source(
+                    self.state.sources,
+                    PreVerificationState {
+                        start_chain_information: self.state.start_chain_information,
+                    },
+                    None,
+                )),
                 Some(Error::NewRuntime(error)),
             ),
         }

--- a/src/sync/warp_sync.rs
+++ b/src/sync/warp_sync.rs
@@ -15,11 +15,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Grandpa warp syncing.
+//! Warp syncing.
 //!
 //! # Overview
 //!
-//! The Grandpa warp syncing algorithm consists in the following steps:
+//! The warp syncing algorithm works only if the chain uses Grandpa for its finality.
+//! It consists in the following steps:
 //!
 //! - Downloading a warp sync proof from a source. This proof contains a list of *fragments*. Each
 //! fragment represents a change in the list of Grandpa authorities, and a list of signatures of
@@ -37,7 +38,7 @@
 //!
 //! # Usage
 //!
-//! Use the [`grandpa_warp_sync`] function to start a Grandpa warp syncing state machine.
+//! Use the [`warp_sync`] function to start a Grandpa warp syncing state machine.
 //!
 //! At any given moment, this state machine holds a list of *sources* that it might use to
 //! download the warp sync proof or the runtime code. Sources must be added and removed by the API
@@ -47,8 +48,8 @@
 //! of type `TSrc` associated to it. The content of this "user data" is at the discretion of the
 //! API user.
 //!
-//! The [`InProgressGrandpaWarpSync`] enum must be examined in order to determine how to make the
-//! warp syncing process.
+//! The [`InProgressWarpSync`] enum must be examined in order to determine how to make the warp
+//! syncing process.
 //!
 //! At the end of the process, a [`Success`] is returned and can be used to kick-off another
 //! syncing phase.
@@ -73,7 +74,7 @@ use alloc::vec::Vec;
 
 pub use warp_sync::Error as FragmentError;
 
-/// Problem encountered during a call to [`grandpa_warp_sync`].
+/// Problem encountered during a call to [`warp_sync`].
 #[derive(Debug, derive_more::Display)]
 pub enum Error {
     #[display(fmt = "Missing :code")]
@@ -89,7 +90,7 @@ pub enum Error {
     InvalidChain(chain_information::ValidityError),
 }
 
-/// The configuration for [`grandpa_warp_sync`].
+/// The configuration for [`warp_sync`].
 pub struct Config {
     /// The chain information of the starting point of the warp syncing.
     pub start_chain_information: ValidChainInformation,
@@ -97,9 +98,10 @@ pub struct Config {
     pub sources_capacity: usize,
 }
 
-/// Starts syncing via GrandPa warp sync.
-pub fn grandpa_warp_sync<TSrc>(config: Config) -> InProgressGrandpaWarpSync<TSrc> {
-    InProgressGrandpaWarpSync::WaitingForSources(WaitingForSources {
+/// Initializes the warp sync state machine.
+pub fn warp_sync<TSrc>(config: Config) -> InProgressWarpSync<TSrc> {
+    // TODO: detect if chain.start_chain_information is not using Grandpa
+    InProgressWarpSync::WaitingForSources(WaitingForSources {
         state: PreVerificationState {
             start_chain_information: config.start_chain_information,
         },
@@ -108,7 +110,7 @@ pub fn grandpa_warp_sync<TSrc>(config: Config) -> InProgressGrandpaWarpSync<TSrc
     })
 }
 
-/// Identifier for a source in the [`GrandpaWarpSync`].
+/// Identifier for a source in the [`WarpSync`].
 //
 // Implementation note: this represents the index within the `Slab` used for the list of sources.
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -125,17 +127,17 @@ pub struct Success<TSrc> {
     pub sources: Vec<TSrc>,
 }
 
-/// The GrandPa warp sync state machine.
+/// The warp sync state machine.
 #[derive(derive_more::From)]
-pub enum GrandpaWarpSync<TSrc> {
+pub enum WarpSync<TSrc> {
     /// Warp syncing is over.
     Finished(Success<TSrc>),
     /// Warp syncing is in progress,
-    InProgress(InProgressGrandpaWarpSync<TSrc>),
+    InProgress(InProgressWarpSync<TSrc>),
 }
 
 #[derive(derive_more::From)]
-pub enum InProgressGrandpaWarpSync<TSrc> {
+pub enum InProgressWarpSync<TSrc> {
     /// Loading a storage value is required in order to continue.
     #[from]
     StorageGet(StorageGet<TSrc>),
@@ -147,16 +149,16 @@ pub enum InProgressGrandpaWarpSync<TSrc> {
     Verifier(Verifier<TSrc>),
     /// Requesting GrandPa warp sync data from a source is required to continue.
     #[from]
-    WarpSyncRequest(WarpSyncRequest<TSrc>),
+    WarpSyncRequest(GrandpaWarpSyncRequest<TSrc>),
     /// Fetching the parameters for the virtual machine is required to continue.
     #[from]
     VirtualMachineParamsGet(VirtualMachineParamsGet<TSrc>),
-    /// Adding more sources of GrandPa warp sync data to is required to continue.
+    /// Adding more sources of warp sync data to is required to continue.
     #[from]
     WaitingForSources(WaitingForSources<TSrc>),
 }
 
-impl<TSrc> GrandpaWarpSync<TSrc> {
+impl<TSrc> WarpSync<TSrc> {
     fn from_babe_fetch_epoch_query(
         mut query: babe_fetch_epoch::Query,
         mut fetched_current_epoch: Option<BabeEpochInformation>,
@@ -197,7 +199,7 @@ impl<TSrc> GrandpaWarpSync<TSrc> {
                             Ok(ci) => ci,
                             Err(err) => return (
                                 Self::InProgress(
-                                    InProgressGrandpaWarpSync::warp_sync_request_from_next_source(
+                                    InProgressWarpSync::warp_sync_request_from_next_source(
                                         state.sources,
                                         PreVerificationState {
                                             start_chain_information: state.start_chain_information,
@@ -244,7 +246,7 @@ impl<TSrc> GrandpaWarpSync<TSrc> {
                 ) => {
                     return (
                         Self::InProgress(
-                            InProgressGrandpaWarpSync::warp_sync_request_from_next_source(
+                            InProgressWarpSync::warp_sync_request_from_next_source(
                                 state.sources,
                                 PreVerificationState {
                                     start_chain_information: state.start_chain_information,
@@ -257,7 +259,7 @@ impl<TSrc> GrandpaWarpSync<TSrc> {
                 }
                 (babe_fetch_epoch::Query::StorageGet(storage_get), fetched_current_epoch) => {
                     return (
-                        Self::InProgress(InProgressGrandpaWarpSync::StorageGet(StorageGet {
+                        Self::InProgress(InProgressWarpSync::StorageGet(StorageGet {
                             inner: storage_get,
                             fetched_current_epoch,
                             state,
@@ -271,7 +273,7 @@ impl<TSrc> GrandpaWarpSync<TSrc> {
                 }
                 (babe_fetch_epoch::Query::NextKey(next_key), fetched_current_epoch) => {
                     return (
-                        Self::InProgress(InProgressGrandpaWarpSync::NextKey(NextKey {
+                        Self::InProgress(InProgressWarpSync::NextKey(NextKey {
                             inner: next_key,
                             fetched_current_epoch,
                             state,
@@ -284,7 +286,7 @@ impl<TSrc> GrandpaWarpSync<TSrc> {
     }
 }
 
-impl<TSrc> InProgressGrandpaWarpSync<TSrc> {
+impl<TSrc> InProgressWarpSync<TSrc> {
     /// Returns the chain information that is considered verified.
     pub fn as_chain_information(&self) -> ValidChainInformationRef {
         match self {
@@ -384,7 +386,7 @@ impl<TSrc> InProgressGrandpaWarpSync<TSrc> {
             .map(|(id, _)| SourceId(id));
 
         if let Some(next_id) = next_id {
-            Self::WarpSyncRequest(WarpSyncRequest {
+            Self::WarpSyncRequest(GrandpaWarpSyncRequest {
                 source_id: next_id,
                 sources,
                 state,
@@ -406,7 +408,7 @@ impl<TSrc> InProgressGrandpaWarpSync<TSrc> {
     ///
     /// Panics if the source wasn't added to the list earlier.
     ///
-    pub fn remove_source(self, to_remove: SourceId) -> (TSrc, InProgressGrandpaWarpSync<TSrc>) {
+    pub fn remove_source(self, to_remove: SourceId) -> (TSrc, InProgressWarpSync<TSrc>) {
         match self {
             Self::WaitingForSources(waiting_for_sources) => {
                 waiting_for_sources.remove_source(to_remove)
@@ -501,8 +503,8 @@ impl<TSrc> StorageGet<TSrc> {
     pub fn inject_value(
         self,
         value: Option<impl Iterator<Item = impl AsRef<[u8]>>>,
-    ) -> (GrandpaWarpSync<TSrc>, Option<Error>) {
-        GrandpaWarpSync::from_babe_fetch_epoch_query(
+    ) -> (WarpSync<TSrc>, Option<Error>) {
+        WarpSync::from_babe_fetch_epoch_query(
             self.inner.inject_value(value),
             self.fetched_current_epoch,
             self.state,
@@ -510,9 +512,9 @@ impl<TSrc> StorageGet<TSrc> {
     }
 
     /// Injects a failure to retrieve the storage value.
-    pub fn inject_error(self) -> GrandpaWarpSync<TSrc> {
-        GrandpaWarpSync::InProgress(
-            InProgressGrandpaWarpSync::warp_sync_request_from_next_source(
+    pub fn inject_error(self) -> WarpSync<TSrc> {
+        WarpSync::InProgress(
+            InProgressWarpSync::warp_sync_request_from_next_source(
                 self.state.sources,
                 PreVerificationState {
                     start_chain_information: self.state.start_chain_information,
@@ -571,8 +573,8 @@ impl<TSrc> NextKey<TSrc> {
     pub fn inject_key(
         self,
         key: Option<impl AsRef<[u8]>>,
-    ) -> (GrandpaWarpSync<TSrc>, Option<Error>) {
-        GrandpaWarpSync::from_babe_fetch_epoch_query(
+    ) -> (WarpSync<TSrc>, Option<Error>) {
+        WarpSync::from_babe_fetch_epoch_query(
             self.inner.inject_key(key),
             self.fetched_current_epoch,
             self.state,
@@ -605,12 +607,12 @@ impl<TSrc> Verifier<TSrc> {
     ///
     /// Panics if the source wasn't added to the list earlier.
     ///
-    pub fn remove_source(mut self, to_remove: SourceId) -> (TSrc, InProgressGrandpaWarpSync<TSrc>) {
+    pub fn remove_source(mut self, to_remove: SourceId) -> (TSrc, InProgressWarpSync<TSrc>) {
         debug_assert!(self.sources.contains(to_remove.0));
         let removed = self.sources.remove(to_remove.0).user_data;
 
         if to_remove == self.warp_sync_source_id {
-            let next_state = InProgressGrandpaWarpSync::warp_sync_request_from_next_source(
+            let next_state = InProgressWarpSync::warp_sync_request_from_next_source(
                 self.sources,
                 self.state,
                 self.previous_verifier_values,
@@ -618,7 +620,7 @@ impl<TSrc> Verifier<TSrc> {
 
             (removed, next_state)
         } else {
-            (removed, InProgressGrandpaWarpSync::Verifier(self))
+            (removed, InProgressWarpSync::Verifier(self))
         }
     }
 
@@ -632,10 +634,10 @@ impl<TSrc> Verifier<TSrc> {
     }
 
     /// Verifies the next warp sync fragment in queue.
-    pub fn next(self) -> (InProgressGrandpaWarpSync<TSrc>, Result<(), FragmentError>) {
+    pub fn next(self) -> (InProgressWarpSync<TSrc>, Result<(), FragmentError>) {
         match self.verifier.next() {
             Ok(warp_sync::Next::NotFinished(next_verifier)) => (
-                InProgressGrandpaWarpSync::Verifier(Self {
+                InProgressWarpSync::Verifier(Self {
                     verifier: next_verifier,
                     state: self.state,
                     sources: self.sources,
@@ -655,7 +657,7 @@ impl<TSrc> Verifier<TSrc> {
 
                 if self.final_set_of_fragments {
                     (
-                        InProgressGrandpaWarpSync::VirtualMachineParamsGet(
+                        InProgressWarpSync::VirtualMachineParamsGet(
                             VirtualMachineParamsGet {
                                 state: PostVerificationState {
                                     header,
@@ -670,7 +672,7 @@ impl<TSrc> Verifier<TSrc> {
                     )
                 } else {
                     (
-                        InProgressGrandpaWarpSync::WarpSyncRequest(WarpSyncRequest {
+                        InProgressWarpSync::WarpSyncRequest(GrandpaWarpSyncRequest {
                             source_id: self.warp_sync_source_id,
                             sources: self.sources,
                             state: self.state,
@@ -681,7 +683,7 @@ impl<TSrc> Verifier<TSrc> {
                 }
             }
             Err(error) => (
-                InProgressGrandpaWarpSync::warp_sync_request_from_next_source(
+                InProgressWarpSync::warp_sync_request_from_next_source(
                     self.sources,
                     self.state,
                     self.previous_verifier_values,
@@ -713,7 +715,7 @@ impl<TSrc> PostVerificationState<TSrc> {
             (
                 removed,
                 StateRemoveSourceResult::RemovedCurrent(
-                    InProgressGrandpaWarpSync::warp_sync_request_from_next_source(
+                    InProgressWarpSync::warp_sync_request_from_next_source(
                         self.sources,
                         PreVerificationState {
                             start_chain_information: self.start_chain_information,
@@ -729,19 +731,19 @@ impl<TSrc> PostVerificationState<TSrc> {
 }
 
 enum StateRemoveSourceResult<TSrc> {
-    RemovedCurrent(InProgressGrandpaWarpSync<TSrc>),
+    RemovedCurrent(InProgressWarpSync<TSrc>),
     RemovedOther(PostVerificationState<TSrc>),
 }
 
 /// Requesting GrandPa warp sync data from a source is required to continue.
-pub struct WarpSyncRequest<TSrc> {
+pub struct GrandpaWarpSyncRequest<TSrc> {
     source_id: SourceId,
     sources: slab::Slab<Source<TSrc>>,
     state: PreVerificationState,
     previous_verifier_values: Option<(Header, ChainInformationFinality)>,
 }
 
-impl<TSrc> WarpSyncRequest<TSrc> {
+impl<TSrc> GrandpaWarpSyncRequest<TSrc> {
     /// The source to make a GrandPa warp sync request to.
     pub fn current_source(&self) -> (SourceId, &TSrc) {
         debug_assert!(self.sources.contains(self.source_id.0));
@@ -775,12 +777,12 @@ impl<TSrc> WarpSyncRequest<TSrc> {
     ///
     /// Panics if the source wasn't added to the list earlier.
     ///
-    pub fn remove_source(mut self, to_remove: SourceId) -> (TSrc, InProgressGrandpaWarpSync<TSrc>) {
+    pub fn remove_source(mut self, to_remove: SourceId) -> (TSrc, InProgressWarpSync<TSrc>) {
         debug_assert!(self.sources.contains(to_remove.0));
         let removed = self.sources.remove(to_remove.0).user_data;
 
         if to_remove == self.source_id {
-            let next_state = InProgressGrandpaWarpSync::warp_sync_request_from_next_source(
+            let next_state = InProgressWarpSync::warp_sync_request_from_next_source(
                 self.sources,
                 self.state,
                 self.previous_verifier_values,
@@ -788,7 +790,7 @@ impl<TSrc> WarpSyncRequest<TSrc> {
 
             (removed, next_state)
         } else {
-            (removed, InProgressGrandpaWarpSync::WarpSyncRequest(self))
+            (removed, InProgressWarpSync::WarpSyncRequest(self))
         }
     }
 
@@ -796,7 +798,7 @@ impl<TSrc> WarpSyncRequest<TSrc> {
     pub fn handle_response(
         mut self,
         response: Option<GrandpaWarpSyncResponse>,
-    ) -> InProgressGrandpaWarpSync<TSrc> {
+    ) -> InProgressWarpSync<TSrc> {
         debug_assert!(self.sources.contains(self.source_id.0));
 
         self.sources[self.source_id.0].already_tried = true;
@@ -818,7 +820,7 @@ impl<TSrc> WarpSyncRequest<TSrc> {
                     ),
                 };
 
-                InProgressGrandpaWarpSync::Verifier(Verifier {
+                InProgressWarpSync::Verifier(Verifier {
                     final_set_of_fragments,
                     verifier,
                     state: self.state,
@@ -827,7 +829,7 @@ impl<TSrc> WarpSyncRequest<TSrc> {
                     previous_verifier_values: self.previous_verifier_values,
                 })
             }
-            None => InProgressGrandpaWarpSync::warp_sync_request_from_next_source(
+            None => InProgressWarpSync::warp_sync_request_from_next_source(
                 self.sources,
                 self.state,
                 self.previous_verifier_values,
@@ -869,9 +871,9 @@ impl<TSrc> VirtualMachineParamsGet<TSrc> {
     }
 
     /// Injects a failure to retrieve the parameters.
-    pub fn inject_error(self) -> GrandpaWarpSync<TSrc> {
-        GrandpaWarpSync::InProgress(
-            InProgressGrandpaWarpSync::warp_sync_request_from_next_source(
+    pub fn inject_error(self) -> WarpSync<TSrc> {
+        WarpSync::InProgress(
+            InProgressWarpSync::warp_sync_request_from_next_source(
                 self.state.sources,
                 PreVerificationState {
                     start_chain_information: self.state.start_chain_information,
@@ -888,13 +890,13 @@ impl<TSrc> VirtualMachineParamsGet<TSrc> {
         code: Option<impl AsRef<[u8]>>,
         heap_pages: Option<impl AsRef<[u8]>>,
         exec_hint: ExecHint,
-    ) -> (GrandpaWarpSync<TSrc>, Option<Error>) {
+    ) -> (WarpSync<TSrc>, Option<Error>) {
         let code = match code {
             Some(code) => code,
             None => {
                 return (
-                    GrandpaWarpSync::InProgress(
-                        InProgressGrandpaWarpSync::warp_sync_request_from_next_source(
+                    WarpSync::InProgress(
+                        InProgressWarpSync::warp_sync_request_from_next_source(
                             self.state.sources,
                             PreVerificationState {
                                 start_chain_information: self.state.start_chain_information,
@@ -912,8 +914,8 @@ impl<TSrc> VirtualMachineParamsGet<TSrc> {
                 Ok(hp) => hp,
                 Err(err) => {
                     return (
-                        GrandpaWarpSync::InProgress(
-                            InProgressGrandpaWarpSync::warp_sync_request_from_next_source(
+                        WarpSync::InProgress(
+                            InProgressWarpSync::warp_sync_request_from_next_source(
                                 self.state.sources,
                                 PreVerificationState {
                                     start_chain_information: self.state.start_chain_information,
@@ -934,17 +936,17 @@ impl<TSrc> VirtualMachineParamsGet<TSrc> {
                         epoch_to_fetch: babe_fetch_epoch::BabeEpochToFetch::CurrentEpoch,
                     });
 
-                let (grandpa_warp_sync, error) = GrandpaWarpSync::from_babe_fetch_epoch_query(
+                let (warp_sync, error) = WarpSync::from_babe_fetch_epoch_query(
                     babe_current_epoch_query,
                     None,
                     self.state,
                 );
 
-                (grandpa_warp_sync, error)
+                (warp_sync, error)
             }
             Err(error) => (
-                GrandpaWarpSync::InProgress(
-                    InProgressGrandpaWarpSync::warp_sync_request_from_next_source(
+                WarpSync::InProgress(
+                    InProgressWarpSync::warp_sync_request_from_next_source(
                         self.state.sources,
                         PreVerificationState {
                             start_chain_information: self.state.start_chain_information,
@@ -958,7 +960,7 @@ impl<TSrc> VirtualMachineParamsGet<TSrc> {
     }
 }
 
-/// Adding more sources of GrandPa warp sync data to is required to continue.
+/// Adding more sources of warp sync data to is required to continue.
 pub struct WaitingForSources<TSrc> {
     /// List of sources. It is guaranteed that they all have `already_tried` equal to `true`.
     sources: slab::Slab<Source<TSrc>>,
@@ -968,13 +970,13 @@ pub struct WaitingForSources<TSrc> {
 
 impl<TSrc> WaitingForSources<TSrc> {
     /// Add a source to the list of sources.
-    pub fn add_source(mut self, user_data: TSrc) -> WarpSyncRequest<TSrc> {
+    pub fn add_source(mut self, user_data: TSrc) -> GrandpaWarpSyncRequest<TSrc> {
         let source_id = SourceId(self.sources.insert(Source {
             user_data,
             already_tried: false,
         }));
 
-        WarpSyncRequest {
+        GrandpaWarpSyncRequest {
             source_id,
             sources: self.sources,
             state: self.state,
@@ -988,10 +990,10 @@ impl<TSrc> WaitingForSources<TSrc> {
     ///
     /// Panics if the source wasn't added to the list earlier.
     ///
-    pub fn remove_source(mut self, to_remove: SourceId) -> (TSrc, InProgressGrandpaWarpSync<TSrc>) {
+    pub fn remove_source(mut self, to_remove: SourceId) -> (TSrc, InProgressWarpSync<TSrc>) {
         debug_assert!(self.sources.contains(to_remove.0));
         let removed = self.sources.remove(to_remove.0).user_data;
-        (removed, InProgressGrandpaWarpSync::WaitingForSources(self))
+        (removed, InProgressWarpSync::WaitingForSources(self))
     }
 }
 


### PR DESCRIPTION
Removes most of the `Grandpa` prefixes, but not all. The warp sync state machine is no longer specific to Grandpa, but still emits requests that are specific to Grandpa.