### PR TITLE
Use debug = 1 for the dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ criterion = "0.3.5"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [profile.dev]
+debug = 1
 opt-level = 2
 panic = "abort"
 [profile.dev.package."*"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ criterion = "0.3.5"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [profile.dev]
-debug = 1
+debug = 1    # Default value is `2`, which contains the full debug info. `1` is enough for stack traces.
 opt-level = 2
 panic = "abort"
 [profile.dev.package."*"]


### PR DESCRIPTION
Reduces the debug wasm size from 95 MiB to 45.8 MiB, and the full node size from 159.9 MiB to 132.2 MiB.