### PR TITLE
Support chain specs with `forkId`

### DIFF
--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -215,6 +215,13 @@ impl ChainSpec {
         self.client_spec.protocol_id.as_deref().unwrap_or("sup")
     }
 
+    /// Returns the "fork id" of the chain. This is arbitrary string that can be used in order to
+    /// segregate nodes in case when multiple chains have the same genesis hash. Nodes should only
+    /// synchronize with nodes that have the same "fork id".
+    pub fn fork_id(&self) -> Option<&str> {
+        self.client_spec.fork_id.as_deref()
+    }
+
     // TODO: this API is probably unstable, as the meaning of the string is unclear
     pub fn relay_chain(&self) -> Option<(&str, u32)> {
         self.client_spec

--- a/src/chain_spec/structs.rs
+++ b/src/chain_spec/structs.rs
@@ -53,6 +53,8 @@ pub(super) struct ClientSpec {
     pub(super) boot_nodes: Vec<String>,
     pub(super) telemetry_endpoints: Option<Vec<(String, u8)>>,
     pub(super) protocol_id: Option<String>,
+    #[serde(default = "Default::default", skip_serializing_if = "Option::is_none")]
+    pub(super) fork_id: Option<String>,
     pub(super) properties: Option<Box<serde_json::value::RawValue>>,
     // TODO: make use of this
     pub(super) fork_blocks: Option<Vec<(u64, HashHexString)>>,


### PR DESCRIPTION
cc https://github.com/paritytech/smoldot/issues/1955

This PR adds support for chain specs with a `forkId` field, because they exist in the wild now and we need to be able to parse them.
The purpose of the `forkId` is to eventually replace `protocolId`, but at the moment Substrate/Polkadot nodes only support `protocolId` when it comes to released versions, and support both when it comes to the master branch.

Another smoldot PR later should add support for `forkId` once Substrate/Polkadot have released a version that uses it.
