### PR TITLE
Fix not trying again the same peer ever

### DIFF
--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -843,6 +843,7 @@ where
                 desired: true,
                 open: NotificationsOutOpenState::Closed,
             });
+            current_state.desired = true;
 
             // If substream is closed, try to open it.
             if matches!(current_state.open, NotificationsOutOpenState::Closed) {


### PR DESCRIPTION
When marking a peer as desired in the `peers` state machine, if the state machine already contained an entry for a specific peer, we didn't mark it as `desired: true` again, meaning that each peer will only ever be attempted once and then never again.

This fixes it.