### PR TITLE
Accept empty proofs if finished: true

### DIFF
--- a/src/chain/chain_information.rs
+++ b/src/chain/chain_information.rs
@@ -159,19 +159,7 @@ impl<'a> From<ChainInformationRef<'a>> for ChainInformation {
                     finalized_next_epoch_transition: finalized_next_epoch_transition.into(),
                 },
             },
-            finality: match info.finality {
-                ChainInformationFinalityRef::Outsourced => ChainInformationFinality::Outsourced,
-                ChainInformationFinalityRef::Grandpa {
-                    after_finalized_block_authorities_set_id,
-                    finalized_triggered_authorities,
-                    finalized_scheduled_change,
-                } => ChainInformationFinality::Grandpa {
-                    after_finalized_block_authorities_set_id,
-                    finalized_scheduled_change: finalized_scheduled_change
-                        .map(|(n, l)| (n, l.into())),
-                    finalized_triggered_authorities: finalized_triggered_authorities.into(),
-                },
-            },
+            finality: info.finality.into(),
         }
     }
 }
@@ -323,6 +311,23 @@ pub enum ChainInformationFinality {
         /// >           change is triggered is the same as the one where it is scheduled.
         finalized_scheduled_change: Option<(u64, Vec<header::GrandpaAuthority>)>,
     },
+}
+
+impl<'a> From<ChainInformationFinalityRef<'a>> for ChainInformationFinality {
+    fn from(finality: ChainInformationFinalityRef<'a>) -> ChainInformationFinality {
+        match finality {
+            ChainInformationFinalityRef::Outsourced => ChainInformationFinality::Outsourced,
+            ChainInformationFinalityRef::Grandpa {
+                after_finalized_block_authorities_set_id,
+                finalized_triggered_authorities,
+                finalized_scheduled_change,
+            } => ChainInformationFinality::Grandpa {
+                after_finalized_block_authorities_set_id,
+                finalized_scheduled_change: finalized_scheduled_change.map(|(n, l)| (n, l.into())),
+                finalized_triggered_authorities: finalized_triggered_authorities.into(),
+            },
+        }
+    }
 }
 
 /// Equivalent to a [`ChainInformation`] but referencing an existing structure. Cheap to copy.

--- a/src/finality/grandpa/warp_sync.rs
+++ b/src/finality/grandpa/warp_sync.rs
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// TODO: really needs documentation
+
 use crate::chain::chain_information::{ChainInformationFinality, ChainInformationFinalityRef};
 use crate::finality;
 use crate::finality::justification::verify::{
@@ -124,7 +126,11 @@ impl Verifier {
         }
 
         if self.fragments.is_empty() {
-            return Err(Error::EmptyProof);
+            if self.is_proof_complete {
+                return Ok(Next::EmptyProof);
+            } else {
+                return Err(Error::EmptyProof);
+            }
         }
 
         debug_assert!(self.fragments.len() > self.index);
@@ -196,6 +202,7 @@ impl Verifier {
 
 pub enum Next {
     NotFinished(Verifier),
+    EmptyProof,
     Success {
         scale_encoded_header: Vec<u8>,
         chain_information_finality: ChainInformationFinality,

--- a/src/sync/warp_sync.rs
+++ b/src/sync/warp_sync.rs
@@ -678,6 +678,28 @@ impl<TSrc> Verifier<TSrc> {
                 }),
                 Ok(()),
             ),
+            Ok(warp_sync::Next::EmptyProof) => (
+                InProgressWarpSync::VirtualMachineParamsGet(VirtualMachineParamsGet {
+                    state: PostVerificationState {
+                        header: self
+                            .state
+                            .start_chain_information
+                            .as_ref()
+                            .finalized_block_header
+                            .into(),
+                        chain_information_finality: self
+                            .state
+                            .start_chain_information
+                            .as_ref()
+                            .finality
+                            .into(),
+                        start_chain_information: self.state.start_chain_information,
+                        sources: self.sources,
+                        warp_sync_source_id: self.warp_sync_source_id,
+                    },
+                }),
+                Ok(()),
+            ),
             Ok(warp_sync::Next::Success {
                 scale_encoded_header,
                 chain_information_finality,


### PR DESCRIPTION
Right now, if we do a warp sync proof and the node returns "well, I have nothing", we print an error. This PR changes this so that we accept the proof instead.

While this could lead to nodes pretending to have nothing even though they have things, it is already the case today that nodes can return fewer fragments than they actually have. While this would be annoying, this isn't really an attack as it would only change the moment when we switch to a slower syncing technique.

Fix https://github.com/paritytech/smoldot/issues/1952

cc https://github.com/paritytech/smoldot/issues/722