### PR TITLE
Do the dependencies management through GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: cargo
-    directory: "/"
-    labels: []
-    schedule:
-      interval: "daily"
-    rebase-strategy: disabled  # Redundant with mergify
-    open-pull-requests-limit: 4
-
   - package-ecosystem: "npm"
     directory: "/bin/wasm-node/javascript"
     labels: []

--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -1,0 +1,18 @@
+name: dependencies-update
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  dependencies-update:
+    runs-on: ubuntu-latest
+    container:
+      image: rust
+    steps:
+      - uses: actions/checkout@v2
+      - run: cargo update
+      - uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: Run `cargo update`
+          title: Run `cargo update`
+          branch: update-dependencies
+          delete-branch: true


### PR DESCRIPTION
Dependabot clearly doesn't work properly. Doing `cargo update` now shows tons of updates that the bot hasn't opened PRs for.