### PR TITLE
Report crashes in one call to console.error instead of two

### DIFF
--- a/bin/wasm-node/javascript/src/client.ts
+++ b/bin/wasm-node/javascript/src/client.ts
@@ -520,14 +520,15 @@ export function start(options?: ClientOptions): Client {
   workerOnError(worker, (error) => {
     // A worker error should only happen in case of a critical error as the result of a bug
     // somewhere. Consequently, nothing is really in place to cleanly report the error.
+    const errorToString = error.toString();
     console.error(
       "Smoldot has panicked" +
       (workerCurrentTask.name ? (" while executing task `" + workerCurrentTask.name + "`") : "") +
       ". This is a bug in smoldot. Please open an issue at " +
-      "https://github.com/paritytech/smoldot/issues with the following message:"
+      "https://github.com/paritytech/smoldot/issues with the following message:\n" +
+      errorToString
     );
-    console.error(error);
-    workerError = new CrashError(error.toString());
+    workerError = new CrashError(errorToString);
 
     // Reject all promises returned by `addChain`.
     for (var pending of pendingConfirmations) {


### PR DESCRIPTION
Minor change that makes more sense to me