### PR TITLE
Add a name to the worker when in the browser

### DIFF
--- a/bin/wasm-node/javascript/src/worker/spawn-browser-overwrite.js
+++ b/bin/wasm-node/javascript/src/worker/spawn-browser-overwrite.js
@@ -24,6 +24,6 @@ export default function () {
     // Because this line is precisely recognized by bundlers, we extract it to a separate
     // JavaScript file.
     // See also the README.md for more context.
-    const worker = new Worker(new URL('./worker.js', import.meta.url));
+    const worker = new Worker(new URL('./worker.js', import.meta.url), { name: "smoldot" });
     return worker;
 }


### PR DESCRIPTION
Tested with WebPack 5 on Firefox and Chrome. Firefox doesn't seem to display the name anywhere.