### PR TITLE
Compress the .wasm before base64-encoding it

### DIFF
--- a/bin/wasm-node/javascript/package-lock.json
+++ b/bin/wasm-node/javascript/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "buffer": "^6.0.1",
+        "pako": "^2.0.4",
         "performance-now": "^2.1.0",
         "randombytes": "^2.1.0",
         "websocket": "^1.0.32"
@@ -3535,6 +3536,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "node_modules/parse-json": {
       "version": "4.0.0",
@@ -7899,6 +7905,11 @@
           "dev": true
         }
       }
+    },
+    "pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "parse-json": {
       "version": "4.0.0",

--- a/bin/wasm-node/javascript/package.json
+++ b/bin/wasm-node/javascript/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "buffer": "^6.0.1",
+    "pako": "^2.0.4",
     "performance-now": "^2.1.0",
     "randombytes": "^2.1.0",
     "websocket": "^1.0.32"

--- a/bin/wasm-node/javascript/src/worker.js
+++ b/bin/wasm-node/javascript/src/worker.js
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { Buffer } from 'buffer';
+import { default as pako } from 'pako';
 import * as compat from './compat-nodejs.js';
 import { default as smoldot_light_builder } from './bindings-smoldot-light.js';
 import { default as wasi_builder } from './bindings-wasi.js';
@@ -107,10 +108,11 @@ const injectMessage = (instance, message) => {
 };
 
 const startInstance = async (config) => {
-  // The actual Wasm bytecode is base64-decoded from a constant found in a different file.
+  // The actual Wasm bytecode is base64-decoded then gzip-decoded from a constant found in a
+  // different file.
   // This is suboptimal compared to using `instantiateStreaming`, but it is the most
   // cross-platform cross-bundler approach.
-  const wasmBytecode = new Uint8Array(Buffer.from(wasm_base64, 'base64'));
+  const wasmBytecode = pako.inflate(new Uint8Array(Buffer.from(wasm_base64, 'base64')));
 
   // Used to bind with the smoldot-light bindings. See the `bindings-smoldot-light.js` file.
   const smoldotJsConfig = {


### PR DESCRIPTION
See comment.

Unfortunately, we now depend on a new library, `pako`, which is itself ~200kiB, meaning that we don't actually gain much.
However, this solves the problem of the Mozilla extension store having a maximum allowed size of 4 MiB on individual files.