### PR TITLE
Improvements to all_forks syncing

### DIFF
--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -482,7 +482,7 @@ pub(super) async fn start_parachain<TPlat: Platform>(
                             let decoded_header_hash = decoded.header.hash();
                             sync_sources.add_known_block(local_id, decoded.header.number, decoded_header_hash);
                             if decoded.is_best {
-                                sync_sources.set_best_block(local_id, decoded.header.number, decoded_header_hash);
+                                sync_sources.add_known_block_and_set_best(local_id, decoded.header.number, decoded_header_hash);
                             }
                         },
                         _ => {

--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -2218,7 +2218,7 @@ impl<TRq> Shared<TRq> {
             max_disjoint_headers: self.max_disjoint_headers,
             max_requests_per_block: self.max_requests_per_block,
             full: false,
-            banned_blocks: Default::default(), // TODO: not implemented, should be passed by config
+            banned_blocks: iter::empty(), // TODO: not implemented, should be passed by config after the optimistic sync supports banned blocks too
         });
 
         debug_assert!(self

--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -2218,6 +2218,7 @@ impl<TRq> Shared<TRq> {
             max_disjoint_headers: self.max_disjoint_headers,
             max_requests_per_block: self.max_requests_per_block,
             full: false,
+            banned_blocks: Default::default(), // TODO: not implemented, should be passed by config
         });
 
         debug_assert!(self

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -324,7 +324,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
             if self.inner.banned_blocks.contains(&best_block_hash) {
                 self.inner
                     .blocks
-                    .set_unverified_block_bad(best_block_number, &best_block_hash);
+                    .mark_unverified_block_as_bad(best_block_number, &best_block_hash);
             }
         }
 
@@ -832,7 +832,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
             if self.inner.banned_blocks.contains(header_hash) {
                 self.inner
                     .blocks
-                    .set_unverified_block_bad(header.number, header_hash);
+                    .mark_unverified_block_as_bad(header.number, header_hash);
             }
 
             // If there are too many blocks stored in the blocks list, remove unnecessary ones.
@@ -1149,7 +1149,7 @@ impl<TBl, TRq, TSrc> HeaderVerify<TBl, TRq, TSrc> {
             );
             outcome.justifications
         } else {
-            self.parent.inner.blocks.set_unverified_block_bad(
+            self.parent.inner.blocks.mark_unverified_block_as_bad(
                 self.block_to_verify.block_number,
                 &self.block_to_verify.block_hash,
             );

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -753,7 +753,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
         if known_to_be_source_best {
             self.inner
                 .blocks
-                .set_best_block(source_id, header.number, *header_hash);
+                .add_known_block_and_set_best(source_id, header.number, *header_hash);
         } else {
             self.inner
                 .blocks

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -102,7 +102,7 @@ pub use pending_blocks::{RequestId, RequestParams, SourceId};
 
 /// Configuration for the [`AllForksSync`].
 #[derive(Debug)]
-pub struct Config {
+pub struct Config<TBannedBlocksIter> {
     /// Information about the latest finalized block and its ancestors.
     pub chain_information: chain_information::ValidChainInformation,
 
@@ -156,8 +156,7 @@ pub struct Config {
     /// > **Note**: This list is typically filled with a list of blocks found in the chain
     /// >           specification. It is part of the "trusted setup" of the node, in other words
     /// >           the information that is passed by the user and blindly assumed to be true.
-    // TODO: use iterator instead
-    pub banned_blocks: hashbrown::HashSet<[u8; 32], fnv::FnvBuildHasher>,
+    pub banned_blocks: TBannedBlocksIter,
 }
 
 pub struct AllForksSync<TBl, TRq, TSrc> {
@@ -197,7 +196,7 @@ struct Block<TBl> {
 
 impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     /// Initializes a new [`AllForksSync`].
-    pub fn new(config: Config) -> Self {
+    pub fn new(config: Config<impl Iterator<Item = [u8; 32]>>) -> Self {
         let finalized_block_height = config
             .chain_information
             .as_ref()
@@ -220,7 +219,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
                     verify_bodies: config.full,
                 }),
                 pending_justifications_verify: Vec::new().into_iter(),
-                banned_blocks: config.banned_blocks,
+                banned_blocks: config.banned_blocks.collect(),
             },
         }
     }

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -1096,7 +1096,7 @@ impl<TBl, TRq, TSrc> HeaderVerify<TBl, TRq, TSrc> {
 
         // Remove the verified block from `pending_blocks`.
         let justifications = if result.is_ok() {
-            let outcome = self.parent.inner.blocks.remove(
+            let outcome = self.parent.inner.blocks.remove_block_and_tracking(
                 self.block_to_verify.block_number,
                 &self.block_to_verify.block_hash,
             );

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -620,7 +620,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
             // Assume that the source doesn't know this block, as it is apparently unable to
             // serve it anyway. This avoids sending the same request to the same source over and
             // over again.
-            self.inner.blocks.remove_source_known_block(
+            self.inner.blocks.remove_known_block_of_source(
                 source_id,
                 requested_block_height,
                 &requested_block_hash,
@@ -767,7 +767,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
         // No matter what is done below, start by updating the view the state machine maintains
         // for this source.
         if known_to_be_source_best {
-            self.inner.blocks.add_source_known_block_and_set_best(
+            self.inner.blocks.add_known_block_to_source_and_set_best(
                 source_id,
                 header.number,
                 *header_hash,
@@ -775,13 +775,15 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
         } else {
             self.inner
                 .blocks
-                .add_source_known_block(source_id, header.number, *header_hash);
+                .add_known_block_to_source(source_id, header.number, *header_hash);
         }
 
         // Source also knows the parent of the announced block.
-        self.inner
-            .blocks
-            .add_source_known_block(source_id, header.number - 1, *header.parent_hash);
+        self.inner.blocks.add_known_block_to_source(
+            source_id,
+            header.number - 1,
+            *header.parent_hash,
+        );
 
         // It is assumed that all sources will eventually agree on the same finalized chain. If
         // the block number is lower or equal than the locally-finalized block number, it is

--- a/src/sync/all_forks/disjoint.rs
+++ b/src/sync/all_forks/disjoint.rs
@@ -219,6 +219,8 @@ impl<TBl> DisjointBlocks<TBl> {
     /// # Panic
     ///
     /// Panics if the block with the given height and hash hasn't been inserted before.
+    /// Panics if the parent hash of that block was already known, and is different from the one
+    /// passed as parameter.
     ///
     #[track_caller]
     pub fn set_parent_hash(&mut self, height: u64, hash: &[u8; 32], parent_hash: [u8; 32]) {
@@ -233,7 +235,7 @@ impl<TBl> DisjointBlocks<TBl> {
         let block = self.blocks.get_mut(&(height, *hash)).unwrap();
 
         match &mut block.parent_hash {
-            &mut Some(ph) => debug_assert_eq!(ph, parent_hash),
+            &mut Some(ph) => assert_eq!(ph, parent_hash),
             ph @ &mut None => *ph = Some(parent_hash),
         }
 

--- a/src/sync/all_forks/disjoint.rs
+++ b/src/sync/all_forks/disjoint.rs
@@ -351,6 +351,29 @@ impl<TBl> DisjointBlocks<TBl> {
             (None, None) => None,
         })
     }
+
+    /// Returns whether a block is marked as bad.
+    ///
+    /// Returns `None` if the block isn't known.
+    pub fn is_bad(&self, height: u64, hash: &[u8; 32]) -> Option<bool> {
+        Some(self.blocks.get(&(height, *hash))?.bad)
+    }
+
+    /// Returns whether the parent of a block is bad.
+    ///
+    /// Returns `None` if either the block or its parent isn't known.
+    pub fn is_parent_bad(&self, height: u64, hash: &[u8; 32]) -> Option<bool> {
+        let parent_hash = self.blocks.get(&(height, *hash))?.parent_hash?;
+        let parent_height = match height.checked_sub(1) {
+            Some(h) => h,
+            None => return Some(false), // Parent is known and isn't present in the data structure.
+        };
+        Some(
+            self.blocks
+                .get(&(parent_height, parent_hash))
+                .map_or(false, |parent| parent.bad),
+        )
+    }
 }
 
 impl<TBl: fmt::Debug> fmt::Debug for DisjointBlocks<TBl> {

--- a/src/sync/all_forks/pending_blocks.rs
+++ b/src/sync/all_forks/pending_blocks.rs
@@ -654,7 +654,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     /// Panics if the block wasn't present in the data structure.
     ///
     #[track_caller]
-    pub fn set_unverified_block_bad(&mut self, height: u64, hash: &[u8; 32]) {
+    pub fn mark_unverified_block_as_bad(&mut self, height: u64, hash: &[u8; 32]) {
         self.blocks.set_block_bad(height, hash);
     }
 

--- a/src/sync/all_forks/pending_blocks.rs
+++ b/src/sync/all_forks/pending_blocks.rs
@@ -548,7 +548,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     /// state where the header is known.
     ///
     /// > **Note**: A user of this data structure is expected to manually add the parent block to
-    ///             this data structure as well in case it is unknown.
+    ///             this data structure as well in case it is unverified.
     ///
     /// # Panic
     ///
@@ -589,7 +589,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     /// to a state where the header and body are known.
     ///
     /// > **Note**: A user of this data structure is expected to manually add the parent block to
-    ///             this data structure as well in case it is unknown.
+    ///             this data structure as well in case it is unverified.
     ///
     /// # Panic
     ///

--- a/src/sync/all_forks/pending_blocks.rs
+++ b/src/sync/all_forks/pending_blocks.rs
@@ -386,7 +386,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
 
     /// Returns the current best block of the given source.
     ///
-    /// This corresponds either the latest call to [`PendingBlocks::set_best_block`],
+    /// This corresponds either the latest call to [`PendingBlocks::add_known_block_and_set_best`],
     /// or to the parameter passed to [`PendingBlocks::add_source`].
     ///
     /// # Panic
@@ -429,9 +429,10 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
         self.sources.knows_non_finalized_block(height, hash)
     }
 
-    /// Returns true if [`PendingBlocks::add_known_block`] or [`PendingBlocks::set_best_block`]
-    /// has earlier been called on this source with this height and hash, or if the source was
-    /// originally created (using [`PendingBlocks::add_source`]) with this height and hash.
+    /// Returns true if [`PendingBlocks::add_known_block`] or
+    /// [`PendingBlocks::add_known_block_and_set_best`] has earlier been called on this source
+    /// with this height and hash, or if the source was originally created (using
+    /// [`PendingBlocks::add_source`]) with this height and hash.
     ///
     /// # Panic
     ///
@@ -475,7 +476,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     /// Returns the previous user data associated to this block, if any.
     ///
     /// > **Note**: You should probably also call [`PendingBlocks::add_known_block`] or
-    /// >           [`PendingBlocks::set_best_block`].
+    /// >           [`PendingBlocks::add_known_block_and_set_best`].
     pub fn insert_unverified_block(
         &mut self,
         height: u64,

--- a/src/sync/all_forks/pending_blocks.rs
+++ b/src/sync/all_forks/pending_blocks.rs
@@ -618,6 +618,10 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
         self.blocks.set_parent_hash(height, hash, parent_hash);
     }
 
+    pub fn remove_block_tracking(&mut self, height: u64, hash: &[u8; 32]) {
+        self.sources.remove_known_block(height, hash);
+    }
+
     /// Removes the given block from the collection.
     ///
     /// > **Note**: Use this method after a block has been successfully verified, or in order to
@@ -627,8 +631,19 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     ///
     /// Panics if the block wasn't present in the data structure.
     ///
-    pub fn remove(&mut self, height: u64, hash: &[u8; 32]) -> TBl {
+    pub fn remove_block(&mut self, height: u64, hash: &[u8; 32]) -> TBl {
         self.blocks.remove(height, hash).user_data
+    }
+
+    /// Shortcut for [`PendingBlocks::remove_block_tracking`] and [`PendingBlocks::remove_block`].
+    ///
+    /// # Panic
+    ///
+    /// Panics if the block wasn't present in the data structure.
+    ///
+    pub fn remove_block_and_tracking(&mut self, height: u64, hash: &[u8; 32]) -> TBl {
+        self.remove_block_tracking(height, hash);
+        self.remove_block(height, hash)
     }
 
     /// Marks the given block and all its known children as "bad".

--- a/src/sync/all_forks/pending_blocks.rs
+++ b/src/sync/all_forks/pending_blocks.rs
@@ -127,14 +127,6 @@ pub struct Config {
     ///
     /// The higher the value, the more bandwidth is potentially wasted.
     pub max_requests_per_block: NonZeroU32,
-
-    /// List of block hashes that are known to be bad and shouldn't be downloaded or verified.
-    ///
-    /// > **Note**: This list is typically filled with a list of blocks found in the chain
-    /// >           specification. It is part of the "trusted setup" of the node, in other words
-    /// >           the information that is passed by the user and blindly assumed to be true.
-    // TODO: unused
-    pub banned_blocks: Vec<[u8; 64]>,
 }
 
 /// State of a block in the data structure.

--- a/src/sync/all_forks/pending_blocks.rs
+++ b/src/sync/all_forks/pending_blocks.rs
@@ -338,7 +338,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     ///
     /// Panics if the [`SourceId`] is out of range.
     ///
-    pub fn add_source_known_block(&mut self, source_id: SourceId, height: u64, hash: [u8; 32]) {
+    pub fn add_known_block_to_source(&mut self, source_id: SourceId, height: u64, hash: [u8; 32]) {
         self.sources.add_known_block(source_id, height, hash);
     }
 
@@ -353,7 +353,12 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     ///
     /// Panics if the [`SourceId`] is out of range.
     ///
-    pub fn remove_source_known_block(&mut self, source_id: SourceId, height: u64, hash: &[u8; 32]) {
+    pub fn remove_known_block_of_source(
+        &mut self,
+        source_id: SourceId,
+        height: u64,
+        hash: &[u8; 32],
+    ) {
         self.sources
             .source_remove_known_block(source_id, height, hash);
     }
@@ -369,7 +374,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     ///
     /// Panics if the [`SourceId`] is out of range.
     ///
-    pub fn add_source_known_block_and_set_best(
+    pub fn add_known_block_to_source_and_set_best(
         &mut self,
         source_id: SourceId,
         height: u64,
@@ -381,7 +386,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
 
     /// Returns the current best block of the given source.
     ///
-    /// This corresponds either the latest call to [`PendingBlocks::add_source_known_block_and_set_best`],
+    /// This corresponds either the latest call to [`PendingBlocks::add_known_block_to_source_and_set_best`],
     /// or to the parameter passed to [`PendingBlocks::add_source`].
     ///
     /// # Panic
@@ -424,8 +429,8 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
         self.sources.knows_non_finalized_block(height, hash)
     }
 
-    /// Returns true if [`PendingBlocks::add_source_known_block`] or
-    /// [`PendingBlocks::add_source_known_block_and_set_best`] has earlier been called on this
+    /// Returns true if [`PendingBlocks::add_known_block_to_source`] or
+    /// [`PendingBlocks::add_known_block_to_source_and_set_best`] has earlier been called on this
     /// source with this height and hash, or if the source was originally created (using
     /// [`PendingBlocks::add_source`]) with this height and hash.
     ///
@@ -470,8 +475,8 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     ///
     /// Returns the previous user data associated to this block, if any.
     ///
-    /// > **Note**: You should probably also call [`PendingBlocks::add_source_known_block`] or
-    /// >           [`PendingBlocks::add_source_known_block_and_set_best`].
+    /// > **Note**: You should probably also call [`PendingBlocks::add_known_block_to_source`] or
+    /// >           [`PendingBlocks::add_known_block_to_source_and_set_best`].
     pub fn insert_unverified_block(
         &mut self,
         height: u64,
@@ -625,7 +630,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
 
     /// Removes the given block from the list of known blocks of all from the sources.
     ///
-    /// This is equivalent to calling [`PendingBlocks::remove_source_known_block`] for each
+    /// This is equivalent to calling [`PendingBlocks::remove_known_block_of_source`] for each
     /// source.
     pub fn remove_sources_known_block(&mut self, height: u64, hash: &[u8; 32]) {
         self.sources.remove_known_block(height, hash);

--- a/src/sync/all_forks/pending_blocks.rs
+++ b/src/sync/all_forks/pending_blocks.rs
@@ -49,7 +49,7 @@
 //! Note that unverified blocks are added/removed completely separately from blocks known by
 //! sources.
 //!
-//! Unverified blocks are expected to be added to this collection whenever we hear about them
+//! Unverified blocks are expected to be added to this collection whenever this node hears about them
 //! from a source of blocks (such as a peer) and that it is not possible to verify them
 //! immediately (because their parent isn't known).
 //!

--- a/src/sync/all_forks/sources.rs
+++ b/src/sync/all_forks/sources.rs
@@ -92,6 +92,11 @@ impl<TSrc> AllForksSources<TSrc> {
         self.sources.is_empty()
     }
 
+    /// Iterates over all sources.
+    pub fn iter(&'_ self) -> impl Iterator<Item = SourceId> + '_ {
+        self.sources.keys().copied()
+    }
+
     /// Returns the number of sources in the data structure.
     pub fn len(&self) -> usize {
         self.sources.len()

--- a/src/sync/all_forks/sources.rs
+++ b/src/sync/all_forks/sources.rs
@@ -309,8 +309,9 @@ impl<TSrc> AllForksSources<TSrc> {
 
     /// Returns the current best block of the given source.
     ///
-    /// This corresponds either the latest call to [`AllForksSources::set_best_block`],
-    /// or to the parameter passed to [`AllForksSources::add_source`].
+    /// This corresponds either the latest call to
+    /// [`AllForksSources::add_known_block_and_set_best`], or to the parameter passed to
+    /// [`AllForksSources::add_source`].
     ///
     /// # Panic
     ///
@@ -344,9 +345,10 @@ impl<TSrc> AllForksSources<TSrc> {
             .map(|(_, _, id)| *id)
     }
 
-    /// Returns true if [`AllForksSources::add_known_block`] or [`AllForksSources::set_best_block`]
-    /// has earlier been called on this source with this height and hash, or if the source was
-    /// originally created (using [`AllForksSources::add_source`]) with this height and hash.
+    /// Returns true if [`AllForksSources::add_known_block`] or
+    /// [`AllForksSources::add_known_block_and_set_best`] has earlier been called on this source
+    /// with this height and hash, or if the source was originally created (using
+    /// [`AllForksSources::add_source`]) with this height and hash.
     ///
     /// # Panic
     ///

--- a/src/sync/all_forks/sources.rs
+++ b/src/sync/all_forks/sources.rs
@@ -279,14 +279,22 @@ impl<TSrc> AllForksSources<TSrc> {
         debug_assert_eq!(_was_in1, _was_in2);
     }
 
-    /// Sets the best block of this source.
+    /// Registers a new block that the source is aware of and sets it as its best block.
+    ///
+    /// If the block height is inferior or equal to the finalized block height, the block itself
+    /// isn't kept in memory but is still set as the source's best block.
     ///
     /// # Panic
     ///
     /// Panics if the [`SourceId`] is out of range.
     ///
     #[track_caller]
-    pub fn set_best_block(&mut self, source_id: SourceId, height: u64, hash: [u8; 32]) {
+    pub fn add_known_block_and_set_best(
+        &mut self,
+        source_id: SourceId,
+        height: u64,
+        hash: [u8; 32],
+    ) {
         self.add_known_block(source_id, height, hash);
 
         let source = self.sources.get_mut(&source_id).unwrap();
@@ -400,7 +408,7 @@ mod tests {
         assert_eq!(sources.num_blocks(), 1);
         assert!(sources.source_knows_non_finalized_block(source1, 12, &[1; 32]));
 
-        sources.set_best_block(source1, 13, [2; 32]);
+        sources.add_known_block_and_set_best(source1, 13, [2; 32]);
         assert_eq!(sources.num_blocks(), 2);
         assert!(sources.source_knows_non_finalized_block(source1, 12, &[1; 32]));
         assert!(sources.source_knows_non_finalized_block(source1, 13, &[2; 32]));

--- a/src/sync/all_forks/sources.rs
+++ b/src/sync/all_forks/sources.rs
@@ -309,7 +309,7 @@ impl<TSrc> AllForksSources<TSrc> {
 
     /// Returns the current best block of the given source.
     ///
-    /// This corresponds either the latest call to
+    /// This corresponds either to the latest call to
     /// [`AllForksSources::add_known_block_and_set_best`], or to the parameter passed to
     /// [`AllForksSources::add_source`].
     ///


### PR DESCRIPTION
I don't know how to title this PR more appropriately than "generic improvements to the code".
This PR basically finishes the original vision of the `pending_blocks.rs` module by adding a `unnecessary_unverified_blocks` function.

For context, the data structure in `pending_blocks.rs` tracks blocks that we know exist but can't be verified yet (because they're not a direct child of a block that has been verified, or because haven't downloaded their header yet, or in the case of the full node because we only have their header and not their body).

This newly-added `unnecessary_unverified_blocks` function returns a list of unverified blocks that aren't strictly necessary to make the syncing progress. These blocks are blocks that are known to be on a bad fork, and blocks that are somewhere in-between the best block of a peer and a locally-known fork.

For example, if we are at block 10 and a peer announces block 15, we will download block 14, then block 13, then block 12, etc. (note: in reality we should download all 5 blocks at once, but in the worst case scenario we'll download them one by one). After block 13 has been downloaded, we can remove block 14 from memory (and keep block 13) without impacting the syncing, as the download of block 12 will still happen.

These unnecessary unverified blocks are removed from the data structure if it reaches a certain size.
It is important to do so, in order to avoid spam attacks where peers announce for example block 9999 when the chain is actually only at block 10. The PR sets the arbitrary threshold to 100 blocks, meaning that in that example, after we've downloaded block 9900, we will start removing block 9998, then block 9997, etc. Despite removing blocks, we will, in finite time, still be able to determine whether this alternative chain is good or bad. If the announcement of block 9999 turned out to be legit, then we will be synchronized at block 110, and will start downloading the blocks from block 9999 again from scratch. It isn't great, but again it guarantees that we'll be fully in sync in finite time, and without an explosion in memory usage.
For long range downloads, such as the initial syncing, the so-called "optimistic" syncing should be used instead. In other words, long-range downloads are out of scope of this code.

In addition to this new method, this PR does a lot of renaming and documentation clean ups, in order to clarify how the data structure works. I've had to do this in order to implement `unnecessary_unverified_blocks` because I was myself a bit lost. It introduces some small hacks into `all_forks.rs`, but `all_forks.rs` isn't super clean at the moment, and I don't think its quality is really degraded by these changes. It is necessary to put `pending_blocks.rs` in a clean state before `all_forks.rs` itself can be cleaned up.

@melekes I understand that this is a bit complicated since you don't know about this code at all, so I'm fine with you not properly reviewing this.