### PR TITLE
Increase size for input data

### DIFF
--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -361,7 +361,7 @@ impl HostVmPrototype {
         // Now create the actual virtual machine. We pass as parameter `heap_base` as the location
         // of the input data.
         let mut vm = match self.vm_proto.start(
-            vm::HeapPages::new(16 + self.heap_base / (64 * 1024)), // TODO: `16 + ` is a hack for the start value; solve with https://github.com/paritytech/smoldot/issues/132
+            vm::HeapPages::new(32 + self.heap_base / (64 * 1024)), // TODO: `32 + ` is a hack for the start value; solve with https://github.com/paritytech/smoldot/issues/132
             function_to_call,
             &[
                 vm::WasmValue::I32(i32::from_ne_bytes(self.heap_base.to_ne_bytes())),

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -361,7 +361,7 @@ impl HostVmPrototype {
         // Now create the actual virtual machine. We pass as parameter `heap_base` as the location
         // of the input data.
         let mut vm = match self.vm_proto.start(
-            vm::HeapPages::new(1 + self.heap_base / (64 * 1024)), // TODO: `1 + ` is a hack for the start value; solve with https://github.com/paritytech/smoldot/issues/132
+            vm::HeapPages::new(16 + self.heap_base / (64 * 1024)), // TODO: `16 + ` is a hack for the start value; solve with https://github.com/paritytech/smoldot/issues/132
             function_to_call,
             &[
                 vm::WasmValue::I32(i32::from_ne_bytes(self.heap_base.to_ne_bytes())),


### PR DESCRIPTION
Normally the input data isn't part of the heap but below. In smoldot we make it part of the heap (cc #132). The problem is that this munches on the available memory. To solve this, we hackily add one page to the available memory. However it turns out that one extra page sometimes isn't enough.
