### PR TITLE
Give a configuration struct to HostVmPrototype::new

### DIFF
--- a/bin/full-node/src/run/consensus_service.rs
+++ b/bin/full-node/src/run/consensus_service.rs
@@ -196,12 +196,12 @@ impl ConsensusService {
                                 .map(|v| &v[..]),
                         )
                         .unwrap();
-                        executor::host::HostVmPrototype::new(
+                        executor::host::HostVmPrototype::new(executor::host::Config {
                             module,
                             heap_pages,
-                            executor::vm::ExecHint::CompileAheadOfTime, // TODO: probably should be decided by the optimisticsync
-                            false,
-                        )
+                            exec_hint: executor::vm::ExecHint::CompileAheadOfTime, // TODO: probably should be decided by the optimisticsync
+                            allow_unresolved_imports: false,
+                        })
                         .unwrap()
                     },
                 }),

--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -2206,7 +2206,12 @@ impl SuccessfulRuntime {
         // Having unresolved imports might cause errors later on, for example when validating
         // transactions or getting the parachain heads, but for now we continue the execution
         // and print a warning.
-        match executor::host::HostVmPrototype::new(module, heap_pages, exec_hint, false) {
+        match executor::host::HostVmPrototype::new(executor::host::Config {
+            module,
+            heap_pages,
+            exec_hint,
+            allow_unresolved_imports: false,
+        }) {
             Ok(vm) => return Self::from_virtual_machine(vm).await,
             Err(executor::host::NewErr::VirtualMachine(
                 executor::vm::NewErr::UnresolvedFunctionImport {
@@ -2214,7 +2219,12 @@ impl SuccessfulRuntime {
                     module_name,
                 },
             )) => {
-                match executor::host::HostVmPrototype::new(module, heap_pages, exec_hint, true) {
+                match executor::host::HostVmPrototype::new(executor::host::Config {
+                    module,
+                    heap_pages,
+                    exec_hint,
+                    allow_unresolved_imports: true,
+                }) {
                     Ok(vm) => {
                         log::warn!(
                             "Unresolved host function in runtime: `{}`:`{}`. Smoldot might \

--- a/src/author/runtime/tests.rs
+++ b/src/author/runtime/tests.rs
@@ -34,12 +34,12 @@ fn block_building_works() {
             .next()
             .unwrap()
             .1;
-        crate::executor::host::HostVmPrototype::new(
-            code,
-            crate::executor::DEFAULT_HEAP_PAGES,
-            crate::executor::vm::ExecHint::Oneshot,
-            false,
-        )
+        crate::executor::host::HostVmPrototype::new(crate::executor::host::Config {
+            module: code,
+            heap_pages: crate::executor::DEFAULT_HEAP_PAGES,
+            exec_hint: crate::executor::vm::ExecHint::Oneshot,
+            allow_unresolved_imports: false,
+        })
         .unwrap()
     };
 

--- a/src/chain/chain_information/aura_config.rs
+++ b/src/chain/chain_information/aura_config.rs
@@ -51,8 +51,13 @@ impl AuraConfiguration {
         let heap_pages =
             executor::storage_heap_pages_to_value(storage_access(b":heappages").as_deref())
                 .map_err(FromStorageError::HeapPagesDecode)?;
-        let vm = host::HostVmPrototype::new(&wasm_code, heap_pages, vm::ExecHint::Oneshot, false)
-            .map_err(FromStorageError::VmInitialization)?;
+        let vm = host::HostVmPrototype::new(host::Config {
+            module: &wasm_code,
+            heap_pages,
+            exec_hint: vm::ExecHint::Oneshot,
+            allow_unresolved_imports: false,
+        })
+        .map_err(FromStorageError::VmInitialization)?;
         let (cfg, _) = Self::from_virtual_machine_prototype(vm, storage_access)
             .map_err(FromStorageError::VmError)?;
         Ok(cfg)

--- a/src/chain/chain_information/babe_genesis_config.rs
+++ b/src/chain/chain_information/babe_genesis_config.rs
@@ -46,8 +46,13 @@ impl BabeGenesisConfiguration {
         let heap_pages =
             executor::storage_heap_pages_to_value(genesis_storage_access(b":heappages").as_deref())
                 .map_err(FromGenesisStorageError::HeapPagesDecode)?;
-        let vm = host::HostVmPrototype::new(&wasm_code, heap_pages, vm::ExecHint::Oneshot, false)
-            .map_err(FromGenesisStorageError::VmInitialization)?;
+        let vm = host::HostVmPrototype::new(host::Config {
+            module: &wasm_code,
+            heap_pages,
+            exec_hint: vm::ExecHint::Oneshot,
+            allow_unresolved_imports: false,
+        })
+        .map_err(FromGenesisStorageError::VmInitialization)?;
         let (cfg, _) = Self::from_virtual_machine_prototype(vm, genesis_storage_access)
             .map_err(FromGenesisStorageError::VmError)?;
         Ok(cfg)

--- a/src/chain/chain_information/grandpa_genesis_config.rs
+++ b/src/chain/chain_information/grandpa_genesis_config.rs
@@ -64,9 +64,13 @@ impl GrandpaGenesisConfiguration {
                 genesis_storage_access(b":heappages").as_deref(),
             )
             .map_err(FromGenesisStorageError::HeapPagesDecode)?;
-            let vm =
-                host::HostVmPrototype::new(&wasm_code, heap_pages, vm::ExecHint::Oneshot, false)
-                    .map_err(FromGenesisStorageError::VmInitialization)?;
+            let vm = host::HostVmPrototype::new(host::Config {
+                module: &wasm_code,
+                heap_pages,
+                exec_hint: vm::ExecHint::Oneshot,
+                allow_unresolved_imports: false,
+            })
+            .map_err(FromGenesisStorageError::VmInitialization)?;
             Self::from_virtual_machine_prototype(vm, genesis_storage_access)
                 .map_err(FromGenesisStorageError::VmError)?
         };

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -130,18 +130,18 @@
 //! ## Example
 //!
 //! ```
-//! use smoldot::executor::host::{HeapPages, HostVm, HostVmPrototype};
+//! use smoldot::executor::host::{Config, HeapPages, HostVm, HostVmPrototype};
 //!
 //! # let wasm_binary_code: &[u8] = return;
 //!
 //! // Start executing a function on the runtime.
 //! let mut vm: HostVm = {
-//!     let prototype = HostVmPrototype::new(
-//!         &wasm_binary_code,
-//!         HeapPages::from(2048),
-//!         smoldot::executor::vm::ExecHint::Oneshot,
-//!         false
-//!     ).unwrap();
+//!     let prototype = HostVmPrototype::new(Config {
+//!         module: &wasm_binary_code,
+//!         heap_pages: HeapPages::from(2048),
+//!         exec_hint: smoldot::executor::vm::ExecHint::Oneshot,
+//!         allow_unresolved_imports: false
+//!     }).unwrap();
 //!     prototype.run_no_param("Core_version").unwrap().into()
 //! };
 //!

--- a/src/executor/read_only_runtime_host.rs
+++ b/src/executor/read_only_runtime_host.rs
@@ -302,12 +302,12 @@ impl Inner {
                     // upgrades are quite uncommon and that a caching system is rather non-trivial
                     // to set up, the approach of recompiling every single time is preferred here.
                     // TODO: number of heap pages?! we use the default here, but not sure whether that's correct or if we have to take the current heap pages
-                    let vm_prototype = match host::HostVmPrototype::new(
-                        req.wasm_code(),
-                        executor::DEFAULT_HEAP_PAGES,
-                        vm::ExecHint::Oneshot,
-                        false, // TODO: what is a correct value here?
-                    ) {
+                    let vm_prototype = match host::HostVmPrototype::new(host::Config {
+                        module: req.wasm_code(),
+                        heap_pages: executor::DEFAULT_HEAP_PAGES,
+                        exec_hint: vm::ExecHint::Oneshot,
+                        allow_unresolved_imports: false, // TODO: what is a correct value here?
+                    }) {
                         Ok(w) => w,
                         Err(_) => {
                             self.vm = req.resume(Err(()));

--- a/src/executor/runtime_host.rs
+++ b/src/executor/runtime_host.rs
@@ -694,12 +694,12 @@ impl Inner {
                     // upgrades are quite uncommon and that a caching system is rather non-trivial
                     // to set up, the approach of recompiling every single time is preferred here.
                     // TODO: number of heap pages?! we use the default here, but not sure whether that's correct or if we have to take the current heap pages
-                    let vm_prototype = match host::HostVmPrototype::new(
-                        req.wasm_code(),
-                        executor::DEFAULT_HEAP_PAGES,
-                        vm::ExecHint::Oneshot,
-                        false, // TODO: what is a correct value here?
-                    ) {
+                    let vm_prototype = match host::HostVmPrototype::new(host::Config {
+                        module: req.wasm_code(),
+                        heap_pages: executor::DEFAULT_HEAP_PAGES,
+                        exec_hint: vm::ExecHint::Oneshot,
+                        allow_unresolved_imports: false, // TODO: what is a correct value here?
+                    }) {
                         Ok(w) => w,
                         Err(_) => {
                             self.vm = req.resume(Err(()));

--- a/src/sync/warp_sync.rs
+++ b/src/sync/warp_sync.rs
@@ -62,7 +62,7 @@ use crate::{
     },
     executor::{
         self,
-        host::{HostVmPrototype, NewErr},
+        host::{self, HostVmPrototype, NewErr},
         vm::ExecHint,
     },
     finality::grandpa::warp_sync,
@@ -982,12 +982,12 @@ impl<TSrc> VirtualMachineParamsGet<TSrc> {
                 }
             };
 
-        match HostVmPrototype::new(
-            &code,
-            decoded_heap_pages,
+        match HostVmPrototype::new(host::Config {
+            module: &code,
+            heap_pages: decoded_heap_pages,
             exec_hint,
             allow_unresolved_imports,
-        ) {
+        }) {
             Ok(runtime) => {
                 let babe_current_epoch_query =
                     babe_fetch_epoch::babe_fetch_epoch(babe_fetch_epoch::Config {

--- a/src/verify/header_body.rs
+++ b/src/verify/header_body.rs
@@ -497,12 +497,12 @@ impl RuntimeCompilation {
             .as_ref()
             .unwrap();
 
-        let new_runtime = match host::HostVmPrototype::new(
-            code,
-            self.heap_pages,
-            vm::ExecHint::CompileAheadOfTime,
-            false,
-        ) {
+        let new_runtime = match host::HostVmPrototype::new(host::Config {
+            module: code,
+            heap_pages: self.heap_pages,
+            exec_hint: vm::ExecHint::CompileAheadOfTime,
+            allow_unresolved_imports: false,
+        }) {
             Ok(vm) => vm,
             Err(err) => {
                 return Verify::Finished(Err((


### PR DESCRIPTION
Doesn't change anything, but ensures that parameters are named.