### PR TITLE
Add an option to HostVmPrototype::new to allow unresolved imports

### DIFF
--- a/bin/full-node/src/run/consensus_service.rs
+++ b/bin/full-node/src/run/consensus_service.rs
@@ -200,6 +200,7 @@ impl ConsensusService {
                             module,
                             heap_pages,
                             executor::vm::ExecHint::CompileAheadOfTime, // TODO: probably should be decided by the optimisticsync
+                            false,
                         )
                         .unwrap()
                     },

--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -449,6 +449,7 @@ impl<TPlat: Platform> RuntimeService<TPlat> {
                 .map_err(RuntimeError::InvalidHeapPages)
                 .map_err(RuntimeCallError::InvalidRuntime)?,
             executor::vm::ExecHint::CompileAheadOfTime,
+            true,
         ) {
             Ok(vm) => vm,
             Err(error) => {
@@ -2543,6 +2544,7 @@ impl SuccessfulRuntime {
             executor::storage_heap_pages_to_value(heap_pages.as_deref())
                 .map_err(RuntimeError::InvalidHeapPages)?,
             executor::vm::ExecHint::CompileAheadOfTime,
+            true,
         ) {
             Ok(vm) => vm,
             Err(error) => {

--- a/src/author/runtime/tests.rs
+++ b/src/author/runtime/tests.rs
@@ -38,6 +38,7 @@ fn block_building_works() {
             code,
             crate::executor::DEFAULT_HEAP_PAGES,
             crate::executor::vm::ExecHint::Oneshot,
+            false,
         )
         .unwrap()
     };

--- a/src/chain/chain_information/aura_config.rs
+++ b/src/chain/chain_information/aura_config.rs
@@ -51,7 +51,7 @@ impl AuraConfiguration {
         let heap_pages =
             executor::storage_heap_pages_to_value(storage_access(b":heappages").as_deref())
                 .map_err(FromStorageError::HeapPagesDecode)?;
-        let vm = host::HostVmPrototype::new(&wasm_code, heap_pages, vm::ExecHint::Oneshot)
+        let vm = host::HostVmPrototype::new(&wasm_code, heap_pages, vm::ExecHint::Oneshot, false)
             .map_err(FromStorageError::VmInitialization)?;
         let (cfg, _) = Self::from_virtual_machine_prototype(vm, storage_access)
             .map_err(FromStorageError::VmError)?;

--- a/src/chain/chain_information/babe_genesis_config.rs
+++ b/src/chain/chain_information/babe_genesis_config.rs
@@ -46,7 +46,7 @@ impl BabeGenesisConfiguration {
         let heap_pages =
             executor::storage_heap_pages_to_value(genesis_storage_access(b":heappages").as_deref())
                 .map_err(FromGenesisStorageError::HeapPagesDecode)?;
-        let vm = host::HostVmPrototype::new(&wasm_code, heap_pages, vm::ExecHint::Oneshot)
+        let vm = host::HostVmPrototype::new(&wasm_code, heap_pages, vm::ExecHint::Oneshot, false)
             .map_err(FromGenesisStorageError::VmInitialization)?;
         let (cfg, _) = Self::from_virtual_machine_prototype(vm, genesis_storage_access)
             .map_err(FromGenesisStorageError::VmError)?;

--- a/src/chain/chain_information/grandpa_genesis_config.rs
+++ b/src/chain/chain_information/grandpa_genesis_config.rs
@@ -64,8 +64,9 @@ impl GrandpaGenesisConfiguration {
                 genesis_storage_access(b":heappages").as_deref(),
             )
             .map_err(FromGenesisStorageError::HeapPagesDecode)?;
-            let vm = host::HostVmPrototype::new(&wasm_code, heap_pages, vm::ExecHint::Oneshot, false)
-                .map_err(FromGenesisStorageError::VmInitialization)?;
+            let vm =
+                host::HostVmPrototype::new(&wasm_code, heap_pages, vm::ExecHint::Oneshot, false)
+                    .map_err(FromGenesisStorageError::VmInitialization)?;
             Self::from_virtual_machine_prototype(vm, genesis_storage_access)
                 .map_err(FromGenesisStorageError::VmError)?
         };

--- a/src/chain/chain_information/grandpa_genesis_config.rs
+++ b/src/chain/chain_information/grandpa_genesis_config.rs
@@ -64,7 +64,7 @@ impl GrandpaGenesisConfiguration {
                 genesis_storage_access(b":heappages").as_deref(),
             )
             .map_err(FromGenesisStorageError::HeapPagesDecode)?;
-            let vm = host::HostVmPrototype::new(&wasm_code, heap_pages, vm::ExecHint::Oneshot)
+            let vm = host::HostVmPrototype::new(&wasm_code, heap_pages, vm::ExecHint::Oneshot, false)
                 .map_err(FromGenesisStorageError::VmInitialization)?;
             Self::from_virtual_machine_prototype(vm, genesis_storage_access)
                 .map_err(FromGenesisStorageError::VmError)?

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -142,7 +142,8 @@
 //!     let prototype = HostVmPrototype::new(
 //!         &wasm_binary_code,
 //!         HeapPages::from(2048),
-//!         smoldot::executor::vm::ExecHint::Oneshot
+//!         smoldot::executor::vm::ExecHint::Oneshot,
+//!         false
 //!     ).unwrap();
 //!     prototype.run_no_param("Core_version").unwrap().into()
 //! };

--- a/src/executor/read_only_runtime_host.rs
+++ b/src/executor/read_only_runtime_host.rs
@@ -306,7 +306,7 @@ impl Inner {
                         req.wasm_code(),
                         executor::DEFAULT_HEAP_PAGES,
                         vm::ExecHint::Oneshot,
-                        false,
+                        false, // TODO: what is a correct value here?
                     ) {
                         Ok(w) => w,
                         Err(_) => {

--- a/src/executor/read_only_runtime_host.rs
+++ b/src/executor/read_only_runtime_host.rs
@@ -306,6 +306,7 @@ impl Inner {
                         req.wasm_code(),
                         executor::DEFAULT_HEAP_PAGES,
                         vm::ExecHint::Oneshot,
+                        false,
                     ) {
                         Ok(w) => w,
                         Err(_) => {

--- a/src/executor/runtime_host.rs
+++ b/src/executor/runtime_host.rs
@@ -715,6 +715,7 @@ impl Inner {
                         req.wasm_code(),
                         executor::DEFAULT_HEAP_PAGES,
                         vm::ExecHint::Oneshot,
+                        false,
                     ) {
                         Ok(w) => w,
                         Err(_) => {

--- a/src/executor/runtime_host.rs
+++ b/src/executor/runtime_host.rs
@@ -715,7 +715,7 @@ impl Inner {
                         req.wasm_code(),
                         executor::DEFAULT_HEAP_PAGES,
                         vm::ExecHint::Oneshot,
-                        false,
+                        false, // TODO: what is a correct value here?
                     ) {
                         Ok(w) => w,
                         Err(_) => {

--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -1237,8 +1237,13 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                 // the runtime to the API user. The API user might then immediately throw away
                 // this runtime, but we don't care enough about this possibility to optimize
                 // this.
-                let (grandpa_warp_sync, error) =
-                    sync.set_virtual_machine_params(code, heap_pages, ExecHint::CompileAheadOfTime);
+                // TODO: make `allow_unresolved_imports` configurable
+                let (grandpa_warp_sync, error) = sync.set_virtual_machine_params(
+                    code,
+                    heap_pages,
+                    ExecHint::CompileAheadOfTime,
+                    false,
+                );
 
                 if let Some(_error) = error {
                     // TODO: error handling

--- a/src/sync/warp_sync.rs
+++ b/src/sync/warp_sync.rs
@@ -902,6 +902,7 @@ impl<TSrc> VirtualMachineParamsGet<TSrc> {
         code: Option<impl AsRef<[u8]>>,
         heap_pages: Option<impl AsRef<[u8]>>,
         exec_hint: ExecHint,
+        allow_unresolved_imports: bool,
     ) -> (WarpSync<TSrc>, Option<Error>) {
         let code = match code {
             Some(code) => code.as_ref().to_vec(),
@@ -938,7 +939,12 @@ impl<TSrc> VirtualMachineParamsGet<TSrc> {
                 }
             };
 
-        match HostVmPrototype::new(&code, decoded_heap_pages, exec_hint) {
+        match HostVmPrototype::new(
+            &code,
+            decoded_heap_pages,
+            exec_hint,
+            allow_unresolved_imports,
+        ) {
             Ok(runtime) => {
                 let babe_current_epoch_query =
                     babe_fetch_epoch::babe_fetch_epoch(babe_fetch_epoch::Config {

--- a/src/verify/header_body.rs
+++ b/src/verify/header_body.rs
@@ -501,6 +501,7 @@ impl RuntimeCompilation {
             code,
             self.heap_pages,
             vm::ExecHint::CompileAheadOfTime,
+            false,
         ) {
             Ok(vm) => vm,
             Err(err) => {


### PR DESCRIPTION
cc https://github.com/paritytech/smoldot/pull/1838

The idea is that there's no need to prevent the runtime from compiling if it uses host functions. The problem only comes when these functions are called, in which case we trap.

This is helpful in situations where, for example, the runtime uses a new offchain worker function, but we don't care since we don't run offchain workers.

The values I've put are:

- `false` for things that touches the genesis runtime, as it's useful to detect problems there.
- `false` but with a `TODO: make configurable` for GrandPa warp syncing, with the intention to switch to `true` in the light client.
- `false` but with a `TODO` for the implementation of `ext_misc_runtime_version_version_1`.
- `true` in the light client.
