### PR TITLE
Use cached cargo-install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,11 @@ jobs:
       with:
         node-version: '14'
     - run: cargo install twiggy  # TODO: somehow cache this in order to not compile twiggy every single time
+    - name: Install twiggy with cache
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-nextest
+          version: 0.9
     - run: git checkout ${{ github.event.pull_request.base.sha }}
     - run: cd bin/wasm-node/javascript && npm ci && npm run-script build
     - run: cp ./target/wasm32-wasi/min-size-release/smoldot_light_wasm.wasm ./.ci-parent-build.wasm  # TODO: maybe get the path from the `npm build` output or something?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     - uses: actions/setup-node@v2.5.1
       with:
         node-version: '14'
-    - uses: baptiste0928/cargo-install@v1
+    - uses: baptiste0928/cargo-install@v1  # This action ensures that the twiggy compilation is cached.
       with:
         crate: twiggy
         version: 0.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,12 +69,10 @@ jobs:
     - uses: actions/setup-node@v2.5.1
       with:
         node-version: '14'
-    - run: cargo install twiggy  # TODO: somehow cache this in order to not compile twiggy every single time
-    - name: Install twiggy with cache
-        uses: baptiste0928/cargo-install@v1
-        with:
-          crate: cargo-nextest
-          version: 0.9
+    - uses: baptiste0928/cargo-install@v1
+      with:
+        crate: twiggy
+        version: 0.6
     - run: git checkout ${{ github.event.pull_request.base.sha }}
     - run: cd bin/wasm-node/javascript && npm ci && npm run-script build
     - run: cp ./target/wasm32-wasi/min-size-release/smoldot_light_wasm.wasm ./.ci-parent-build.wasm  # TODO: maybe get the path from the `npm build` output or something?


### PR DESCRIPTION
I assumed @tomaka  didn't like [`cargo-nextest`](https://nexte.st/index.html) so not suggesting it here.
Here you go, 1sec instead of 2 min
![image](https://user-images.githubusercontent.com/17856421/154522446-50d7d4f2-7ec3-46b3-a475-b4557c0d6899.png)
