### PR TITLE
Allocate Wasm memory lazily

### DIFF
--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -78,6 +78,12 @@
 //! machine is always fixed, and is equal to the initial size of the memory plus the value of
 //! `heap_pages` that is passed as parameter to [`HostVmPrototype::new`].
 //!
+//! Note that the WebAssembly code can also itself contain a maximum number of memory pages. While
+//! it would in principle make sense to check at initialization that
+//! `maximum_pages >= __heap_base + heap_pages`, in practice this check fails for most runtimes
+//! and is therefore not performed. Reaching the maximum number of pages is considered as an out
+//! of memory error.
+//!
 //! ## Entry points
 //!
 //! All entry points that can be called from the host (using, for example,
@@ -184,7 +190,7 @@ use super::{allocator, vm};
 use crate::{trie, util};
 
 use alloc::{borrow::ToOwned as _, format, string::String, vec, vec::Vec};
-use core::{fmt, hash::Hasher as _, iter, str};
+use core::{cmp, fmt, hash::Hasher as _, iter, str};
 use sha2::Digest as _;
 use tiny_keccak::Hasher as _;
 
@@ -222,7 +228,7 @@ pub struct HostVmPrototype {
     heap_pages: HeapPages,
 
     /// Total number of pages of Wasm memory. This is equal to `heap_base / 64k` (rounded up) plus
-    /// `heap_pages`.
+    /// `heap_pages`, capped at the maximum enforced by the Wasm module.
     memory_total_pages: HeapPages,
 }
 
@@ -276,18 +282,17 @@ impl HostVmPrototype {
             .global_value("__heap_base")
             .map_err(|_| NewErr::HeapBaseNotFound)?;
 
-        let memory_total_pages = if heap_base == 0 {
-            heap_pages
-        } else {
-            HeapPages::new((heap_base - 1) / (64 * 1024)) + heap_pages + HeapPages::new(1)
-        };
+        let memory_total_pages = {
+            let base = if heap_base == 0 {
+                heap_pages
+            } else {
+                HeapPages::new((heap_base - 1) / (64 * 1024)) + heap_pages + HeapPages::new(1)
+            };
 
-        if vm_proto
-            .memory_max_pages()
-            .map_or(false, |max| max < memory_total_pages)
-        {
-            return Err(NewErr::MemoryMaxSizeTooLow);
-        }
+            vm_proto
+                .memory_max_pages()
+                .map_or(base, |limit| cmp::min(limit, base))
+        };
 
         Ok(HostVmPrototype {
             module,
@@ -2340,8 +2345,8 @@ impl Inner {
             // in case `last_byte_memory_page` is the maximum possible value.
             let to_grow = last_byte_memory_page - current_num_pages + HeapPages::new(1);
 
-            // We check at initialization that the virtual machine is capable of growing up to
-            // `memory_total_pages`, meaning that this `unwrap` can't panic.
+            // We tell the allocator how much the memory of the virtual machine is capable of
+            // growing. A panic here indicates a bug either in the allocator or this module.
             self.vm.grow_memory(to_grow).unwrap();
         }
 
@@ -2372,9 +2377,6 @@ pub enum NewErr {
     BadFormat(ModuleFormatError),
     /// Couldn't find the `__heap_base` symbol in the Wasm code.
     HeapBaseNotFound,
-    /// Maximum size of the Wasm memory found in the module is too low to provide the requested
-    /// number of heap pages.
-    MemoryMaxSizeTooLow,
 }
 
 /// Error that can happen when starting a VM.
@@ -2839,8 +2841,8 @@ impl<'a> allocator::Memory for MemAccess<'a> {
             // in case `written_memory_page` is the maximum possible value.
             let to_grow = written_memory_page - current_num_pages + HeapPages::new(1);
 
-            // We check at initialization that the virtual machine is capable of growing up to
-            // `memory_total_pages`, meaning that this `unwrap` can't panic.
+            // We tell the allocator how much the memory of the virtual machine is capable of
+            // growing. A panic here indicates a bug either in the allocator or this module.
             self.vm.grow_memory(to_grow).unwrap();
         }
 

--- a/src/executor/vm.rs
+++ b/src/executor/vm.rs
@@ -49,21 +49,6 @@
 //! is returned and the virtual machine is now paused. Once the logic of the host function has
 //! been executed, call `run` again, passing the return value of that host function.
 //!
-//! # About heap pages
-//!
-//! In the WebAssembly specification, the memory available in the WebAssembly virtual machine has
-//! an initial size and a maximum size. One of the instructions available in WebAssembly code is
-//! [the `memory.grow` instruction](https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-memorymathsfmemorygrow),
-//! which allows increasing the size of the memory.
-//!
-//! The Substrate/Polkadot runtime environment, however, differs. Rather than having a resizable
-//! memory, memory has a fixed size that consists of its initial size plus a number of pages equal
-//! to the value of `heap_pages` passed as parameter. It is forbidden for the WebAssembly code
-//! to use `memory.grow`.
-//!
-//! See also the [`../externals`] module for more information about how memory works in the
-//! context of the Substrate/Polkadot runtime.
-//!
 //! # About `__indirect_function_table`
 //!
 //! At initialization, the virtual machine will look for a table named `__indirect_function_table`.
@@ -154,18 +139,17 @@ impl VirtualMachinePrototype {
     /// See [the module-level documentation](..) for an explanation of the parameters.
     pub fn new(
         module: &Module,
-        heap_pages: HeapPages,
         symbols: impl FnMut(&str, &str, &Signature) -> Result<usize, ()>,
     ) -> Result<Self, NewErr> {
         Ok(VirtualMachinePrototype {
             inner: match &module.inner {
                 ModuleInner::Interpreter(module) => VirtualMachinePrototypeInner::Interpreter(
-                    interpreter::InterpreterPrototype::new(module, heap_pages, symbols)?,
+                    interpreter::InterpreterPrototype::new(module, symbols)?,
                 ),
                 #[cfg(all(target_arch = "x86_64", feature = "std"))]
-                ModuleInner::Jit(module) => VirtualMachinePrototypeInner::Jit(
-                    jit::JitPrototype::new(module, heap_pages, symbols)?,
-                ),
+                ModuleInner::Jit(module) => {
+                    VirtualMachinePrototypeInner::Jit(jit::JitPrototype::new(module, symbols)?)
+                }
             },
         })
     }
@@ -181,10 +165,26 @@ impl VirtualMachinePrototype {
         }
     }
 
+    /// Returns the maximum number of pages that the memory can have.
+    ///
+    /// `None` if there is no limit.
+    pub fn memory_max_pages(&self) -> Option<HeapPages> {
+        match &self.inner {
+            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            VirtualMachinePrototypeInner::Jit(inner) => inner.memory_max_pages(),
+            VirtualMachinePrototypeInner::Interpreter(inner) => inner.memory_max_pages(),
+        }
+    }
+
     /// Turns this prototype into an actual virtual machine. This requires choosing which function
     /// to execute.
+    ///
+    /// The `min_memory_pages` value describes the minimum number of pages of Wasm memory that
+    /// should be initially available to the Wasm function call. In other words, the Wasm code
+    /// must be able to write to any memory location inferior to `min_memory_pages * 64 * 1024`.
     pub fn start(
         mut self,
+        min_memory_pages: HeapPages,
         function_name: &str,
         params: &[WasmValue],
     ) -> Result<VirtualMachine, (StartErr, Self)> {
@@ -201,7 +201,7 @@ impl VirtualMachinePrototype {
                     }
                 }
                 VirtualMachinePrototypeInner::Interpreter(inner) => {
-                    match inner.start(function_name, params) {
+                    match inner.start(min_memory_pages, function_name, params) {
                         Ok(vm) => VirtualMachineInner::Interpreter(vm),
                         Err((err, proto)) => {
                             self.inner = VirtualMachinePrototypeInner::Interpreter(proto);
@@ -253,7 +253,7 @@ impl VirtualMachine {
     /// Returns the size of the memory, in bytes.
     ///
     /// > **Note**: This can change over time if the Wasm code uses the `grow` opcode.
-    pub fn memory_size(&self) -> u32 {
+    pub fn memory_size(&self) -> HeapPages {
         match &self.inner {
             #[cfg(all(target_arch = "x86_64", feature = "std"))]
             VirtualMachineInner::Jit(inner) => inner.memory_size(),
@@ -289,6 +289,18 @@ impl VirtualMachine {
             #[cfg(all(target_arch = "x86_64", feature = "std"))]
             VirtualMachineInner::Jit(inner) => inner.write_memory(offset, value),
             VirtualMachineInner::Interpreter(inner) => inner.write_memory(offset, value),
+        }
+    }
+
+    /// Increases the size of the memory by the given number of pages.
+    ///
+    /// Returns an error if the size of the memory can't be expanded more. This can be known ahead
+    /// of time by using [`VirtualMachinePrototype::memory_max_pages`].
+    pub fn grow_memory(&mut self, additional: HeapPages) -> Result<(), OutOfBoundsError> {
+        match &mut self.inner {
+            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            VirtualMachineInner::Jit(inner) => inner.grow_memory(additional),
+            VirtualMachineInner::Interpreter(inner) => inner.grow_memory(additional),
         }
     }
 
@@ -333,7 +345,11 @@ pub enum ExecHint {
 }
 
 /// Number of heap pages available to the Wasm code.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+///
+/// Each page is 64kiB.
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::Add, derive_more::Sub,
+)]
 pub struct HeapPages(u32);
 
 impl HeapPages {
@@ -631,6 +647,9 @@ pub enum NewErr {
 /// Error that can happen when calling [`VirtualMachinePrototype::start`].
 #[derive(Debug, Clone, derive_more::Display)]
 pub enum StartErr {
+    /// Number of heap pages that have been required is above the limits imposed by the Wasm
+    /// module.
+    RequiredMemoryTooLarge,
     /// Couldn't find the requested function.
     #[display(fmt = "Function to start was not found.")]
     FunctionNotFound,

--- a/src/executor/vm/jit.rs
+++ b/src/executor/vm/jit.rs
@@ -508,10 +508,7 @@ impl Jit {
         Ok(())
     }
 
-    /// Increases the size of the memory by the given number of pages.
-    ///
-    /// Returns an error if the size of the memory can't be expanded more. This can be known ahead
-    /// of time by using [`VirtualMachinePrototype::memory_max_pages`].
+    /// See [`super::VirtualMachine::grow_memory`].
     pub fn grow_memory(&mut self, additional: HeapPages) -> Result<(), OutOfBoundsError> {
         let mem = match self.memory.as_ref() {
             Some(m) => m,

--- a/src/executor/vm/jit.rs
+++ b/src/executor/vm/jit.rs
@@ -25,7 +25,7 @@ use super::{
 use alloc::{boxed::Box, rc::Rc, string::String, vec::Vec};
 use core::{
     cell::RefCell,
-    cmp, fmt,
+    fmt,
     task::{Context, Poll, Waker},
 };
 
@@ -72,6 +72,7 @@ pub struct JitPrototype {
     shared: Rc<RefCell<Shared>>,
 
     /// Reference to the memory used by the module, if any.
+    // TODO: shouldn't be an Option? just return error if no memory?
     memory: Option<wasmtime::Memory>,
 
     /// Reference to the table of indirect functions, in case we need to access it.
@@ -83,7 +84,6 @@ impl JitPrototype {
     /// See [`super::VirtualMachinePrototype::new`].
     pub fn new(
         module: &Module,
-        heap_pages: HeapPages,
         mut symbols: impl FnMut(&str, &str, &Signature) -> Result<usize, ()>,
     ) -> Result<Self, NewErr> {
         let store = wasmtime::Store::new(module.inner.engine());
@@ -189,19 +189,11 @@ impl JitPrototype {
                         )));
                     }
                     wasmtime::ExternType::Memory(m) => {
-                        let limits = {
-                            let heap_pages = u32::from(heap_pages);
-                            let min = cmp::max(m.limits().min(), heap_pages);
-                            let _max = m.limits().max(); // TODO: make sure it's > to min, otherwise error
-                            let num = min + heap_pages;
-                            wasmtime::Limits::new(num, Some(num))
-                        };
-
                         // TODO: check name and all?
                         // TODO: proper error instead of asserting?
                         assert!(imported_memory.is_none());
                         imported_memory = Some(
-                            wasmtime::Memory::new(&store, wasmtime::MemoryType::new(limits))
+                            wasmtime::Memory::new(&store, wasmtime::MemoryType::new(*m.limits()))
                                 .map_err(|_| NewErr::CouldntAllocateMemory)?,
                         );
                         imports.push(wasmtime::Extern::Memory(
@@ -223,8 +215,6 @@ impl JitPrototype {
 
         let exported_memory = if let Some(mem) = instance.get_export("memory") {
             if let Some(mem) = mem.into_memory() {
-                // TODO: do this properly
-                mem.grow(u32::try_from(heap_pages).unwrap()).unwrap();
                 Some(mem)
             } else {
                 return Err(NewErr::MemoryIsntMemory);
@@ -266,6 +256,15 @@ impl JitPrototype {
                 _ => Err(GlobalValueErr::Invalid),
             },
             _ => Err(GlobalValueErr::NotFound),
+        }
+    }
+
+    /// See [`super::VirtualMachinePrototype::memory_max_pages`].
+    pub fn memory_max_pages(&self) -> Option<HeapPages> {
+        if let Some(memory) = &self.memory {
+            Some(HeapPages::new(memory.size()))
+        } else {
+            None
         }
     }
 
@@ -430,13 +429,13 @@ impl Jit {
     }
 
     /// See [`super::VirtualMachine::memory_size`].
-    pub fn memory_size(&self) -> u32 {
+    pub fn memory_size(&self) -> HeapPages {
         let mem = match self.memory.as_ref() {
             Some(m) => m,
-            None => return 0,
+            None => return HeapPages::new(0),
         };
 
-        u32::try_from(mem.data_size()).unwrap()
+        HeapPages::new(u32::try_from(mem.size()).unwrap())
     }
 
     /// See [`super::VirtualMachine::read_memory`].
@@ -464,6 +463,7 @@ impl Jit {
         // Soundness: the documentation of wasmtime precisely explains what is safe or not.
         // Basically, we are safe as long as we are sure that we don't potentially grow the
         // buffer (which would invalidate the buffer pointer).
+        // This is safe because `Jit` doesn't implement `Sync`.
         unsafe {
             if end > mem.data_unchecked().len() {
                 return Err(OutOfBoundsError);
@@ -501,6 +501,25 @@ impl Jit {
                 mem.data_unchecked_mut()[start..end].copy_from_slice(value);
             }
         }
+
+        Ok(())
+    }
+
+    /// Increases the size of the memory by the given number of pages.
+    ///
+    /// Returns an error if the size of the memory can't be expanded more. This can be known ahead
+    /// of time by using [`VirtualMachinePrototype::memory_max_pages`].
+    pub fn grow_memory(&mut self, additional: HeapPages) -> Result<(), OutOfBoundsError> {
+        let mem = match self.memory.as_ref() {
+            Some(m) => m,
+            None => return Err(OutOfBoundsError),
+        };
+
+        // Note that `grow` invalidates the pointer returned by `read_memory` above.
+        // This is safe because `Jit` doesn't implement `Sync`.
+        // TODO: maybe write a test for not implementing Sync? sounds kind of complicated
+        mem.grow(u32::from(additional))
+            .map_err(|_| OutOfBoundsError)?;
 
         Ok(())
     }

--- a/src/executor/vm/jit.rs
+++ b/src/executor/vm/jit.rs
@@ -265,7 +265,7 @@ impl JitPrototype {
     /// See [`super::VirtualMachinePrototype::memory_max_pages`].
     pub fn memory_max_pages(&self) -> Option<HeapPages> {
         if let Some(memory) = &self.memory {
-            Some(HeapPages::new(memory.size()))
+            memory.ty().limits().max().map(HeapPages::new)
         } else {
             None
         }

--- a/src/executor/vm/jit.rs
+++ b/src/executor/vm/jit.rs
@@ -193,8 +193,11 @@ impl JitPrototype {
                         // TODO: proper error instead of asserting?
                         assert!(imported_memory.is_none());
                         imported_memory = Some(
-                            wasmtime::Memory::new(&store, wasmtime::MemoryType::new(*m.limits()))
-                                .map_err(|_| NewErr::CouldntAllocateMemory)?,
+                            wasmtime::Memory::new(
+                                &store,
+                                wasmtime::MemoryType::new(m.limits().clone()),
+                            )
+                            .map_err(|_| NewErr::CouldntAllocateMemory)?,
                         );
                         imports.push(wasmtime::Extern::Memory(
                             imported_memory.as_ref().unwrap().clone(),


### PR DESCRIPTION
This PR fixes the current mess with `heap_pages`.
I now have a better understanding of what heap pages are for.

It also adds a new feature: the memory of the heap is not completely allocated upfront, but lazily when the allocator allocates from it.
In other words, if your heap pages value is for example 10, we start with 0 (and check that 10 would fit) and dynamically increase the actual allocated memory. 10 is only the limit given to the allocator after which it returns an error, but doesn't correspond to an actual amount of allocated memory anymore.
