### PR TITLE
Log the block's parent in block announces

### DIFF
--- a/bin/light-base/src/sync_service/standalone.rs
+++ b/bin/light-base/src/sync_service/standalone.rs
@@ -801,10 +801,11 @@ impl<TPlat: Platform> Task<TPlat> {
 
                 log::debug!(
                     target: &self.log_target,
-                    "Sync <= BlockAnnounce(sender={}, hash={}, is_best={})",
+                    "Sync <= BlockAnnounce(sender={}, hash={}, is_best={}, parent_hash={})",
                     peer_id,
                     HashDisplay(&header::hash_from_scale_encoded_header(&decoded.scale_encoded_header)),
-                    decoded.is_best
+                    decoded.is_best,
+                    HashDisplay(decoded.header.parent_hash)
                 );
 
                 match self.sync.block_announce(


### PR DESCRIPTION
When investigating https://github.com/paritytech/smoldot/issues/2088 I realized that we were missing this critical info.