### PR TITLE
Give proper requests count and timeout parameters to every network request

### DIFF
--- a/bin/full-node/src/run/network_service.rs
+++ b/bin/full-node/src/run/network_service.rs
@@ -718,7 +718,13 @@ impl NetworkService {
 
         self.inner
             .network
-            .blocks_request(Instant::now(), &target, chain_index, config)
+            .blocks_request(
+                Instant::now(),
+                &target,
+                chain_index,
+                config,
+                Duration::from_secs(12),
+            )
             .await
     }
 }

--- a/bin/light-base/src/json_rpc_service.rs
+++ b/bin/light-base/src/json_rpc_service.rs
@@ -994,9 +994,7 @@ impl<TPlat: Platform> Background<TPlat> {
                 .await;
             }
 
-            _method
-            @
-            (methods::MethodCall::account_nextIndex { .. }
+            _method @ (methods::MethodCall::account_nextIndex { .. }
             | methods::MethodCall::author_hasKey { .. }
             | methods::MethodCall::author_hasSessionKeys { .. }
             | methods::MethodCall::author_insertKey { .. }

--- a/bin/light-base/src/json_rpc_service.rs
+++ b/bin/light-base/src/json_rpc_service.rs
@@ -61,6 +61,7 @@ use std::{
     num::NonZeroU32,
     str,
     sync::{atomic, Arc},
+    time::Duration,
 };
 
 /// Configuration for a JSON-RPC service.
@@ -655,10 +656,12 @@ impl<TPlat: Platform> Background<TPlat> {
         // Each call is handled in a separate method.
         match call {
             methods::MethodCall::author_pendingExtrinsics {} => {
-                self.author_pending_extrinsics(request_id, &state_machine_request_id).await;
+                self.author_pending_extrinsics(request_id, &state_machine_request_id)
+                    .await;
             }
             methods::MethodCall::author_submitExtrinsic { transaction } => {
-                self.author_submit_extrinsic(request_id, &state_machine_request_id, transaction).await;
+                self.author_submit_extrinsic(request_id, &state_machine_request_id, transaction)
+                    .await;
             }
             methods::MethodCall::author_submitAndWatchExtrinsic { transaction } => {
                 self.submit_and_watch_transaction(
@@ -670,10 +673,12 @@ impl<TPlat: Platform> Background<TPlat> {
                 .await
             }
             methods::MethodCall::author_unwatchExtrinsic { subscription } => {
-                self.author_unwatch_extrinsic(request_id, &state_machine_request_id, subscription).await;
+                self.author_unwatch_extrinsic(request_id, &state_machine_request_id, subscription)
+                    .await;
             }
             methods::MethodCall::chain_getBlock { hash } => {
-                self.chain_get_block(request_id, &state_machine_request_id, hash).await;
+                self.chain_get_block(request_id, &state_machine_request_id, hash)
+                    .await;
             }
             methods::MethodCall::chain_getBlockHash { height } => {
                 self.chain_get_block_hash(request_id, &state_machine_request_id, height)
@@ -684,7 +689,8 @@ impl<TPlat: Platform> Background<TPlat> {
                     .await;
             }
             methods::MethodCall::chain_getHeader { hash } => {
-                self.chain_get_header(request_id, &state_machine_request_id, hash).await;
+                self.chain_get_header(request_id, &state_machine_request_id, hash)
+                    .await;
             }
             methods::MethodCall::chain_subscribeAllHeads {} => {
                 self.chain_subscribe_all_heads(request_id, &state_machine_request_id)
@@ -699,19 +705,41 @@ impl<TPlat: Platform> Background<TPlat> {
                     .await;
             }
             methods::MethodCall::chain_unsubscribeAllHeads { subscription } => {
-                self.chain_unsubscribe_all_heads(request_id, &state_machine_request_id, subscription).await;
+                self.chain_unsubscribe_all_heads(
+                    request_id,
+                    &state_machine_request_id,
+                    subscription,
+                )
+                .await;
             }
             methods::MethodCall::chain_unsubscribeFinalizedHeads { subscription } => {
-                self.chain_unsubscribe_finalized_heads(request_id, &state_machine_request_id, subscription).await;
+                self.chain_unsubscribe_finalized_heads(
+                    request_id,
+                    &state_machine_request_id,
+                    subscription,
+                )
+                .await;
             }
             methods::MethodCall::chain_unsubscribeNewHeads { subscription } => {
-                self.chain_unsubscribe_new_heads(request_id, &state_machine_request_id, subscription).await;
+                self.chain_unsubscribe_new_heads(
+                    request_id,
+                    &state_machine_request_id,
+                    subscription,
+                )
+                .await;
             }
             methods::MethodCall::payment_queryInfo { extrinsic, hash } => {
-                self.payment_query_info(request_id, &state_machine_request_id, &extrinsic.0, hash.as_ref().map(|h| &h.0)).await;
+                self.payment_query_info(
+                    request_id,
+                    &state_machine_request_id,
+                    &extrinsic.0,
+                    hash.as_ref().map(|h| &h.0),
+                )
+                .await;
             }
             methods::MethodCall::rpc_methods {} => {
-                self.rpc_methods(request_id, &state_machine_request_id).await;
+                self.rpc_methods(request_id, &state_machine_request_id)
+                    .await;
             }
             methods::MethodCall::state_getKeysPaged {
                 prefix,
@@ -719,87 +747,152 @@ impl<TPlat: Platform> Background<TPlat> {
                 start_key,
                 hash,
             } => {
-                self.state_get_keys_paged(request_id, &state_machine_request_id, prefix, count, start_key, hash).await;
+                self.state_get_keys_paged(
+                    request_id,
+                    &state_machine_request_id,
+                    prefix,
+                    count,
+                    start_key,
+                    hash,
+                )
+                .await;
             }
             methods::MethodCall::state_queryStorageAt { keys, at } => {
-                self.state_query_storage_at(request_id, &state_machine_request_id, keys, at).await;
+                self.state_query_storage_at(request_id, &state_machine_request_id, keys, at)
+                    .await;
             }
             methods::MethodCall::state_getMetadata { hash } => {
-                self.state_get_metadata(request_id, &state_machine_request_id, hash).await;
+                self.state_get_metadata(request_id, &state_machine_request_id, hash)
+                    .await;
             }
             methods::MethodCall::state_getStorage { key, hash } => {
-                self.state_get_storage(request_id, &state_machine_request_id, key, hash).await;
+                self.state_get_storage(request_id, &state_machine_request_id, key, hash)
+                    .await;
             }
             methods::MethodCall::state_subscribeRuntimeVersion {} => {
-                self.state_subscribe_runtime_version(request_id, &state_machine_request_id).await;
+                self.state_subscribe_runtime_version(request_id, &state_machine_request_id)
+                    .await;
             }
             methods::MethodCall::state_unsubscribeRuntimeVersion { subscription } => {
-                self.state_unsubscribe_runtime_version(request_id, &state_machine_request_id, subscription).await;
+                self.state_unsubscribe_runtime_version(
+                    request_id,
+                    &state_machine_request_id,
+                    subscription,
+                )
+                .await;
             }
             methods::MethodCall::state_subscribeStorage { list } => {
-                self.state_subscribe_storage(request_id, &state_machine_request_id, list).await;
+                self.state_subscribe_storage(request_id, &state_machine_request_id, list)
+                    .await;
             }
             methods::MethodCall::state_unsubscribeStorage { subscription } => {
-                self.state_unsubscribe_storage(request_id, &state_machine_request_id, subscription).await;
+                self.state_unsubscribe_storage(request_id, &state_machine_request_id, subscription)
+                    .await;
             }
             methods::MethodCall::state_getRuntimeVersion { at } => {
-                self.state_get_runtime_version(request_id, &state_machine_request_id, at.as_ref().map(|h| &h.0)).await;
+                self.state_get_runtime_version(
+                    request_id,
+                    &state_machine_request_id,
+                    at.as_ref().map(|h| &h.0),
+                )
+                .await;
             }
             methods::MethodCall::system_accountNextIndex { account } => {
-                self.account_next_index(request_id, &state_machine_request_id, account).await;
+                self.account_next_index(request_id, &state_machine_request_id, account)
+                    .await;
             }
             methods::MethodCall::system_chain {} => {
-                self.system_chain(request_id, &state_machine_request_id).await;
+                self.system_chain(request_id, &state_machine_request_id)
+                    .await;
             }
             methods::MethodCall::system_chainType {} => {
-                self.system_chain_type(request_id, &state_machine_request_id).await;
+                self.system_chain_type(request_id, &state_machine_request_id)
+                    .await;
             }
             methods::MethodCall::system_health {} => {
-                self.system_health(request_id, &state_machine_request_id).await;
+                self.system_health(request_id, &state_machine_request_id)
+                    .await;
             }
             methods::MethodCall::system_localListenAddresses {} => {
-                self.system_local_listen_addresses(request_id, &state_machine_request_id).await;
+                self.system_local_listen_addresses(request_id, &state_machine_request_id)
+                    .await;
             }
             methods::MethodCall::system_localPeerId {} => {
-                self.system_local_peer_id(request_id, &state_machine_request_id).await;
+                self.system_local_peer_id(request_id, &state_machine_request_id)
+                    .await;
             }
             methods::MethodCall::system_name {} => {
-                self.system_name(request_id, &state_machine_request_id).await;
+                self.system_name(request_id, &state_machine_request_id)
+                    .await;
             }
             methods::MethodCall::system_peers {} => {
-                self.system_peers(request_id, &state_machine_request_id).await;
+                self.system_peers(request_id, &state_machine_request_id)
+                    .await;
             }
             methods::MethodCall::system_properties {} => {
-                self.system_properties(request_id, &state_machine_request_id).await;
+                self.system_properties(request_id, &state_machine_request_id)
+                    .await;
             }
             methods::MethodCall::system_version {} => {
-                self.system_version(request_id, &state_machine_request_id).await;
+                self.system_version(request_id, &state_machine_request_id)
+                    .await;
             }
 
             methods::MethodCall::chainHead_unstable_stopBody { subscription_id } => {
-                self.chain_head_unstable_stop_body(request_id, &state_machine_request_id, subscription_id).await;
+                self.chain_head_unstable_stop_body(
+                    request_id,
+                    &state_machine_request_id,
+                    subscription_id,
+                )
+                .await;
             }
             methods::MethodCall::chainHead_unstable_body {
                 follow_subscription_id,
                 hash,
-                .. // TODO: network_config
+                network_config,
             } => {
-                self.chain_head_unstable_body(request_id, &state_machine_request_id, follow_subscription_id, hash).await;
+                self.chain_head_unstable_body(
+                    request_id,
+                    &state_machine_request_id,
+                    follow_subscription_id,
+                    hash,
+                    network_config,
+                )
+                .await;
             }
             methods::MethodCall::chainHead_unstable_call {
                 follow_subscription_id,
                 hash,
                 function,
                 call_parameters,
-                .. // TODO: network_config
+                network_config,
             } => {
-                self.chain_head_call(request_id, &state_machine_request_id, follow_subscription_id, hash, function, call_parameters).await;
+                self.chain_head_call(
+                    request_id,
+                    &state_machine_request_id,
+                    follow_subscription_id,
+                    hash,
+                    function,
+                    call_parameters,
+                    network_config,
+                )
+                .await;
             }
             methods::MethodCall::chainHead_unstable_stopCall { subscription_id } => {
-                self.chain_head_unstable_stop_call(request_id, &state_machine_request_id, subscription_id).await;
+                self.chain_head_unstable_stop_call(
+                    request_id,
+                    &state_machine_request_id,
+                    subscription_id,
+                )
+                .await;
             }
             methods::MethodCall::chainHead_unstable_stopStorage { subscription_id } => {
-                self.chain_head_unstable_stop_storage(request_id, &state_machine_request_id, subscription_id).await;
+                self.chain_head_unstable_stop_storage(
+                    request_id,
+                    &state_machine_request_id,
+                    subscription_id,
+                )
+                .await;
             }
             methods::MethodCall::chainHead_unstable_storage {
                 follow_subscription_id,
@@ -807,48 +900,81 @@ impl<TPlat: Platform> Background<TPlat> {
                 key,
                 child_key,
                 r#type: ty,
-                .. // TODO: network_config
+                network_config,
             } => {
-                self.chain_head_storage(request_id, &state_machine_request_id, follow_subscription_id, hash, key, child_key, ty).await;
+                self.chain_head_storage(
+                    request_id,
+                    &state_machine_request_id,
+                    follow_subscription_id,
+                    hash,
+                    key,
+                    child_key,
+                    ty,
+                    network_config,
+                )
+                .await;
             }
             methods::MethodCall::chainHead_unstable_follow { runtime_updates } => {
                 self.chain_head_follow(request_id, &state_machine_request_id, runtime_updates)
                     .await;
             }
             methods::MethodCall::chainHead_unstable_genesisHash {} => {
-                self.chain_head_unstable_genesis_hash(request_id, &state_machine_request_id).await;
+                self.chain_head_unstable_genesis_hash(request_id, &state_machine_request_id)
+                    .await;
             }
             methods::MethodCall::chainHead_unstable_header {
                 follow_subscription_id,
                 hash,
             } => {
-                self.chain_head_unstable_header(request_id, &state_machine_request_id, follow_subscription_id, hash).await;
+                self.chain_head_unstable_header(
+                    request_id,
+                    &state_machine_request_id,
+                    follow_subscription_id,
+                    hash,
+                )
+                .await;
             }
             methods::MethodCall::chainHead_unstable_unpin {
                 follow_subscription_id,
                 hash,
             } => {
-                self.chain_head_unstable_unpin(request_id, &state_machine_request_id, follow_subscription_id, hash).await;
+                self.chain_head_unstable_unpin(
+                    request_id,
+                    &state_machine_request_id,
+                    follow_subscription_id,
+                    hash,
+                )
+                .await;
             }
             methods::MethodCall::chainHead_unstable_unfollow {
                 follow_subscription_id,
             } => {
-                self.chain_head_unstable_unfollow(request_id, &state_machine_request_id, follow_subscription_id).await;
+                self.chain_head_unstable_unfollow(
+                    request_id,
+                    &state_machine_request_id,
+                    follow_subscription_id,
+                )
+                .await;
             }
             methods::MethodCall::chainSpec_unstable_chainName {} => {
-                self.chain_spec_unstable_chain_name(request_id, &state_machine_request_id).await;
+                self.chain_spec_unstable_chain_name(request_id, &state_machine_request_id)
+                    .await;
             }
             methods::MethodCall::chainSpec_unstable_genesisHash {} => {
-                self.chain_spec_unstable_genesis_hash(request_id, &state_machine_request_id).await;
+                self.chain_spec_unstable_genesis_hash(request_id, &state_machine_request_id)
+                    .await;
             }
             methods::MethodCall::chainSpec_unstable_properties {} => {
-                self.chain_spec_unstable_properties(request_id, &state_machine_request_id).await;
+                self.chain_spec_unstable_properties(request_id, &state_machine_request_id)
+                    .await;
             }
             methods::MethodCall::sudo_unstable_p2pDiscover { multiaddr } => {
-                self.sudo_unstable_p2p_discover(request_id, &state_machine_request_id, multiaddr).await;
+                self.sudo_unstable_p2p_discover(request_id, &state_machine_request_id, multiaddr)
+                    .await;
             }
             methods::MethodCall::sudo_unstable_version {} => {
-                self.sudo_unstable_version(request_id, &state_machine_request_id).await;
+                self.sudo_unstable_version(request_id, &state_machine_request_id)
+                    .await;
             }
             methods::MethodCall::transaction_unstable_submitAndWatch { transaction } => {
                 self.submit_and_watch_transaction(
@@ -860,37 +986,42 @@ impl<TPlat: Platform> Background<TPlat> {
                 .await
             }
             methods::MethodCall::transaction_unstable_unwatch { subscription } => {
-                self.transaction_unstable_unwatch(request_id, &state_machine_request_id, subscription).await;
+                self.transaction_unstable_unwatch(
+                    request_id,
+                    &state_machine_request_id,
+                    subscription,
+                )
+                .await;
             }
 
-            _method @ (
-                methods::MethodCall::account_nextIndex { .. } |
-                methods::MethodCall::author_hasKey { .. } |
-                methods::MethodCall::author_hasSessionKeys { .. } |
-                methods::MethodCall::author_insertKey { .. } |
-                methods::MethodCall::author_removeExtrinsic { .. } |
-                methods::MethodCall::author_rotateKeys { .. } |
-                methods::MethodCall::babe_epochAuthorship { .. } |
-                methods::MethodCall::childstate_getKeys { .. } |
-                methods::MethodCall::childstate_getStorage { .. } |
-                methods::MethodCall::childstate_getStorageHash { .. } |
-                methods::MethodCall::childstate_getStorageSize { .. } |
-                methods::MethodCall::grandpa_roundState { .. } |
-                methods::MethodCall::offchain_localStorageGet { .. } |
-                methods::MethodCall::offchain_localStorageSet { .. } |
-                methods::MethodCall::state_call { .. } |
-                methods::MethodCall::state_getKeys { .. } |
-                methods::MethodCall::state_getPairs { .. } |
-                methods::MethodCall::state_getReadProof { .. } |
-                methods::MethodCall::state_getStorageHash { .. } |
-                methods::MethodCall::state_getStorageSize { .. } |
-                methods::MethodCall::state_queryStorage { .. } |
-                methods::MethodCall::system_addReservedPeer { .. } |
-                methods::MethodCall::system_dryRun { .. } |
-                methods::MethodCall::system_networkState { .. } |
-                methods::MethodCall::system_nodeRoles { .. } |
-                methods::MethodCall::system_removeReservedPeer { .. }
-            ) => {
+            _method
+            @
+            (methods::MethodCall::account_nextIndex { .. }
+            | methods::MethodCall::author_hasKey { .. }
+            | methods::MethodCall::author_hasSessionKeys { .. }
+            | methods::MethodCall::author_insertKey { .. }
+            | methods::MethodCall::author_removeExtrinsic { .. }
+            | methods::MethodCall::author_rotateKeys { .. }
+            | methods::MethodCall::babe_epochAuthorship { .. }
+            | methods::MethodCall::childstate_getKeys { .. }
+            | methods::MethodCall::childstate_getStorage { .. }
+            | methods::MethodCall::childstate_getStorageHash { .. }
+            | methods::MethodCall::childstate_getStorageSize { .. }
+            | methods::MethodCall::grandpa_roundState { .. }
+            | methods::MethodCall::offchain_localStorageGet { .. }
+            | methods::MethodCall::offchain_localStorageSet { .. }
+            | methods::MethodCall::state_call { .. }
+            | methods::MethodCall::state_getKeys { .. }
+            | methods::MethodCall::state_getPairs { .. }
+            | methods::MethodCall::state_getReadProof { .. }
+            | methods::MethodCall::state_getStorageHash { .. }
+            | methods::MethodCall::state_getStorageSize { .. }
+            | methods::MethodCall::state_queryStorage { .. }
+            | methods::MethodCall::system_addReservedPeer { .. }
+            | methods::MethodCall::system_dryRun { .. }
+            | methods::MethodCall::system_networkState { .. }
+            | methods::MethodCall::system_nodeRoles { .. }
+            | methods::MethodCall::system_removeReservedPeer { .. }) => {
                 // TODO: implement the ones that make sense to implement ^
                 log::error!(target: &self.log_target, "JSON-RPC call not supported yet: {:?}", _method);
                 self.requests_subscriptions
@@ -1004,6 +1135,9 @@ impl<TPlat: Platform> Background<TPlat> {
                                         body: false,
                                         justifications: false,
                                     },
+                                    4,
+                                    Duration::from_secs(8),
+                                    NonZeroU32::new(2).unwrap(),
                                 )
                                 .await;
 
@@ -1042,6 +1176,9 @@ impl<TPlat: Platform> Background<TPlat> {
         &self,
         keys: impl Iterator<Item = impl AsRef<[u8]>> + Clone,
         hash: &[u8; 32],
+        total_attempts: u32,
+        timeout_per_request: Duration,
+        max_parallel: NonZeroU32,
     ) -> Result<Vec<Option<Vec<u8>>>, StorageQueryError> {
         let (state_trie_root_hash, block_number) = self
             .state_trie_root_hash(&hash)
@@ -1051,7 +1188,15 @@ impl<TPlat: Platform> Background<TPlat> {
         let result = self
             .sync_service
             .clone()
-            .storage_query(block_number, hash, &state_trie_root_hash, keys)
+            .storage_query(
+                block_number,
+                hash,
+                &state_trie_root_hash,
+                keys,
+                total_attempts,
+                timeout_per_request,
+                max_parallel,
+            )
             .await
             .map_err(StorageQueryError::StorageRetrieval)?;
 
@@ -1065,6 +1210,9 @@ impl<TPlat: Platform> Background<TPlat> {
         block_hash: &[u8; 32],
         function_to_call: &str,
         call_parameters: impl Iterator<Item = impl AsRef<[u8]>> + Clone,
+        total_attempts: u32,
+        timeout_per_request: Duration,
+        max_parallel: NonZeroU32,
     ) -> Result<Vec<u8>, RuntimeCallError> {
         // This function contains two steps: obtaining the runtime of the block in question,
         // then performing the actual call. The first step is the longest and most difficult.
@@ -1112,6 +1260,9 @@ impl<TPlat: Platform> Background<TPlat> {
                             block_hash,
                             &state_trie_root_hash,
                             iter::once(&b":code"[..]).chain(iter::once(&b":heappages"[..])),
+                            3,
+                            Duration::from_secs(20),
+                            NonZeroU32::new(1).unwrap(),
                         )
                         .await
                         .map_err(runtime_service::RuntimeCallError::StorageQuery)
@@ -1146,7 +1297,13 @@ impl<TPlat: Platform> Background<TPlat> {
         };
 
         let (runtime_call_lock, virtual_machine) = precall
-            .start(function_to_call, call_parameters.clone())
+            .start(
+                function_to_call,
+                call_parameters.clone(),
+                total_attempts,
+                timeout_per_request,
+                max_parallel,
+            )
             .await
             .unwrap(); // TODO: don't unwrap
 

--- a/bin/light-base/src/json_rpc_service/state_chain.rs
+++ b/bin/light-base/src/json_rpc_service/state_chain.rs
@@ -29,8 +29,11 @@ use smoldot::{
     network::protocol,
 };
 use std::{
-    iter, str,
+    iter,
+    num::NonZeroU32,
+    str,
     sync::{atomic, Arc},
+    time::Duration,
 };
 
 impl<TPlat: Platform> Background<TPlat> {
@@ -49,6 +52,9 @@ impl<TPlat: Platform> Background<TPlat> {
                 &block_hash,
                 "AccountNonceApi_account_nonce",
                 iter::once(&account.0),
+                4,
+                Duration::from_secs(4),
+                NonZeroU32::new(2).unwrap(),
             )
             .await;
 
@@ -132,6 +138,9 @@ impl<TPlat: Platform> Background<TPlat> {
                         body: true,
                         justifications: true,
                     },
+                    3,
+                    Duration::from_secs(8),
+                    NonZeroU32::new(1).unwrap(),
                 )
                 .await
         } else {
@@ -144,6 +153,9 @@ impl<TPlat: Platform> Background<TPlat> {
                         body: true,
                         justifications: true,
                     },
+                    3,
+                    Duration::from_secs(8),
+                    NonZeroU32::new(1).unwrap(),
                 )
                 .await
         };
@@ -263,6 +275,9 @@ impl<TPlat: Platform> Background<TPlat> {
                                 body: false,
                                 justifications: false,
                             },
+                            3,
+                            Duration::from_secs(8),
+                            NonZeroU32::new(1).unwrap(),
                         )
                         .await
                 } else {
@@ -275,6 +290,9 @@ impl<TPlat: Platform> Background<TPlat> {
                                 body: false,
                                 justifications: false,
                             },
+                            3,
+                            Duration::from_secs(8),
+                            NonZeroU32::new(1).unwrap(),
                         )
                         .await
                 };
@@ -768,6 +786,9 @@ impl<TPlat: Platform> Background<TPlat> {
                 &block_hash,
                 json_rpc::payment_info::PAYMENT_FEES_FUNCTION_NAME,
                 json_rpc::payment_info::payment_info_parameters(extrinsic),
+                4,
+                Duration::from_secs(4),
+                NonZeroU32::new(2).unwrap(),
             )
             .await;
 
@@ -851,6 +872,9 @@ impl<TPlat: Platform> Background<TPlat> {
                 &hash,
                 &prefix.unwrap().0, // TODO: don't unwrap! what is this Option?
                 &state_root,
+                3,
+                Duration::from_secs(12),
+                NonZeroU32::new(1).unwrap(),
             )
             .await;
 
@@ -891,7 +915,14 @@ impl<TPlat: Platform> Background<TPlat> {
         };
 
         let result = self
-            .runtime_call(&block_hash, "Metadata_metadata", iter::empty::<Vec<u8>>())
+            .runtime_call(
+                &block_hash,
+                "Metadata_metadata",
+                iter::empty::<Vec<u8>>(),
+                3,
+                Duration::from_secs(8),
+                NonZeroU32::new(1).unwrap(),
+            )
             .await;
         let result = result
             .as_ref()
@@ -994,6 +1025,9 @@ impl<TPlat: Platform> Background<TPlat> {
                             &block_hash,
                             &state_trie_root_hash,
                             iter::once(&b":code"[..]).chain(iter::once(&b":heappages"[..])),
+                            3,
+                            Duration::from_secs(24),
+                            NonZeroU32::new(1).unwrap(),
                         )
                         .await
                         .map_err(runtime_service::RuntimeCallError::StorageQuery)
@@ -1073,7 +1107,13 @@ impl<TPlat: Platform> Background<TPlat> {
                 &self.runtime_service.subscribe_best().await.0,
             ));
 
-        let fut = self.storage_query(iter::once(&key.0), &hash);
+        let fut = self.storage_query(
+            iter::once(&key.0),
+            &hash,
+            3,
+            Duration::from_secs(12),
+            NonZeroU32::new(1).unwrap(),
+        );
         let response = fut.await;
         let response = match response.map(|mut r| r.pop().unwrap()) {
             Ok(Some(value)) => {
@@ -1115,7 +1155,13 @@ impl<TPlat: Platform> Background<TPlat> {
 
         drop(cache);
 
-        let fut = self.storage_query(keys.iter(), &at);
+        let fut = self.storage_query(
+            keys.iter(),
+            &at,
+            3,
+            Duration::from_secs(12),
+            NonZeroU32::new(1).unwrap(),
+        );
 
         if let Ok(values) = fut.await {
             for (value, key) in values.into_iter().zip(keys) {
@@ -1445,6 +1491,9 @@ impl<TPlat: Platform> Background<TPlat> {
                                         &block_hash,
                                         state_trie_root,
                                         iter::once(&key.0),
+                                        4,
+                                        Duration::from_secs(12),
+                                        NonZeroU32::new(2).unwrap(),
                                     )
                                     .await
                                 {

--- a/bin/light-base/src/network_service.rs
+++ b/bin/light-base/src/network_service.rs
@@ -621,6 +621,7 @@ impl<TPlat: Platform> NetworkService<TPlat> {
         target: PeerId, // TODO: takes by value because of future longevity issue
         chain_index: usize,
         config: protocol::BlocksRequestConfig,
+        timeout: Duration,
     ) -> Result<Vec<protocol::BlockData>, service::BlocksRequestError> {
         match &config.start {
             protocol::BlocksRequestConfigStart::Hash(hash) => {
@@ -646,7 +647,7 @@ impl<TPlat: Platform> NetworkService<TPlat> {
         let result = self
             .inner
             .network
-            .blocks_request(TPlat::now(), &target, chain_index, config)
+            .blocks_request(TPlat::now(), &target, chain_index, config, timeout)
             .await;
 
         match &result {
@@ -698,6 +699,7 @@ impl<TPlat: Platform> NetworkService<TPlat> {
         target: PeerId, // TODO: takes by value because of future longevity issue
         chain_index: usize,
         begin_hash: [u8; 32],
+        timeout: Duration,
     ) -> Result<protocol::GrandpaWarpSyncResponse, service::GrandpaWarpSyncRequestError> {
         log::debug!(
             target: "network", "Connection({}) <= GrandpaWarpSyncRequest({})",
@@ -707,7 +709,7 @@ impl<TPlat: Platform> NetworkService<TPlat> {
         let result = self
             .inner
             .network
-            .grandpa_warp_sync_request(TPlat::now(), &target, chain_index, begin_hash)
+            .grandpa_warp_sync_request(TPlat::now(), &target, chain_index, begin_hash, timeout)
             .await;
 
         match &result {
@@ -774,6 +776,7 @@ impl<TPlat: Platform> NetworkService<TPlat> {
         chain_index: usize,
         target: PeerId, // TODO: takes by value because of futures longevity issue
         config: protocol::StorageProofRequestConfig<impl Iterator<Item = impl AsRef<[u8]>>>,
+        timeout: Duration,
     ) -> Result<Vec<Vec<u8>>, service::StorageProofRequestError> {
         log::debug!(
             target: "network",
@@ -785,7 +788,7 @@ impl<TPlat: Platform> NetworkService<TPlat> {
         let result = self
             .inner
             .network
-            .storage_proof_request(TPlat::now(), &target, chain_index, config)
+            .storage_proof_request(TPlat::now(), &target, chain_index, config, timeout)
             .await;
 
         match &result {
@@ -820,6 +823,7 @@ impl<TPlat: Platform> NetworkService<TPlat> {
         chain_index: usize,
         target: PeerId, // TODO: takes by value because of futures longevity issue
         config: protocol::CallProofRequestConfig<'a, impl Iterator<Item = impl AsRef<[u8]>>>,
+        timeout: Duration,
     ) -> Result<Vec<Vec<u8>>, service::CallProofRequestError> {
         log::debug!(
             target: "network",
@@ -832,7 +836,7 @@ impl<TPlat: Platform> NetworkService<TPlat> {
         let result = self
             .inner
             .network
-            .call_proof_request(TPlat::now(), &target, chain_index, config)
+            .call_proof_request(TPlat::now(), &target, chain_index, config, timeout)
             .await;
 
         match &result {

--- a/bin/light-base/src/sync_service.rs
+++ b/bin/light-base/src/sync_service.rs
@@ -40,7 +40,7 @@ use smoldot::{
     network::{protocol, service},
     trie::{self, prefix_proof, proof_verify},
 };
-use std::{fmt, num::NonZeroU32, sync::Arc};
+use std::{fmt, num::NonZeroU32, sync::Arc, time::Duration};
 
 mod parachain;
 mod standalone;
@@ -270,10 +270,11 @@ impl<TPlat: Platform> SyncService<TPlat> {
         block_number: u64,
         hash: [u8; 32],
         fields: protocol::BlocksRequestFields,
+        total_attempts: u32,
+        timeout_per_request: Duration,
+        _max_parallel: NonZeroU32,
     ) -> Result<protocol::BlockData, ()> {
         // TODO: better error?
-        const NUM_ATTEMPTS: usize = 3;
-
         let request_config = protocol::BlocksRequestConfig {
             start: protocol::BlocksRequestConfigStart::Hash(hash),
             desired_count: NonZeroU32::new(1).unwrap(),
@@ -281,16 +282,22 @@ impl<TPlat: Platform> SyncService<TPlat> {
             fields: fields.clone(),
         };
 
+        // TODO: handle max_parallel
         // TODO: better peers selection ; don't just take the first 3
         for target in self
             .peers_assumed_know_blocks(block_number, &hash)
             .await
-            .take(NUM_ATTEMPTS)
+            .take(usize::try_from(total_attempts).unwrap_or(usize::max_value()))
         {
             let mut result = match self
                 .network_service
                 .clone()
-                .blocks_request(target, self.network_chain_index, request_config.clone())
+                .blocks_request(
+                    target,
+                    self.network_chain_index,
+                    request_config.clone(),
+                    timeout_per_request,
+                )
                 .await
             {
                 Ok(b) => b,
@@ -308,10 +315,11 @@ impl<TPlat: Platform> SyncService<TPlat> {
         self: Arc<Self>,
         hash: [u8; 32],
         fields: protocol::BlocksRequestFields,
+        total_attempts: u32,
+        timeout_per_request: Duration,
+        _max_parallel: NonZeroU32,
     ) -> Result<protocol::BlockData, ()> {
         // TODO: better error?
-        const NUM_ATTEMPTS: usize = 3;
-
         let request_config = protocol::BlocksRequestConfig {
             start: protocol::BlocksRequestConfigStart::Hash(hash),
             desired_count: NonZeroU32::new(1).unwrap(),
@@ -319,12 +327,23 @@ impl<TPlat: Platform> SyncService<TPlat> {
             fields: fields.clone(),
         };
 
-        // TODO: better peers selection ; don't just take the first 3
-        for target in self.network_service.peers_list().await.take(NUM_ATTEMPTS) {
+        // TODO: handle max_parallel
+        // TODO: better peers selection ; don't just take the first
+        for target in self
+            .network_service
+            .peers_list()
+            .await
+            .take(usize::try_from(total_attempts).unwrap_or(usize::max_value()))
+        {
             let mut result = match self
                 .network_service
                 .clone()
-                .blocks_request(target, self.network_chain_index, request_config.clone())
+                .blocks_request(
+                    target,
+                    self.network_chain_index,
+                    request_config.clone(),
+                    timeout_per_request,
+                )
                 .await
             {
                 Ok(b) => b,
@@ -359,16 +378,19 @@ impl<TPlat: Platform> SyncService<TPlat> {
         block_hash: &[u8; 32],
         storage_trie_root: &[u8; 32],
         requested_keys: impl Iterator<Item = impl AsRef<[u8]>> + Clone,
+        total_attempts: u32,
+        timeout_per_request: Duration,
+        _max_parallel: NonZeroU32,
     ) -> Result<Vec<Option<Vec<u8>>>, StorageQueryError> {
-        const NUM_ATTEMPTS: usize = 3;
+        let mut outcome_errors =
+            Vec::with_capacity(usize::try_from(total_attempts).unwrap_or(usize::max_value()));
 
-        let mut outcome_errors = Vec::with_capacity(NUM_ATTEMPTS);
-
-        // TODO: better peers selection ; don't just take the first 3
+        // TODO: better peers selection ; don't just take the first
+        // TODO: handle max_parallel
         for target in self
             .peers_assumed_know_blocks(block_number, block_hash)
             .await
-            .take(NUM_ATTEMPTS)
+            .take(usize::try_from(total_attempts).unwrap_or(usize::max_value()))
         {
             let result = self
                 .network_service
@@ -380,6 +402,7 @@ impl<TPlat: Platform> SyncService<TPlat> {
                         block_hash: *block_hash,
                         keys: requested_keys.clone(),
                     },
+                    timeout_per_request,
                 )
                 .await
                 .map_err(StorageQueryErrorDetail::Network)
@@ -419,6 +442,9 @@ impl<TPlat: Platform> SyncService<TPlat> {
         block_hash: &[u8; 32],
         prefix: &[u8],
         storage_trie_root: &[u8; 32],
+        total_attempts: u32,
+        timeout_per_request: Duration,
+        _max_parallel: NonZeroU32,
     ) -> Result<Vec<Vec<u8>>, StorageQueryError> {
         let mut prefix_scan = prefix_proof::prefix_scan(prefix_proof::Config {
             prefix,
@@ -426,15 +452,15 @@ impl<TPlat: Platform> SyncService<TPlat> {
         });
 
         'main_scan: loop {
-            const NUM_ATTEMPTS: usize = 3;
+            let mut outcome_errors =
+                Vec::with_capacity(usize::try_from(total_attempts).unwrap_or(usize::max_value()));
 
-            let mut outcome_errors = Vec::with_capacity(NUM_ATTEMPTS);
-
-            // TODO: better peers selection ; don't just take the first 3
+            // TODO: better peers selection ; don't just take the first
+            // TODO: handle max_parallel
             for target in self
                 .peers_assumed_know_blocks(block_number, block_hash)
                 .await
-                .take(NUM_ATTEMPTS)
+                .take(usize::try_from(total_attempts).unwrap_or(usize::max_value()))
             {
                 let result = self
                     .network_service
@@ -448,6 +474,7 @@ impl<TPlat: Platform> SyncService<TPlat> {
                                 trie::nibbles_to_bytes_extend(nibbles).collect::<Vec<_>>()
                             }),
                         },
+                        timeout_per_request,
                     )
                     .await
                     .map_err(StorageQueryErrorDetail::Network);
@@ -491,21 +518,29 @@ impl<TPlat: Platform> SyncService<TPlat> {
             'a,
             impl Iterator<Item = impl AsRef<[u8]>> + Clone,
         >,
+        total_attempts: u32,
+        timeout_per_request: Duration,
+        _max_parallel: NonZeroU32,
     ) -> Result<Vec<Vec<u8>>, CallProofQueryError> {
-        const NUM_ATTEMPTS: usize = 3;
+        let mut outcome_errors =
+            Vec::with_capacity(usize::try_from(total_attempts).unwrap_or(usize::max_value()));
 
-        let mut outcome_errors = Vec::with_capacity(NUM_ATTEMPTS);
-
-        // TODO: better peers selection ; don't just take the first 3
+        // TODO: better peers selection ; don't just take the first
+        // TODO: handle max_parallel
         for target in self
             .peers_assumed_know_blocks(block_number, &config.block_hash)
             .await
-            .take(NUM_ATTEMPTS)
+            .take(usize::try_from(total_attempts).unwrap_or(usize::max_value()))
         {
             let result = self
                 .network_service
                 .clone()
-                .call_proof_request(self.network_chain_index, target, config.clone())
+                .call_proof_request(
+                    self.network_chain_index,
+                    target,
+                    config.clone(),
+                    timeout_per_request,
+                )
                 .await;
 
             match result {

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -29,7 +29,7 @@ use smoldot::{
     network::protocol,
     sync::{all_forks::sources, para},
 };
-use std::{collections::HashMap, iter, sync::Arc, time::Duration};
+use std::{collections::HashMap, iter, num::NonZeroU32, sync::Arc, time::Duration};
 
 /// Starts a sync service background task to synchronize a parachain.
 pub(super) async fn start_parachain<TPlat: Platform>(
@@ -504,6 +504,9 @@ async fn parahead<TPlat: Platform>(
                 parachain_id,
                 para::OccupiedCoreAssumption::TimedOut,
             ),
+            6,
+            Duration::from_secs(10),
+            NonZeroU32::new(2).unwrap(),
         )
         .await
         .map_err(ParaheadError::Call)?;

--- a/bin/light-base/src/transactions_service.rs
+++ b/bin/light-base/src/transactions_service.rs
@@ -482,6 +482,9 @@ async fn background_task<TPlat: Platform>(
                             header: true, // TODO: must be true in order for the body to be verified; fix the sync_service to not require that
                             justifications: false,
                         },
+                        3,
+                        Duration::from_secs(8),
+                        NonZeroU32::new(3).unwrap(),
                     );
 
                     async move { (block_hash, download_future.await.map(|b| b.body.unwrap())) }
@@ -1001,6 +1004,9 @@ async fn validate_transaction<TPlat: Platform>(
                 source,
                 &block_hash,
             ),
+            1,
+            Duration::from_secs(8),
+            NonZeroU32::new(1).unwrap(),
         )
         .await
         .map_err(ValidateTransactionError::Call)?;

--- a/src/json_rpc/methods.rs
+++ b/src/json_rpc/methods.rs
@@ -773,7 +773,7 @@ pub struct NetworkConfig {
     #[serde(rename = "totalAttempts")]
     pub total_attempts: u32,
     #[serde(rename = "maxParallel")]
-    pub max_parallel: u32,
+    pub max_parallel: u32, // TODO: NonZeroU32?
     #[serde(rename = "timeoutMs")]
     pub timeout_ms: u32,
 }

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -580,6 +580,7 @@ where
         target: &peer_id::PeerId,
         chain_index: usize,
         config: protocol::BlocksRequestConfig,
+        timeout: Duration,
     ) -> Result<Vec<protocol::BlockData>, BlocksRequestError> {
         if !config.fields.header {
             return Err(BlocksRequestError::NotVerifiable);
@@ -589,7 +590,7 @@ where
         let requested_fields = config.fields.clone();
 
         let mut result = self
-            .blocks_request_unchecked(now, target, chain_index, config)
+            .blocks_request_unchecked(now, target, chain_index, config, timeout)
             .await?;
 
         if result.is_empty() {
@@ -682,16 +683,12 @@ where
         target: &peer_id::PeerId,
         chain_index: usize,
         config: protocol::BlocksRequestConfig,
+        timeout: Duration,
     ) -> Result<Vec<protocol::BlockData>, BlocksRequestError> {
         let request_data = protocol::build_block_request(config).fold(Vec::new(), |mut a, b| {
             a.extend_from_slice(b.as_ref());
             a
         });
-
-        // The timeout needs to be long enough to potentially download the maximum
-        // response size of 16 MiB. Assuming a 128 kiB/sec connection, that's 128 seconds.
-        // TODO: 128 seconds is way too long, so we put 16 seconds instead for now
-        let timeout = now + Duration::from_secs(16);
 
         let response = self
             .inner
@@ -699,7 +696,7 @@ where
                 target,
                 self.protocol_index(chain_index, 0),
                 request_data,
-                timeout,
+                now + timeout,
             )
             .map_err(BlocksRequestError::Request)
             .await?;
@@ -713,13 +710,9 @@ where
         target: &peer_id::PeerId,
         chain_index: usize,
         begin_hash: [u8; 32],
+        timeout: Duration,
     ) -> Result<protocol::GrandpaWarpSyncResponse, GrandpaWarpSyncRequestError> {
         let request_data = begin_hash.to_vec();
-
-        // The timeout needs to be long enough to potentially download the maximum
-        // response size of 16 MiB. Assuming a 128 kiB/sec connection, that's 128 seconds.
-        // TODO: 128 seconds is way too much so we temporarily put less, we need to reduce these 16 MiB to less
-        let timeout = now + Duration::from_secs(32);
 
         let response = self
             .inner
@@ -727,7 +720,7 @@ where
                 target,
                 self.protocol_index(chain_index, 3),
                 request_data,
-                timeout,
+                now + timeout,
             )
             .map_err(GrandpaWarpSyncRequestError::Request)
             .await?;
@@ -755,6 +748,7 @@ where
         chain_index: usize,
         block_hash: [u8; 32],
         start_key: &[u8],
+        timeout: Duration,
     ) -> Result<Vec<protocol::StateResponseEntry>, StateRequestError> {
         let request_data = protocol::build_state_request(protocol::StateRequestConfig {
             block_hash,
@@ -765,18 +759,13 @@ where
             a
         });
 
-        // The timeout needs to be long enough to potentially download the maximum
-        // response size of 16 MiB. Assuming a 128 kiB/sec connection, that's 128 seconds.
-        // TODO: 128 seconds is way too much so we temporarily put less, we need to reduce these 16 MiB to less
-        let timeout = now + Duration::from_secs(32);
-
         let response = self
             .inner
             .request(
                 target,
                 self.protocol_index(chain_index, 4),
                 request_data,
-                timeout,
+                now + timeout,
             )
             .map_err(StateRequestError::Request)
             .await?;
@@ -792,6 +781,7 @@ where
         target: &peer_id::PeerId,
         chain_index: usize,
         config: protocol::StorageProofRequestConfig<impl Iterator<Item = impl AsRef<[u8]>>>,
+        timeout: Duration,
     ) -> Result<Vec<Vec<u8>>, StorageProofRequestError> {
         let request_data =
             protocol::build_storage_proof_request(config).fold(Vec::new(), |mut a, b| {
@@ -799,18 +789,13 @@ where
                 a
             });
 
-        // The timeout needs to be long enough to potentially download the maximum
-        // response size of 10 MiB. Assuming a 128 kiB/sec connection, that's 80 seconds.
-        // TODO: 80 seconds is too much, reduce these 10 MiB to less?
-        let timeout = now + Duration::from_secs(80);
-
         let response = self
             .inner
             .request(
                 target,
                 self.protocol_index(chain_index, 1),
                 request_data,
-                timeout,
+                now + timeout,
             )
             .map_err(StorageProofRequestError::Request)
             .await?;
@@ -834,6 +819,7 @@ where
         target: &peer_id::PeerId,
         chain_index: usize,
         config: protocol::CallProofRequestConfig<'_, impl Iterator<Item = impl AsRef<[u8]>>>,
+        timeout: Duration,
     ) -> Result<Vec<Vec<u8>>, CallProofRequestError> {
         let request_data =
             protocol::build_call_proof_request(config).fold(Vec::new(), |mut a, b| {
@@ -841,18 +827,13 @@ where
                 a
             });
 
-        // The timeout needs to be long enough to potentially download the maximum
-        // response size of 10 MiB. Assuming a 128 kiB/sec connection, that's 80 seconds.
-        // TODO: 80 seconds is too much, reduce these 10 MiB to less?
-        let timeout = now + Duration::from_secs(80);
-
         let response = self
             .inner
             .request(
                 target,
                 self.protocol_index(chain_index, 1),
                 request_data,
-                timeout,
+                now + timeout,
             )
             .map_err(CallProofRequestError::Request)
             .await?;


### PR DESCRIPTION
At the moment, sending an individual request to a peer always has a fixed timeout, after which the request fails.
Sending a "group request" (e.g. downloading a block body, without indicating who to download it from) always has 3 serial attempts after which the "group request" fails.

In practice, this isn't great.
Some requests are bigger than others and some are more urgent than other, and because there is a cap on the bandwidth of each peer and on the number of allowed parallel requests we should have some way to prioritize some requests over others.

This PR changes the API of all the network primitives to make it possible to specify a total number of requests, a maximum number of parallel requests, and a timeout for each individual request.
This PR thus also implements the `networkConfig` parameter of the `chainHead_` JSON-RPC functions.

Note: the diff in `json_rpc_service.rs` is a bit large because `rustfmt` somehow reformats the whole match block.
