### PR TITLE
Use new std::thread::available_parallelism function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,7 +2406,6 @@ dependencies = [
  "hashbrown 0.12.0",
  "hex",
  "mick-jaeger",
- "num_cpus",
  "rand",
  "smoldot",
  "terminal_size",

--- a/bin/full-node/Cargo.toml
+++ b/bin/full-node/Cargo.toml
@@ -28,7 +28,6 @@ futures-timer = "3.0"
 hashbrown = { version = "0.12.0", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 mick-jaeger = "0.1.6"
-num_cpus = "1.13.0"
 rand = "0.8.5"
 smoldot = { version = "0.2.0", path = "../..", default-features = false, features = ["database-sqlite", "std"] }
 terminal_size = "0.1.17"

--- a/bin/full-node/src/run/network_service.rs
+++ b/bin/full-node/src/run/network_service.rs
@@ -48,6 +48,7 @@ use std::{
     net::{IpAddr, SocketAddr},
     num::NonZeroUsize,
     sync::Arc,
+    thread,
     time::Instant,
 };
 use tracing::Instrument as _;
@@ -461,7 +462,7 @@ impl NetworkService {
         }
 
         // A channel is used to communicate new tasks dedicated to handling connections.
-        let (connec_tx, mut connec_rx) = mpsc::channel(num_cpus::get());
+        let (connec_tx, mut connec_rx) = mpsc::channel(thread::available_parallelism().unwrap_or(4));
 
         // For each listening address in the configuration, create a background task dedicated to
         // listening on that address.

--- a/bin/full-node/src/run/network_service.rs
+++ b/bin/full-node/src/run/network_service.rs
@@ -462,8 +462,11 @@ impl NetworkService {
         }
 
         // A channel is used to communicate new tasks dedicated to handling connections.
-        let (connec_tx, mut connec_rx) =
-            mpsc::channel(thread::available_parallelism().unwrap_or(4));
+        let (connec_tx, mut connec_rx) = mpsc::channel(
+            thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(4),
+        );
 
         // For each listening address in the configuration, create a background task dedicated to
         // listening on that address.

--- a/bin/full-node/src/run/network_service.rs
+++ b/bin/full-node/src/run/network_service.rs
@@ -462,7 +462,8 @@ impl NetworkService {
         }
 
         // A channel is used to communicate new tasks dedicated to handling connections.
-        let (connec_tx, mut connec_rx) = mpsc::channel(thread::available_parallelism().unwrap_or(4));
+        let (connec_tx, mut connec_rx) =
+            mpsc::channel(thread::available_parallelism().unwrap_or(4));
 
         // For each listening address in the configuration, create a background task dedicated to
         // listening on that address.


### PR DESCRIPTION
New function added in Rust 1.59.

There's no policy about minimum Rust version in smoldot at the moment. We don't have to merge this now but can wait a bit if necessary.
