### PR TITLE
Better select peers for storage queries

### DIFF
--- a/bin/light-base/src/json_rpc_service.rs
+++ b/bin/light-base/src/json_rpc_service.rs
@@ -949,7 +949,7 @@ impl<TPlat: Platform> Background<TPlat> {
         keys: impl Iterator<Item = impl AsRef<[u8]>> + Clone,
         hash: &[u8; 32],
     ) -> Result<Vec<Option<Vec<u8>>>, StorageQueryError> {
-        let (state_trie_root_hash, _) = self
+        let (state_trie_root_hash, block_number) = self
             .state_trie_root_hash(&hash)
             .await
             .map_err(|()| StorageQueryError::FindStorageRootHashError)?;
@@ -957,7 +957,7 @@ impl<TPlat: Platform> Background<TPlat> {
         let result = self
             .sync_service
             .clone()
-            .storage_query(hash, &state_trie_root_hash, keys)
+            .storage_query(block_number, hash, &state_trie_root_hash, keys)
             .await
             .map_err(StorageQueryError::StorageRetrieval)?;
 
@@ -1014,6 +1014,7 @@ impl<TPlat: Platform> Background<TPlat> {
                         .sync_service
                         .clone()
                         .storage_query(
+                            block_number,
                             block_hash,
                             &state_trie_root_hash,
                             iter::once(&b":code"[..]).chain(iter::once(&b":heappages"[..])),

--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -2055,10 +2055,12 @@ impl<TPlat: Platform> Background<TPlat> {
                         let sync_service = self.sync_service.clone();
                         let block_hash = download_params.block_user_data.hash;
                         let state_root = *decoded_header.state_root;
+                        let block_number = decoded_header.number;
 
                         Box::pin(async move {
                             let result = sync_service
                                 .storage_query(
+                                    block_number,
                                     &block_hash,
                                     &state_root,
                                     iter::once(&b":code"[..]).chain(iter::once(&b":heappages"[..])),


### PR DESCRIPTION
Right now a storage query is done by just asking 3 random peers. This PR changes this to instead ask peers that are presumed to know about the block in question. This requires passing the block number to the `storage_query` function.