### PR TITLE
Adjust grammar of CLI option

### DIFF
--- a/bin/full-node/src/cli.rs
+++ b/bin/full-node/src/cli.rs
@@ -38,7 +38,7 @@ use std::{net::SocketAddr, path::PathBuf};
 
 #[derive(Debug, structopt::StructOpt)]
 pub enum CliOptions {
-    /// Connect to the chain and synchronize the local database with the network.
+    /// Connects to the chain and synchronizes the local database with the network.
     Run(CliOptionsRun),
     /// Connects to an IP address and prints some information about the node.
     NodeInfo(CliOptionsNodeInfo),


### PR DESCRIPTION
I actually prefer the current form, but the `--help` option has `s`es as well, so let's go for consistency.