### PR TITLE
Report pruned blocks in runtime service notifications

### DIFF
--- a/bin/light-base/src/json_rpc_service.rs
+++ b/bin/light-base/src/json_rpc_service.rs
@@ -2737,6 +2737,7 @@ impl<TPlat: Platform> Background<TPlat> {
                         either::Left(Some(runtime_service::Notification::Finalized {
                             best_block_hash,
                             hash,
+                            ..
                         }))
                         | either::Right(Some(sync_service::Notification::Finalized {
                             best_block_hash,

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -275,7 +275,7 @@ pub(super) async fn start_parachain<TPlat: Platform>(
                     // Update the local tree of blocks to match the update sent by the relay chain
                     // syncing service.
                     match relay_chain_notif {
-                        runtime_service::Notification::Finalized { hash, best_block_hash } => {
+                        runtime_service::Notification::Finalized { hash, best_block_hash, .. } => {
                             log::debug!(
                                 target: &log_target,
                                 "Relay chain has finalized block 0x{}",


### PR DESCRIPTION
So far my attitude has been "the notifications subscriber can just maintain their own tree of blocks", but it turns out that this is really complicated and annoying to do. Instead, the pruned blocks are also sent by the background task.