### PR TITLE
Make fmt::Debug for Multiaddr behave as Display

### DIFF
--- a/src/libp2p/multiaddr.rs
+++ b/src/libp2p/multiaddr.rs
@@ -156,12 +156,7 @@ impl TryFrom<Vec<u8>> for Multiaddr {
 
 impl fmt::Debug for Multiaddr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_list()
-            .entries(&mut nom::combinator::iterator(
-                &self.bytes[..],
-                protocol::<nom::error::Error<&[u8]>>,
-            ))
-            .finish()
+        fmt::Display::fmt(&self, f)
     }
 }
 


### PR DESCRIPTION
The current `Debug` implementation is quite annoying to read and brings nothing over the regular multiaddr string representation.