### PR TITLE
Reject JSON-RPC requests that are too long

### DIFF
--- a/bin/wasm-node/javascript/src/index.d.ts
+++ b/bin/wasm-node/javascript/src/index.d.ts
@@ -97,7 +97,8 @@ export interface Chain {
    * Be aware that some requests will cause notifications to be sent back using the same callback
    * as the responses.
    *
-   * No response is generated if the request isn't a valid JSON-RPC request. The request is
+   * No response is generated if the request isn't a valid JSON-RPC request or if the request is
+   * unreasonably large (8 MiB at the time of writing of this comment). The request is then
    * silently discarded.
    * If, however, the request is a valid JSON-RPC request but that concerns an unknown method, a
    * error response is properly generated.

--- a/bin/wasm-node/javascript/src/index.js
+++ b/bin/wasm-node/javascript/src/index.js
@@ -124,12 +124,18 @@ export function start(config) {
       // Resolve the promise that `addChain` returned to the user.
       expected.resolve({
         sendJsonRpc: (request) => {
+          // Note: this error isn't covered in the TypeScript documentation, as the type is
+          // normally enforced by TypeScript.
+          if (typeof request !== "string" && !(request instanceof String))
+            throw new Error();
           if (workerError)
             throw workerError;
           if (chainId === null)
             throw new AlreadyDestroyedError();
           if (!chainsJsonRpcCallbacks.has(chainId))
             throw new JsonRpcDisabledError();
+          if (request.length >= 8 * 1024 * 1024)
+            return;
           worker.postMessage({ ty: 'request', request, chainId });
         },
         databaseContent: (maxUtf8BytesSize) => {

--- a/bin/wasm-node/javascript/test/misc.js
+++ b/bin/wasm-node/javascript/test/misc.js
@@ -1,0 +1,51 @@
+// Smoldot
+// Copyright (C) 2019-2022  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import test from 'ava';
+import * as fs from 'fs';
+import { start } from "../src/index.js";
+
+const westendSpec = fs.readFileSync('./test/westend.json', 'utf8');
+
+test('too large json-rpc requests rejected', async t => {
+  let promiseResolve;
+  let promiseReject;
+  const promise = new Promise((resolve, reject) => { promiseResolve = resolve; promiseReject = reject; });
+
+  // Generate a very long string. We start with a length of 1 and double for every iteration.
+  // Thus the final length of the string is `2^i` where `i` is the number of iterations.
+  let veryLongString = 'a';
+  for (let i = 0; i < 24; ++i) {
+    veryLongString += veryLongString;
+  }
+
+  const client = start({ logCallback: () => { } });
+  await client
+    .addChain({
+      chainSpec: westendSpec,
+      jsonRpcCallback: (resp) => { promiseReject(resp) }
+    })
+    .then((chain) => {
+      // The test succeeds if a certain time passes without a response.
+      setTimeout(() => promiseResolve(), 2000);
+      // We use `JSON.stringify` in order to be certain that the request is valid JSON.
+      chain.sendJsonRpc(JSON.stringify({ "jsonrpc": "2.0", "id": 1, "method": "foo", "params": [veryLongString] }), 0, 0);
+    })
+    .then(() => promise)
+    .then(() => t.pass())
+    .then(() => client.terminate());
+});


### PR DESCRIPTION
This is important in order to prevent clients from clogging the server with tons of very large requests.