### PR TITLE
Maybe fix transactions pool bug

### DIFF
--- a/src/transactions/light_pool.rs
+++ b/src/transactions/light_pool.rs
@@ -369,6 +369,7 @@ impl<TTx, TBl> LightPool<TTx, TBl> {
     /// Panics if no block with that hash has been inserted before.
     ///
     // TODO: is it correct to pass a `Result`, instead of just a `ValidTransaction`?
+    // TODO: can the block be the finalized block? (i.e. tree_root_hash)
     pub fn set_validation_result(
         &mut self,
         id: TransactionId,
@@ -760,6 +761,16 @@ impl<TTx, TBl> LightPool<TTx, TBl> {
                         .transaction_validations
                         .remove(&(tx_id, pruned_block.user_data.hash));
                     debug_assert!(_was_removed.is_some());
+
+                    if self
+                        .transaction_validations
+                        .range((tx_id, [0; 32])..=(tx_id, [0xff; 32]))
+                        .next()
+                        .is_none()
+                    {
+                        let _was_inserted = self.not_validated.insert(tx_id);
+                        debug_assert!(_was_inserted);
+                    }
                 }
 
                 out.push((

--- a/src/transactions/light_pool.rs
+++ b/src/transactions/light_pool.rs
@@ -909,6 +909,16 @@ impl<TTx, TBl> LightPool<TTx, TBl> {
                     .transaction_validations
                     .remove(&(tx_id, pruned.user_data.hash));
                 debug_assert!(_was_removed.is_some());
+
+                if self
+                    .transaction_validations
+                    .range((tx_id, [0; 32])..=(tx_id, [0xff; 32]))
+                    .next()
+                    .is_none()
+                {
+                    let _was_inserted = self.not_validated.insert(tx_id);
+                    debug_assert!(_was_inserted);
+                }
             }
 
             return_value.push(PruneBodyFinalized {

--- a/src/transactions/light_pool/tests.rs
+++ b/src/transactions/light_pool/tests.rs
@@ -42,6 +42,14 @@ fn regular_path() {
         .collect::<Vec<_>>();
     assert_eq!(included_txs, vec![(tx_id, 0)]);
     assert_eq!(pool.missing_block_bodies().count(), 0);
+
+    let mut non_finalized_iter = pool.set_finalized_block(&[1; 32]);
+    assert!(non_finalized_iter.next().is_none());
+
+    let mut iter = pool.prune_finalized_with_body();
+    let pruned = iter.next().unwrap();
+    assert_eq!(pruned.block_hash, [1; 32]);
+    assert_eq!(pruned.included_transactions, vec![(tx_id, 0, ())]);
 }
 
 #[test]


### PR DESCRIPTION
cc https://github.com/paritytech/smoldot/issues/1966 https://github.com/paritytech/smoldot/issues/1433

#1966 shows a state mismatch within the pool. The code that this PR adds solves this state mismatch. Unfortunately I can't figure out how to reproduce the issue with a test.
