### PR TITLE
Remove from InherentData the Aura/Babe slot number

### DIFF
--- a/src/author/build.rs
+++ b/src/author/build.rs
@@ -231,11 +231,6 @@ impl AuthoringStart {
         let inherent_data = inherents::InherentData {
             timestamp: u64::try_from(config.now_from_unix_epoch.as_millis())
                 .unwrap_or(u64::max_value()),
-            consensus: match self.consensus {
-                WaitSlotConsensus::Aura(slot) => inherents::InherentDataConsensus::Aura {
-                    slot_number: slot.slot_number,
-                },
-            },
         };
 
         (Shared {

--- a/src/author/runtime.rs
+++ b/src/author/runtime.rs
@@ -476,10 +476,6 @@ impl InherentExtrinsics {
     /// Injects the inherents extrinsics and resumes execution.
     ///
     /// See the module-level documentation for more information.
-    ///
-    /// > **Note**: Some of the values are redundant with the values passed through
-    /// >           [`ConfigPreRuntime`]. This redundancy is considered as a wart in the runtime
-    /// >           environment and is kept for backwards compatibility.
     pub fn inject_inherents(self, inherents: inherents::InherentData) -> BlockBuild {
         self.inject_raw_inherents_list(inherents.as_raw_list())
     }

--- a/src/author/runtime/tests.rs
+++ b/src/author/runtime/tests.rs
@@ -71,7 +71,6 @@ fn block_building_works() {
             super::BlockBuild::InherentExtrinsics(ext) => {
                 builder = ext.inject_inherents(inherents::InherentData {
                     timestamp: 1234,
-                    consensus: inherents::InherentDataConsensus::Aura { slot_number: 1234 },
                 });
             }
             super::BlockBuild::StorageGet(get) => {

--- a/src/author/runtime/tests.rs
+++ b/src/author/runtime/tests.rs
@@ -69,9 +69,7 @@ fn block_building_works() {
             super::BlockBuild::ApplyExtrinsic(ext) => builder = ext.finish(),
             super::BlockBuild::ApplyExtrinsicResult { .. } => unreachable!(),
             super::BlockBuild::InherentExtrinsics(ext) => {
-                builder = ext.inject_inherents(inherents::InherentData {
-                    timestamp: 1234,
-                });
+                builder = ext.inject_inherents(inherents::InherentData { timestamp: 1234 });
             }
             super::BlockBuild::StorageGet(get) => {
                 let key = get.key_as_vec();

--- a/src/verify/inherents.rs
+++ b/src/verify/inherents.rs
@@ -32,10 +32,11 @@
 ///
 /// Historically, the inherent data included an Aura or Babe slot number, using the identifiers
 /// `auraslot` or `babeslot`. The runtime-side verification of the slot number has been removed in
-/// May 2021. Older runtime versions still require the slot number. For this reason, errors
-/// concerning the Aura or Babe modules must be ignored when verifying the inherents of blocks
-/// that are using older runtime versions (by calling `BlockBuilder_check_inherents`). Authoring
-/// blocks using older runtime versions is not supported anymore.
+/// May 2021, and all the checks performed by the runtime are now performed by the client instead.
+/// Older runtime versions still require the slot number. For this reason, verifying the inherents
+/// (calling `BlockBuilder_check_inherents`) of blocks that are using older runtime versions will
+/// lead to errors concerning the Aura or Babe modules. These errors should simply be ignored.
+/// Authoring blocks using older runtime versions is not supported anymore.
 #[derive(Debug)]
 pub struct InherentData {
     /// Number of milliseconds since the UNIX epoch when the block is generated, ignoring leap

--- a/src/verify/inherents.rs
+++ b/src/verify/inherents.rs
@@ -35,8 +35,8 @@
 /// May 2021, and all the checks performed by the runtime are now performed by the client instead.
 /// Older runtime versions still require the slot number. For this reason, verifying the inherents
 /// (calling `BlockBuilder_check_inherents`) of blocks that are using older runtime versions will
-/// lead to errors concerning the Aura or Babe modules. These errors should simply be ignored.
-/// Authoring blocks using older runtime versions is not supported anymore.
+/// lead to errors concerning the Aura or Babe modules that should simply be ignored. Authoring
+/// blocks using older runtime versions is not supported anymore.
 #[derive(Debug)]
 pub struct InherentData {
     /// Number of milliseconds since the UNIX epoch when the block is generated, ignoring leap

--- a/src/verify/inherents.rs
+++ b/src/verify/inherents.rs
@@ -43,7 +43,6 @@ pub struct InherentData {
     ///
     /// Its identifier passed to the runtime is: `timstap0`.
     pub timestamp: u64,
-
     // TODO: figure out uncles
     /*/// List of valid block headers that have the same height as the parent of the one being
     /// generated.
@@ -63,8 +62,6 @@ impl InherentData {
     ) -> impl ExactSizeIterator<Item = ([u8; 8], impl AsRef<[u8]> + Clone + '_)> + Clone + '_ {
         // Note: we use `IntoIter::new` because of a Rust backwards compatibility issue.
         // See https://doc.rust-lang.org/std/primitive.array.html#editions
-        core::array::IntoIter::new([
-            (*b"timstap0", self.timestamp.to_le_bytes())
-        ])
+        core::array::IntoIter::new([(*b"timstap0", self.timestamp.to_le_bytes())])
     }
 }


### PR DESCRIPTION
Close https://github.com/paritytech/smoldot/issues/2096

What the comment says: we no longer pass the Aura/Babe slot number to the runtime when authoring blocks, because they're unused anyway. Authoring blocks using older runtime versions is intentionally not supported.

Verifying the inherents of blocks isn't implemented in smoldot yet, and will be covered by https://github.com/paritytech/smoldot/pull/2073
