### PR TITLE
Update path to artifacts after build profile transition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     - run: cargo install twiggy  # TODO: somehow cache this in order to not compile twiggy every single time
     - run: git checkout ${{ github.event.pull_request.base.sha }}
     - run: cd bin/wasm-node/javascript && npm ci && npm run-script build
-    - run: cp ./target/wasm32-wasi/release/smoldot_light_wasm.wasm ./.ci-parent-build.wasm  # TODO: update the path, plus maybe get the path from the `npm build` output or something?
+    - run: cp ./target/wasm32-wasi/min-size-release/smoldot_light_wasm.wasm ./.ci-parent-build.wasm  # TODO: maybe get the path from the `npm build` output or something?
     - run: git checkout ${{ github.event.pull_request.head.sha }}
     - run: cd bin/wasm-node/javascript && npm ci && npm run-script build
     - run: twiggy diff ./.ci-parent-build.wasm ./target/wasm32-wasi/min-size-release/smoldot_light_wasm.wasm > ./twiggy-diff  # TODO: maybe get the path from the `npm build` output or something?


### PR DESCRIPTION
This is a follow-up to https://github.com/paritytech/smoldot/pull/1729

Without this PR, the CI is broken at the moment.