### PR TITLE
Run the informant every 100 ms instead of every second

### DIFF
--- a/bin/full-node/src/run.rs
+++ b/bin/full-node/src/run.rs
@@ -415,7 +415,7 @@ pub async fn run(cli_options: cli::CliOptionsRun) {
 
     let mut informant_timer = stream::once(future::ready(())).chain(
         stream::unfold((), move |_| {
-            futures_timer::Delay::new(Duration::from_secs(1)).map(|_| Some(((), ())))
+            futures_timer::Delay::new(Duration::from_millis(100)).map(|_| Some(((), ())))
         })
         .map(|_| ()),
     );


### PR DESCRIPTION
It creates a cooler-looking effect.