### PR TITLE
sync_service now returns a ValidChainInformation instead of String

### DIFF
--- a/bin/light-base/src/lib.rs
+++ b/bin/light-base/src/lib.rs
@@ -929,6 +929,7 @@ impl<TChain, TPlat: Platform> Client<TChain, TPlat> {
                 .sync_service
                 .serialize_chain_information()
                 .await
+                .map(|ci| finalized_serialize::encode_chain(&ci))
                 .unwrap_or_else(|| "<unknown>".into());
 
             // Cap the database length to the requested max length.

--- a/bin/light-base/src/sync_service.rs
+++ b/bin/light-base/src/sync_service.rs
@@ -148,7 +148,9 @@ impl<TPlat: Platform> SyncService<TPlat> {
     ///
     /// Returns `None` if this information couldn't be obtained because not enough is known about
     /// the chain.
-    pub async fn serialize_chain_information(&self) -> Option<String> {
+    pub async fn serialize_chain_information(
+        &self,
+    ) -> Option<chain::chain_information::ValidChainInformation> {
         let (send_back, rx) = oneshot::channel();
 
         self.to_background
@@ -688,6 +690,6 @@ enum ToBackground {
     },
     /// See [`SyncService::serialize_chain_information`].
     SerializeChainInformation {
-        send_back: oneshot::Sender<Option<String>>,
+        send_back: oneshot::Sender<Option<chain::chain_information::ValidChainInformation>>,
     },
 }

--- a/bin/light-base/src/sync_service/standalone.rs
+++ b/bin/light-base/src/sync_service/standalone.rs
@@ -20,8 +20,7 @@ use crate::{network_service, Platform};
 
 use futures::{channel::mpsc, prelude::*};
 use smoldot::{
-    chain,
-    header,
+    chain, header,
     informant::HashDisplay,
     libp2p,
     network::{self, protocol},

--- a/bin/light-base/src/sync_service/standalone.rs
+++ b/bin/light-base/src/sync_service/standalone.rs
@@ -21,7 +21,6 @@ use crate::{network_service, Platform};
 use futures::{channel::mpsc, prelude::*};
 use smoldot::{
     chain,
-    database::finalized_serialize,
     header,
     informant::HashDisplay,
     libp2p,
@@ -723,8 +722,7 @@ impl<TPlat: Platform> Task<TPlat> {
             }
 
             ToBackground::SerializeChainInformation { send_back } => {
-                let db = finalized_serialize::encode_chain(self.sync.as_chain_information());
-                let _ = send_back.send(Some(db));
+                let _ = send_back.send(Some(self.sync.as_chain_information().into()));
             }
         }
     }

--- a/src/database/finalized_serialize.rs
+++ b/src/database/finalized_serialize.rs
@@ -40,15 +40,19 @@ mod defs;
 /// Serializes the given chain information as a string.
 ///
 /// This is a shortcut for [`encode_chain_storage`] with no `finalized_storage`.
-pub fn encode_chain(information: chain_information::ValidChainInformationRef<'_>) -> String {
+pub fn encode_chain<'a>(
+    information: impl Into<chain_information::ValidChainInformationRef<'a>>,
+) -> String {
     encode_chain_storage(information, None::<iter::Empty<(Vec<u8>, Vec<u8>)>>)
 }
 
 /// Serializes the given chain information and finalized block storage as a string.
-pub fn encode_chain_storage(
-    information: chain_information::ValidChainInformationRef<'_>,
+pub fn encode_chain_storage<'a>(
+    information: impl Into<chain_information::ValidChainInformationRef<'a>>,
     finalized_storage: Option<impl Iterator<Item = (impl AsRef<[u8]>, impl AsRef<[u8]>)>>,
 ) -> String {
+    let information = information.into();
+
     let decoded = defs::SerializedChainInformation::V1(defs::SerializedChainInformationV1::new(
         information.as_ref(),
         finalized_storage,


### PR DESCRIPTION
This scopes the usage of `finalized_serialize` to `lib.rs`, and also unlocks the way for https://github.com/paritytech/smoldot/issues/1769 which will require knowing the finalized block from `lib.rs`.