### PR TITLE
Better precision for BytesDisplay

### DIFF
--- a/src/informant.rs
+++ b/src/informant.rs
@@ -236,27 +236,39 @@ impl fmt::Display for BytesDisplay {
         }
         value /= 1024.0;
 
-        if value < 1000.0 {
+        if value < 100.0 {
             return write!(f, "{:.1} kiB", value);
         }
+        if value < 1000.0 {
+            return write!(f, "{:.0} kiB", value);
+        }
         value /= 1024.0;
 
-        if value < 1000.0 {
+        if value < 100.0 {
             return write!(f, "{:.1} MiB", value);
         }
+        if value < 1000.0 {
+            return write!(f, "{:.0} MiB", value);
+        }
         value /= 1024.0;
 
-        if value < 1000.0 {
+        if value < 100.0 {
             return write!(f, "{:.1} GiB", value);
         }
-        value /= 1024.0;
-
         if value < 1000.0 {
-            return write!(f, "{:.1} TiB", value);
+            return write!(f, "{:.0} GiB", value);
         }
         value /= 1024.0;
 
-        write!(f, "{:.1}PiB", value)
+        if value < 100.0 {
+            return write!(f, "{:.1} TiB", value);
+        }
+        if value < 1000.0 {
+            return write!(f, "{:.0} TiB", value);
+        }
+        value /= 1024.0;
+
+        write!(f, "{:.1} PiB", value)
 
         // Hopefully we never have to go above petabytes.
     }


### PR DESCRIPTION
We will now print for example `150 kiB` instead of `150.2 kiB`.
The precision still stays when there's less than 3 digits, for example `15.2 kiB` or `1.5 kiB`