### PR TITLE
Replace ahash with siphasher

### DIFF
--- a/.github/cargo-deny.toml
+++ b/.github/cargo-deny.toml
@@ -15,5 +15,9 @@ name = "openssl"
 [[bans.deny]]
 name = "ring"
 
+# The `ahash` library algorithm isn't really proven. Nothing bad about it, but let's be cautious.
+[[bans.deny]]
+name = "ahash"
+
 [sources]
 unknown-git = "deny"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,17 +53,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom 0.2.3",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,7 +1142,6 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash",
  "serde",
 ]
 
@@ -1359,9 +1347,6 @@ name = "lru"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c748cfe47cb8da225c37595b3108bea1c198c84aaae8ea0ba76d01dda9fc803"
-dependencies = [
- "hashbrown 0.11.2",
-]
 
 [[package]]
 name = "mach"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,6 +2302,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
+
+[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,7 +2323,6 @@ checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 name = "smoldot"
 version = "0.2.0"
 dependencies = [
- "ahash",
  "arrayvec 0.7.2",
  "async-std",
  "bip39",
@@ -2354,6 +2359,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.0",
+ "siphasher",
  "slab",
  "smallvec",
  "snow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ std = [
 # Before adding a crate here, please make sure that it is `no_std`-compatible. If a crate should
 # theoretically be `no_std`-compatible (i.e. doesn't need the help of the operating system) but is
 # not, or if things are sketchy, please leave a comment next to it.
-ahash = { version = "0.7.6", default-features = false }
 arrayvec = { version = "0.7.2", default-features = false }
 bip39 = { version = "1.0.1", default-features = false }
 blake2-rfc = { version = "0.2.18", default-features = false }
@@ -74,6 +73,7 @@ schnorrkel = { version = "0.10.2", default-features = false, features = ["preaud
 serde = { version = "1.0.130", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0.72", default-features = false, features = ["alloc", "raw_value"] }
 sha2 = { version = "0.10.0", default-features = false }
+siphasher = { version = "0.3.7", default-features = false }
 slab = { version = "0.4.5", default-features = false }
 smallvec = "1.7.0"
 snow = { version = "0.8.0", default-features = false, features = ["default-resolver"] }

--- a/bin/light-base/Cargo.toml
+++ b/bin/light-base/Cargo.toml
@@ -18,7 +18,7 @@ hashbrown = { version = "0.11.2", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 itertools = "0.10.3"
 log = { version = "0.4.14", default-features = false }
-lru = "0.7.0"
+lru = { version = "0.7.0", default-features = false }  # TODO: there's no way to use a custom hasher; remove this dependency
 rand = "0.8.4"
 serde_json = "1.0.72"
 slab = { version = "0.4.5", default-features = false }

--- a/src/identity/keystore.rs
+++ b/src/identity/keystore.rs
@@ -20,6 +20,8 @@
 #![cfg(all(feature = "std"))]
 #![cfg_attr(docsrs, doc(cfg(all(feature = "std"))))]
 
+use crate::util::SipHasherBuild;
+
 use futures::lock::Mutex;
 use rand::{Rng as _, SeedableRng as _};
 
@@ -77,12 +79,7 @@ impl Keystore {
         let mut gen_rng = rand_chacha::ChaCha20Rng::from_seed(randomness_seed);
 
         let keys = hashbrown::HashMap::with_capacity_and_hasher(32, {
-            ahash::RandomState::with_seeds(
-                gen_rng.sample(rand::distributions::Standard),
-                gen_rng.sample(rand::distributions::Standard),
-                gen_rng.sample(rand::distributions::Standard),
-                gen_rng.sample(rand::distributions::Standard),
-            )
+            SipHasherBuild::new(gen_rng.sample(rand::distributions::Standard))
         });
 
         Keystore {
@@ -242,7 +239,7 @@ impl Keystore {
 
 struct Guarded {
     gen_rng: rand_chacha::ChaCha20Rng,
-    keys: hashbrown::HashMap<(KeyNamespace, [u8; 32]), PrivateKey, ahash::RandomState>,
+    keys: hashbrown::HashMap<(KeyNamespace, [u8; 32]), PrivateKey, SipHasherBuild>,
 }
 
 pub struct VrfSignature {

--- a/src/libp2p/collection.rs
+++ b/src/libp2p/collection.rs
@@ -1116,7 +1116,7 @@ where
     fn build_connection_config(
         &self,
         now: &TNow,
-        randomness_seed: [u8; 32],
+        randomness_seed: [u8; 16],
     ) -> established::Config<TNow> {
         established::Config {
             notifications_protocols: self
@@ -1814,7 +1814,7 @@ enum ConnectionInner<TNow> {
         /// While it seems a bit dangerous to leave a randomness seed in plain memory, the
         /// randomness isn't used for anything critical or related to cryptography, but only for
         /// example to avoid hash collision attacks.
-        randomness_seed: [u8; 32],
+        randomness_seed: [u8; 16],
 
         /// When the handshake times out.
         timeout: TNow,

--- a/src/libp2p/connection/established.rs
+++ b/src/libp2p/connection/established.rs
@@ -1094,7 +1094,7 @@ pub struct Config<TNow> {
     /// Time after which an outgoing ping is considered failed.
     pub ping_timeout: Duration,
     /// Entropy used for the randomness specific to this connection.
-    pub randomness_seed: [u8; 32],
+    pub randomness_seed: [u8; 16],
 }
 
 /// Configuration for a request-response protocol.

--- a/src/libp2p/connection/yamux.rs
+++ b/src/libp2p/connection/yamux.rs
@@ -50,6 +50,8 @@
 
 // TODO: the code of this module is rather complicated; either simplify it or write a lot of tests, including fuzzing tests
 
+use crate::util::SipHasherBuild;
+
 use alloc::vec::Vec;
 use core::{cmp, fmt, mem, num::NonZeroU32};
 use hashbrown::hash_map::{Entry, OccupiedEntry};
@@ -61,7 +63,7 @@ pub struct Yamux<T> {
     /// List of substreams currently open in the yamux state machine.
     ///
     /// A SipHasher is used in order to avoid hash collision attacks on substream IDs.
-    substreams: hashbrown::HashMap<NonZeroU32, Substream<T>, ahash::RandomState>,
+    substreams: hashbrown::HashMap<NonZeroU32, Substream<T>, SipHasherBuild>,
 
     /// What kind of data is expected on the socket next.
     incoming: Incoming,
@@ -146,18 +148,7 @@ impl<T> Yamux<T> {
         Yamux {
             substreams: hashbrown::HashMap::with_capacity_and_hasher(
                 config.capacity,
-                ahash::RandomState::with_seeds(
-                    u64::from_ne_bytes(<[u8; 8]>::try_from(&config.randomness_seed[0..8]).unwrap()),
-                    u64::from_ne_bytes(
-                        <[u8; 8]>::try_from(&config.randomness_seed[8..16]).unwrap(),
-                    ),
-                    u64::from_ne_bytes(
-                        <[u8; 8]>::try_from(&config.randomness_seed[16..24]).unwrap(),
-                    ),
-                    u64::from_ne_bytes(
-                        <[u8; 8]>::try_from(&config.randomness_seed[24..32]).unwrap(),
-                    ),
-                ),
+                SipHasherBuild::new(config.randomness_seed),
             ),
             incoming: Incoming::Header(arrayvec::ArrayVec::new()),
             next_outbound_substream: if config.is_initiator {
@@ -906,13 +897,13 @@ pub struct Config {
     pub capacity: usize,
     /// Seed used for the randomness. Used to avoid HashDos attack and determines the order in
     /// which the data on substreams is sent out.
-    pub randomness_seed: [u8; 32],
+    pub randomness_seed: [u8; 16],
 }
 
 /// Reference to a substream within the [`Yamux`].
 // TODO: Debug
 pub struct SubstreamMut<'a, T> {
-    substream: OccupiedEntry<'a, NonZeroU32, Substream<T>, ahash::RandomState>,
+    substream: OccupiedEntry<'a, NonZeroU32, Substream<T>, SipHasherBuild>,
 }
 
 impl<'a, T> SubstreamMut<'a, T> {

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -46,6 +46,7 @@
 //!
 
 use crate::libp2p::{self, collection, PeerId};
+use crate::util::SipHasherBuild;
 
 use alloc::{
     collections::{btree_map, BTreeMap, BTreeSet, VecDeque},
@@ -136,12 +137,7 @@ where
         let mut peer_indices = {
             hashbrown::HashMap::with_capacity_and_hasher(
                 config.peers_capacity,
-                ahash::RandomState::with_seeds(
-                    randomness.sample(rand::distributions::Standard),
-                    randomness.sample(rand::distributions::Standard),
-                    randomness.sample(rand::distributions::Standard),
-                    randomness.sample(rand::distributions::Standard),
-                ),
+                SipHasherBuild::new(randomness.sample(rand::distributions::Standard)),
             )
         };
 
@@ -1655,7 +1651,7 @@ struct Guarded<TConn> {
     peers: slab::Slab<Peer>,
 
     /// For each known peer, the corresponding index within [`Guarded::peers`].
-    peer_indices: hashbrown::HashMap<PeerId, usize, ahash::RandomState>,
+    peer_indices: hashbrown::HashMap<PeerId, usize, SipHasherBuild>,
 
     /// Each connection (handshaking or established) stored in [`Peers::inner`] has a `usize` user
     /// data that is an index within this slab.

--- a/src/util.rs
+++ b/src/util.rs
@@ -22,6 +22,26 @@ use core::str;
 
 pub(crate) mod leb128;
 
+/// Implementation of the `BuildHasher` trait for the sip hasher.
+///
+/// Contrary to the one in the standard library, a seed is explicitly passed here, making the
+/// hashing predictable. This is a good thing for tests and no-std compatibility.
+pub struct SipHasherBuild([u8; 16]);
+
+impl SipHasherBuild {
+    pub fn new(seed: [u8; 16]) -> SipHasherBuild {
+        SipHasherBuild(seed)
+    }
+}
+
+impl core::hash::BuildHasher for SipHasherBuild {
+    type Hasher = siphasher::sip::SipHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        siphasher::sip::SipHasher::new_with_key(&self.0)
+    }
+}
+
 /// Returns a parser that decodes a SCALE-encoded `Option`.
 ///
 /// > **Note**: When using this function outside of a `nom` "context", you might have to explicit


### PR DESCRIPTION
Cryptographers don't seem to be fans of `ahash`.