### PR TITLE
Better peers selection in SyncService::block_query

### DIFF
--- a/bin/light-base/src/json_rpc_service.rs
+++ b/bin/light-base/src/json_rpc_service.rs
@@ -903,7 +903,7 @@ impl<TPlat: Platform> Background<TPlat> {
                             // The sync service knows which peers are potentially aware of
                             // this block.
                             let result = sync_service
-                                .block_query(
+                                .block_query_unknown_number(
                                     hash,
                                     protocol::BlocksRequestFields {
                                         header: true,


### PR DESCRIPTION
Same as https://github.com/paritytech/smoldot/pull/1928 but for `block_query`.

As usual, the most tricky part of the code to update were the legacy JSON-RPC functions in `state_chain.rs`.
