### PR TITLE
Make start_slot_number mandatory for past epochs

### DIFF
--- a/src/chain/blocks_tree/verify.rs
+++ b/src/chain/blocks_tree/verify.rs
@@ -372,8 +372,29 @@ impl<T> VerifyContext<T> {
                 VerifyConsensusSpecific::Babe { .. },
                 FinalizedConsensus::Babe { .. },
                 Some(BlockConsensus::Babe { next_epoch, .. }),
-            ) => BlockConsensus::Babe {
+            ) if next_epoch.start_slot_number.is_some() => BlockConsensus::Babe {
                 current_epoch: Some(next_epoch),
+                next_epoch: Arc::new(epoch_transition_target),
+            },
+
+            (
+                verify::header_body::SuccessConsensus::Babe {
+                    epoch_transition_target: Some(epoch_transition_target),
+                    slot_number,
+                    ..
+                },
+                VerifyConsensusSpecific::Babe { .. },
+                FinalizedConsensus::Babe { .. },
+                Some(BlockConsensus::Babe { next_epoch, .. }),
+            ) => BlockConsensus::Babe {
+                current_epoch: Some(Arc::new(chain_information::BabeEpochInformation {
+                    start_slot_number: Some(slot_number),
+                    allowed_slots: next_epoch.allowed_slots,
+                    epoch_index: next_epoch.epoch_index,
+                    authorities: next_epoch.authorities.clone(),
+                    c: next_epoch.c,
+                    randomness: next_epoch.randomness,
+                })),
                 next_epoch: Arc::new(epoch_transition_target),
             },
 
@@ -404,8 +425,32 @@ impl<T> VerifyContext<T> {
                     ..
                 },
                 None,
-            ) => BlockConsensus::Babe {
+            ) if next_epoch_transition.start_slot_number.is_some() => BlockConsensus::Babe {
                 current_epoch: Some(next_epoch_transition),
+                next_epoch: Arc::new(epoch_transition_target),
+            },
+
+            (
+                verify::header_body::SuccessConsensus::Babe {
+                    epoch_transition_target: Some(epoch_transition_target),
+                    slot_number,
+                    ..
+                },
+                VerifyConsensusSpecific::Babe { .. },
+                FinalizedConsensus::Babe {
+                    next_epoch_transition,
+                    ..
+                },
+                None,
+            ) => BlockConsensus::Babe {
+                current_epoch: Some(Arc::new(chain_information::BabeEpochInformation {
+                    start_slot_number: Some(slot_number),
+                    allowed_slots: next_epoch_transition.allowed_slots,
+                    authorities: next_epoch_transition.authorities.clone(),
+                    c: next_epoch_transition.c,
+                    epoch_index: next_epoch_transition.epoch_index,
+                    randomness: next_epoch_transition.randomness,
+                })),
                 next_epoch: Arc::new(epoch_transition_target),
             },
 

--- a/src/chain/chain_information/babe_fetch_epoch.rs
+++ b/src/chain/chain_information/babe_fetch_epoch.rs
@@ -57,9 +57,9 @@ pub enum Error {
 
 /// Fetches a Babe epoch using `BabeApi_current_epoch` or `BabeApi_next_epoch`.
 pub fn babe_fetch_epoch(config: Config) -> Query {
-    let function_to_call = match config.epoch_to_fetch {
-        BabeEpochToFetch::CurrentEpoch => "BabeApi_current_epoch",
-        BabeEpochToFetch::NextEpoch => "BabeApi_next_epoch",
+    let (function_to_call, is_next_epoch) = match config.epoch_to_fetch {
+        BabeEpochToFetch::CurrentEpoch => ("BabeApi_current_epoch", false),
+        BabeEpochToFetch::NextEpoch => ("BabeApi_next_epoch", true),
     };
 
     let vm = read_only_runtime_host::run(read_only_runtime_host::Config {
@@ -70,7 +70,7 @@ pub fn babe_fetch_epoch(config: Config) -> Query {
     });
 
     match vm {
-        Ok(vm) => Query::from_inner(vm),
+        Ok(vm) => Query::from_inner(vm, is_next_epoch),
         Err((err, virtual_machine)) => Query::Finished {
             result: Err(Error::WasmStart(err)),
             virtual_machine,
@@ -99,10 +99,11 @@ pub enum Query {
 }
 
 impl Query {
-    fn from_inner(inner: read_only_runtime_host::RuntimeHostVm) -> Self {
+    fn from_inner(inner: read_only_runtime_host::RuntimeHostVm, is_next_epoch: bool) -> Self {
         match inner {
             read_only_runtime_host::RuntimeHostVm::Finished(Ok(success)) => {
-                let decoded = decode_babe_info(success.virtual_machine.value().as_ref());
+                let decoded =
+                    decode_babe_info(success.virtual_machine.value().as_ref(), is_next_epoch);
                 let virtual_machine = success.virtual_machine.into_prototype();
                 match decoded {
                     Ok(info) => {
@@ -129,19 +130,21 @@ impl Query {
                 virtual_machine: err.prototype,
             },
             read_only_runtime_host::RuntimeHostVm::StorageGet(inner) => {
-                Query::StorageGet(StorageGet(inner))
+                Query::StorageGet(StorageGet(inner, is_next_epoch))
             }
             read_only_runtime_host::RuntimeHostVm::StorageRoot(inner) => {
-                Query::StorageRoot(StorageRoot(inner))
+                Query::StorageRoot(StorageRoot(inner, is_next_epoch))
             }
-            read_only_runtime_host::RuntimeHostVm::NextKey(inner) => Query::NextKey(NextKey(inner)),
+            read_only_runtime_host::RuntimeHostVm::NextKey(inner) => {
+                Query::NextKey(NextKey(inner, is_next_epoch))
+            }
         }
     }
 }
 
 /// Loading a storage value is required in order to continue.
 #[must_use]
-pub struct StorageGet(read_only_runtime_host::StorageGet);
+pub struct StorageGet(read_only_runtime_host::StorageGet, bool);
 
 impl StorageGet {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
@@ -158,13 +161,13 @@ impl StorageGet {
 
     /// Injects the corresponding storage value.
     pub fn inject_value(self, value: Option<impl Iterator<Item = impl AsRef<[u8]>>>) -> Query {
-        Query::from_inner(self.0.inject_value(value))
+        Query::from_inner(self.0.inject_value(value), self.1)
     }
 }
 
 /// Fetching the key that follows a given one is required in order to continue.
 #[must_use]
-pub struct NextKey(read_only_runtime_host::NextKey);
+pub struct NextKey(read_only_runtime_host::NextKey, bool);
 
 impl NextKey {
     /// Returns the key whose next key must be passed back.
@@ -179,22 +182,25 @@ impl NextKey {
     /// Panics if the key passed as parameter isn't strictly superior to the requested key.
     ///
     pub fn inject_key(self, key: Option<impl AsRef<[u8]>>) -> Query {
-        Query::from_inner(self.0.inject_key(key))
+        Query::from_inner(self.0.inject_key(key), self.1)
     }
 }
 
 /// Fetching the storage trie root is required in order to continue.
 #[must_use]
-pub struct StorageRoot(read_only_runtime_host::StorageRoot);
+pub struct StorageRoot(read_only_runtime_host::StorageRoot, bool);
 
 impl StorageRoot {
     /// Writes the trie root hash to the Wasm VM and prepares it for resume.
     pub fn resume(self, hash: &[u8; 32]) -> Query {
-        Query::from_inner(self.0.resume(hash))
+        Query::from_inner(self.0.resume(hash), self.1)
     }
 }
 
-fn decode_babe_info(scale_encoded: &'_ [u8]) -> Result<BabeEpochInformation, Error> {
+fn decode_babe_info(
+    scale_encoded: &'_ [u8],
+    is_next_epoch: bool,
+) -> Result<BabeEpochInformation, Error> {
     let mut combinator = nom::combinator::all_consuming(nom::combinator::map(
         nom::sequence::tuple((
             nom::number::complete::le_u64,
@@ -241,7 +247,15 @@ fn decode_babe_info(scale_encoded: &'_ [u8]) -> Result<BabeEpochInformation, Err
         )| {
             BabeEpochInformation {
                 epoch_index,
-                start_slot_number: Some(start_slot_number),
+                // Smoldot requires `start_slot_number` to be `None` in the context of next
+                // epoch #0, because its start slot number can't be known. The runtime function,
+                // however, as it doesn't have a way to represent `None`, instead returns an
+                // unspecified value (typically `0`).
+                start_slot_number: if !is_next_epoch || epoch_index != 0 {
+                    Some(start_slot_number)
+                } else {
+                    None
+                },
                 authorities,
                 randomness,
                 c: (c0, c1),
@@ -277,6 +291,6 @@ mod tests {
             0, 0, 0, 0, 2,
         ];
 
-        super::decode_babe_info(&sample_data).unwrap();
+        super::decode_babe_info(&sample_data, true).unwrap();
     }
 }

--- a/src/sync/warp_sync.rs
+++ b/src/sync/warp_sync.rs
@@ -679,6 +679,7 @@ impl<TSrc> Verifier<TSrc> {
                 Ok(()),
             ),
             Ok(warp_sync::Next::EmptyProof) => (
+                // TODO: should return success immediately; unfortunately the AllSync is quite complicated to update if we do this
                 InProgressWarpSync::VirtualMachineParamsGet(VirtualMachineParamsGet {
                     state: PostVerificationState {
                         header: self

--- a/src/verify/babe.rs
+++ b/src/verify/babe.rs
@@ -156,9 +156,15 @@ pub struct VerifyConfig<'a> {
 
     /// Epoch the parent block belongs to. Must be `None` if and only if the parent block's number
     /// is 0, as block #0 doesn't belong to any epoch.
+    ///
+    /// If `Some`, then the [`chain_information::BabeEpochInformationRef::start_slot_number`]
+    /// must be `Some`.
     pub parent_block_epoch: Option<chain_information::BabeEpochInformationRef<'a>>,
 
     /// Epoch that follows the epoch the parent block belongs to.
+    ///
+    /// The [`chain_information::BabeEpochInformationRef::start_slot_number`] must be `None` if
+    /// and only if the [`chain_information::BabeEpochInformationRef::epoch_index`] is `0̀ .
     pub parent_block_next_epoch: chain_information::BabeEpochInformationRef<'a>,
 }
 
@@ -267,7 +273,7 @@ pub fn verify_header(config: VerifyConfig) -> Result<VerifySuccess, VerifyError>
             curr.epoch_index.checked_add(1).unwrap(),
             config.parent_block_next_epoch.epoch_index
         );
-        assert_eq!(curr.epoch_index == 0, curr.start_slot_number.is_none());
+        assert!(curr.start_slot_number.is_some());
         assert!(curr.start_slot_number <= parent_slot_number);
     } else {
         assert_eq!(config.parent_block_next_epoch.epoch_index, 0);

--- a/src/verify/babe.rs
+++ b/src/verify/babe.rs
@@ -164,7 +164,7 @@ pub struct VerifyConfig<'a> {
     /// Epoch that follows the epoch the parent block belongs to.
     ///
     /// The [`chain_information::BabeEpochInformationRef::start_slot_number`] must be `None` if
-    /// and only if the [`chain_information::BabeEpochInformationRef::epoch_index`] is `0̀ .
+    /// and only if the [`chain_information::BabeEpochInformationRef::epoch_index`] is `0`.
     pub parent_block_next_epoch: chain_information::BabeEpochInformationRef<'a>,
 }
 


### PR DESCRIPTION
It turns out there is some fiasco regarding `start_slot_number`.

Currently it is an `Option` and the documentation mentions that it must be none iff `epoch_index` is 0.
This is however only true for future epochs. If the current epoch is epoch 0, then its starting slot can be known and must be known.
This PR modifies the check for the validity of chain information to allow passing a slot number for epoch 0 if it is the current epoch. This fixes a problem during warp syncing to a block within epoch 0.

Since the `blocks_tree` module would always leave `start_slot_number` equal to None for epoch 0 when syncing from scratch, it would now lead to an invalid `ChainInformation` when serializing the state when within epoch 0. This has been updated too.

Additionally, when fetching the Babe epoch information at the end of warp syncing, the start slot number is now ignored if we fetch the future epoch and obtain epoch index 0 (in which case the runtime returns an unspecified value).
