### PR TITLE
Fix lifetime error with chainHead_unstable_followEvent

### DIFF
--- a/bin/light-base/src/json_rpc_service/chain_head.rs
+++ b/bin/light-base/src/json_rpc_service/chain_head.rs
@@ -425,7 +425,7 @@ impl<TPlat: Platform> Background<TPlat> {
 
                     initial_notifications.push({
                         methods::ServerToClient::chainHead_unstable_followEvent {
-                            subscription: &subscription_id,
+                            subscription: (&subscription_id).into(),
                             result: methods::FollowEvent::Initialized {
                                 finalized_block_hash: methods::HashHexString(finalized_block_hash),
                                 finalized_block_runtime: Some(convert_runtime_spec(
@@ -458,7 +458,7 @@ impl<TPlat: Platform> Background<TPlat> {
 
                         initial_notifications.push(
                             methods::ServerToClient::chainHead_unstable_followEvent {
-                                subscription: &subscription_id,
+                                subscription: (&subscription_id).into(),
                                 result: methods::FollowEvent::NewBlock {
                                     block_hash: methods::HashHexString(hash),
                                     new_runtime: if let Some(new_runtime) = &block.new_runtime {
@@ -475,7 +475,7 @@ impl<TPlat: Platform> Background<TPlat> {
                         if block.is_new_best {
                             initial_notifications.push(
                                 methods::ServerToClient::chainHead_unstable_followEvent {
-                                    subscription: &subscription_id,
+                                    subscription: (&subscription_id).into(),
                                     result: methods::FollowEvent::BestBlockChanged {
                                         best_block_hash: methods::HashHexString(hash),
                                     },
@@ -497,7 +497,7 @@ impl<TPlat: Platform> Background<TPlat> {
 
                     initial_notifications.push(
                         methods::ServerToClient::chainHead_unstable_followEvent {
-                            subscription: &subscription_id,
+                            subscription: (&subscription_id).into(),
                             result: methods::FollowEvent::Initialized {
                                 finalized_block_hash: methods::HashHexString(finalized_block_hash),
                                 finalized_block_runtime: None,
@@ -528,7 +528,7 @@ impl<TPlat: Platform> Background<TPlat> {
 
                         initial_notifications.push(
                             methods::ServerToClient::chainHead_unstable_followEvent {
-                                subscription: &subscription_id,
+                                subscription: (&subscription_id).into(),
                                 result: methods::FollowEvent::NewBlock {
                                     block_hash: methods::HashHexString(hash),
                                     new_runtime: None,
@@ -541,7 +541,7 @@ impl<TPlat: Platform> Background<TPlat> {
                         if block.is_new_best {
                             initial_notifications.push(
                                 methods::ServerToClient::chainHead_unstable_followEvent {
-                                    subscription: &subscription_id,
+                                    subscription: (&subscription_id).into(),
                                     result: methods::FollowEvent::BestBlockChanged {
                                         best_block_hash: methods::HashHexString(hash),
                                     },
@@ -633,7 +633,7 @@ impl<TPlat: Platform> Background<TPlat> {
                                 .try_push_notification(
                                     &state_machine_subscription,
                                     methods::ServerToClient::chainHead_unstable_followEvent {
-                                        subscription: &subscription_id,
+                                        subscription: (&subscription_id).into(),
                                         result: methods::FollowEvent::BestBlockChanged {
                                             best_block_hash: methods::HashHexString(
                                                 best_block_hash,
@@ -653,7 +653,7 @@ impl<TPlat: Platform> Background<TPlat> {
                                 .try_push_notification(
                                     &state_machine_subscription,
                                     methods::ServerToClient::chainHead_unstable_followEvent {
-                                        subscription: &subscription_id,
+                                        subscription: (&subscription_id).into(),
                                         result: methods::FollowEvent::Finalized {
                                             finalized_blocks_hashes,
                                             pruned_blocks_hashes,
@@ -692,7 +692,7 @@ impl<TPlat: Platform> Background<TPlat> {
                                 .try_push_notification(
                                     &state_machine_subscription,
                                     methods::ServerToClient::chainHead_unstable_followEvent {
-                                        subscription: &subscription_id,
+                                        subscription: (&subscription_id).into(),
                                         result: methods::FollowEvent::NewBlock {
                                             block_hash: methods::HashHexString(hash),
                                             parent_block_hash: methods::HashHexString(
@@ -721,7 +721,7 @@ impl<TPlat: Platform> Background<TPlat> {
                                     .try_push_notification(
                                         &state_machine_subscription,
                                         methods::ServerToClient::chainHead_unstable_followEvent {
-                                            subscription: &subscription_id,
+                                            subscription: (&subscription_id).into(),
                                             result: methods::FollowEvent::BestBlockChanged {
                                                 best_block_hash: methods::HashHexString(hash),
                                             },
@@ -759,7 +759,7 @@ impl<TPlat: Platform> Background<TPlat> {
                                 .try_push_notification(
                                     &state_machine_subscription,
                                     methods::ServerToClient::chainHead_unstable_followEvent {
-                                        subscription: &subscription_id,
+                                        subscription: (&subscription_id).into(),
                                         result: methods::FollowEvent::NewBlock {
                                             block_hash: methods::HashHexString(hash),
                                             parent_block_hash: methods::HashHexString(
@@ -782,7 +782,7 @@ impl<TPlat: Platform> Background<TPlat> {
                                     .try_push_notification(
                                         &state_machine_subscription,
                                         methods::ServerToClient::chainHead_unstable_followEvent {
-                                            subscription: &subscription_id,
+                                            subscription: (&subscription_id).into(),
                                             result: methods::FollowEvent::BestBlockChanged {
                                                 best_block_hash: methods::HashHexString(hash),
                                             },
@@ -810,7 +810,7 @@ impl<TPlat: Platform> Background<TPlat> {
                     .push_notification(
                         &state_machine_subscription,
                         methods::ServerToClient::chainHead_unstable_followEvent {
-                            subscription: &subscription_id,
+                            subscription: (&subscription_id).into(),
                             result: methods::FollowEvent::Stop {},
                         }
                         .to_json_call_object_parameters(None),

--- a/src/json_rpc/methods.rs
+++ b/src/json_rpc/methods.rs
@@ -244,7 +244,7 @@ macro_rules! define_methods {
 
                             // This `_dummy` field is necessary to not have an "unused lifetime"
                             // error if the parameters don't have a lifetime.
-                            #[serde(skip)]
+                            #[serde(borrow, skip)]
                             _dummy: core::marker::PhantomData<&'a ()>,
                         }
                         if let Ok(params) = serde_json::from_str(params) {
@@ -473,7 +473,7 @@ define_methods! {
     // The functions below are experimental and are defined in the document https://github.com/paritytech/json-rpc-interface-spec/
     chainHead_unstable_bodyEvent(subscription: Cow<'a, str>, result: ChainHeadBodyEvent) -> (),
     chainHead_unstable_callEvent(subscription: Cow<'a, str>, result: ChainHeadCallEvent<'a>) -> (),
-    chainHead_unstable_followEvent(subscription: &'a str, result: FollowEvent<'a>) -> (), // TODO: using `Cow` causes borrowck error specifically on this line; figure out
+    chainHead_unstable_followEvent(subscription: Cow<'a, str>, result: FollowEvent<'a>) -> (),
     chainHead_unstable_storageEvent(subscription: Cow<'a, str>, result: ChainHeadStorageEvent) -> (),
     transaction_unstable_watchEvent(subscription: Cow<'a, str>, result: TransactionWatchEvent<'a>) -> (),
 }
@@ -597,7 +597,6 @@ pub enum FollowEvent<'a> {
         #[serde(rename = "finalizedBlockHash")]
         finalized_block_hash: HashHexString,
         #[serde(
-            borrow,
             rename = "finalizedBlockRuntime",
             skip_serializing_if = "Option::is_none"
         )]
@@ -609,7 +608,7 @@ pub enum FollowEvent<'a> {
         block_hash: HashHexString,
         #[serde(rename = "parentBlockHash")]
         parent_block_hash: HashHexString,
-        #[serde(rename = "newRuntime", borrow)]
+        #[serde(rename = "newRuntime")]
         // TODO: must not be present if runtime_updates: false
         new_runtime: Option<MaybeRuntimeSpec<'a>>,
     },
@@ -795,7 +794,6 @@ pub struct RpcMethods {
 pub enum MaybeRuntimeSpec<'a> {
     #[serde(rename = "valid")]
     Valid {
-        #[serde(borrow)]
         spec: RuntimeSpec<'a>,
     },
     #[serde(rename = "invalid")]

--- a/src/json_rpc/methods.rs
+++ b/src/json_rpc/methods.rs
@@ -793,9 +793,7 @@ pub struct RpcMethods {
 #[serde(tag = "type")]
 pub enum MaybeRuntimeSpec<'a> {
     #[serde(rename = "valid")]
-    Valid {
-        spec: RuntimeSpec<'a>,
-    },
+    Valid { spec: RuntimeSpec<'a> },
     #[serde(rename = "invalid")]
     Invalid { error: String }, // TODO: String because it's more convenient; improve
 }


### PR DESCRIPTION
Continuation of https://github.com/paritytech/smoldot/pull/2075

To be honest I have no idea what I'm doing with these `#[serde(borrow)]`. Apparently removing them fixes the problem.
