### PR TITLE
Publish v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2446,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light-wasm"
-version = "0.5.21"
+version = "0.6.0"
 dependencies = [
  "event-listener",
  "futures",

--- a/bin/wasm-node/javascript/package-lock.json
+++ b/bin/wasm-node/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@substrate/smoldot-light",
-  "version": "0.5.21",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@substrate/smoldot-light",
-      "version": "0.5.21",
+      "version": "0.6.0",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "buffer": "^6.0.1",

--- a/bin/wasm-node/javascript/package.json
+++ b/bin/wasm-node/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@substrate/smoldot-light",
-  "version": "0.5.21",
+  "version": "0.6.0",
   "description": "Light client that connects to Polkadot and Substrate-based blockchains",
   "author": "Parity Technologies <admin@parity.io>",
   "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",

--- a/bin/wasm-node/rust/Cargo.toml
+++ b/bin/wasm-node/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light-wasm"
-version = "0.5.21"
+version = "0.6.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Browser bindings to a light client for Substrate-based blockchains"
 repository = "https://github.com/paritytech/smoldot"


### PR DESCRIPTION
I want to release https://github.com/paritytech/smoldot/pull/2030

Major version bump is done because of https://github.com/paritytech/smoldot/pull/2024
There's been no API change otherwise.