### PR TITLE
Optimize storage diff by having both a hashmap and btree

### DIFF
--- a/bin/full-node/src/run/consensus_service.rs
+++ b/bin/full-node/src/run/consensus_service.rs
@@ -1077,7 +1077,7 @@ impl SyncBackground {
                                     .as_ref()
                                     .unwrap()
                                     .storage_top_trie_changes
-                                    .diff_iter()
+                                    .diff_iter_unordered()
                                 {
                                     if let Some(value) = value {
                                         self.finalized_block_storage
@@ -1162,7 +1162,7 @@ async fn database_blocks(database: &database_thread::DatabaseThread, blocks: Vec
                         .as_ref()
                         .unwrap()
                         .storage_top_trie_changes
-                        .diff_iter(),
+                        .diff_iter_unordered(),
                 );
 
                 match result {

--- a/src/executor/runtime_host.rs
+++ b/src/executor/runtime_host.rs
@@ -375,7 +375,7 @@ impl PrefixKeys {
                         .map(|v| v.as_ref().to_vec())
                         .collect::<HashSet<_, fnv::FnvBuildHasher>>();
                     // TODO: slow to iterate over everything?
-                    for (key, value) in self.inner.top_trie_changes.diff_iter() {
+                    for (key, value) in self.inner.top_trie_changes.diff_iter_unordered() {
                         if value.is_none() {
                             continue;
                         }

--- a/src/executor/storage_diff.rs
+++ b/src/executor/storage_diff.rs
@@ -39,10 +39,10 @@
 // TODO: more docs
 
 use alloc::{borrow::ToOwned as _, collections::BTreeMap, vec::Vec};
-use core::{fmt, iter, ops};
+use core::{cmp, fmt, iter, ops};
 use hashbrown::HashMap;
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct StorageDiff {
     /// Contains the same entries as [`StorageDiff::hashmap`], except that values are booleans
     /// indicating whether the value updates (`true`) or deletes (`false`) the underlying
@@ -275,9 +275,19 @@ impl StorageDiff {
 impl fmt::Debug for StorageDiff {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Delegate to `self.inner`
-        fmt::Debug::fmt(&self.btree, f)
+        fmt::Debug::fmt(&self.hash_map, f)
     }
 }
+
+// We implement `PartialEq` manually, because deriving it would mean that both the hash map and
+// the tree are compared.
+impl cmp::PartialEq for StorageDiff {
+    fn eq(&self, other: &Self) -> bool {
+        self.hash_map == other.hash_map
+    }
+}
+
+impl cmp::Eq for StorageDiff {}
 
 impl Default for StorageDiff {
     fn default() -> Self {

--- a/src/executor/storage_diff.rs
+++ b/src/executor/storage_diff.rs
@@ -24,6 +24,15 @@
 //! differences between a block and its child or storing on-going changes while a runtime call is
 //! being performed. It can also be used to store an entire storage, by representing a diff where
 //! the base is an empty storage.
+//!
+//! # About keys hashing
+//!
+//! This data structure internally uses a hash map. This hash map assumes that storage keys are
+//! already uniformly distributed and doesn't perform any additional hashing.
+//!
+//! You should be aware that a malicious runtime could perform hash collision attacks that
+//! considerably slow down this data structure.
+//!
 
 // TODO: is this module properly located?
 
@@ -40,6 +49,11 @@ pub struct StorageDiff {
     /// storage item.
     btree: BTreeMap<Vec<u8>, bool>,
 
+    /// Actual diff. For each key, `Some` if the underlying storage item is updated by this diff,
+    /// and `None` if it is deleted.
+    ///
+    /// A FNV hasher is used because the runtime is supposed to guarantee a uniform distribution
+    /// of storage keys.
     hashmap: HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
 }
 

--- a/src/executor/storage_diff.rs
+++ b/src/executor/storage_diff.rs
@@ -275,7 +275,7 @@ impl StorageDiff {
 impl fmt::Debug for StorageDiff {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Delegate to `self.inner`
-        fmt::Debug::fmt(&self.hash_map, f)
+        fmt::Debug::fmt(&self.hashmap, f)
     }
 }
 
@@ -283,7 +283,7 @@ impl fmt::Debug for StorageDiff {
 // the tree are compared.
 impl cmp::PartialEq for StorageDiff {
     fn eq(&self, other: &Self) -> bool {
-        self.hash_map == other.hash_map
+        self.hashmap == other.hashmap
     }
 }
 


### PR DESCRIPTION
Close https://github.com/paritytech/smoldot/issues/1305

Also renames `diff_iter()` to `diff_iter_unordered()` because the ordering is now broken. This clarifies that no ordering is guaranteed.

Opening as draft because it seems that this might actually slow down syncing. Need to do some precise measurements.
