### PR TITLE
Make set_parent_hash mark entire chain as bad

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -15,3 +15,4 @@
 - Implement the `ext_crypto_ecdsa_verify_version_1` host function ([#2120](https://github.com/paritytech/smoldot/pull/2120)).
 - Implement the `ext_crypto_ecdsa_sign_prehashed_version_1` host function ([#2120](https://github.com/paritytech/smoldot/pull/2120)).
 - Implement the `ext_crypto_ecdsa_verify_prehashed_version_1` host function ([#2120](https://github.com/paritytech/smoldot/pull/2120)).
+- Properly mark all descendants as bad when a block is determined to be bad ([#2121](https://github.com/paritytech/smoldot/pull/2121)).

--- a/src/sync/all_forks/disjoint.rs
+++ b/src/sync/all_forks/disjoint.rs
@@ -446,12 +446,18 @@ mod tests {
         assert!(!collection.is_bad(2, &[2; 32]).unwrap());
         collection.insert(3, [3; 32], Some([2; 32]), ());
         assert!(!collection.is_bad(3, &[3; 32]).unwrap());
+        collection.insert(3, [31; 32], Some([2; 32]), ());
+        assert!(!collection.is_bad(3, &[31; 32]).unwrap());
+        collection.insert(4, [4; 32], Some([3; 32]), ());
+        assert!(!collection.is_bad(4, &[4; 32]).unwrap());
         assert_eq!(collection.unknown_blocks().count(), 1);
 
         collection.set_parent_hash(2, &[2; 32], [1; 32]);
         assert_eq!(collection.unknown_blocks().count(), 0);
         assert!(collection.is_bad(2, &[2; 32]).unwrap());
         assert!(collection.is_bad(3, &[3; 32]).unwrap());
+        assert!(collection.is_bad(3, &[31; 32]).unwrap());
+        assert!(collection.is_bad(4, &[4; 32]).unwrap());
     }
 
     #[test]

--- a/src/sync/all_forks/disjoint.rs
+++ b/src/sync/all_forks/disjoint.rs
@@ -240,7 +240,7 @@ impl<TBl> DisjointBlocks<TBl> {
         }
 
         if parent_is_bad {
-            block.bad = true;
+            self.set_block_bad(height, hash);
         }
     }
 
@@ -432,8 +432,8 @@ mod tests {
 
     #[test]
     fn set_parent_hash_updates_bad() {
-        // Calling `set_parent_hash` where the parent is a known a bad block marks the block as
-        // bad as well.
+        // Calling `set_parent_hash` where the parent is a known a bad block marks the block and
+        // its children as bad as well.
 
         let mut collection = super::DisjointBlocks::new();
 
@@ -443,10 +443,15 @@ mod tests {
         assert_eq!(collection.unknown_blocks().count(), 0);
 
         collection.insert(2, [2; 32], None, ());
+        assert!(!collection.is_bad(2, &[2; 32]).unwrap());
+        collection.insert(3, [3; 32], Some([2; 32]), ());
+        assert!(!collection.is_bad(3, &[3; 32]).unwrap());
         assert_eq!(collection.unknown_blocks().count(), 1);
 
         collection.set_parent_hash(2, &[2; 32], [1; 32]);
         assert_eq!(collection.unknown_blocks().count(), 0);
+        assert!(collection.is_bad(2, &[2; 32]).unwrap());
+        assert!(collection.is_bad(3, &[3; 32]).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
If a certain block is bad, all its descendants are meant to be marked as bad as well.
When you call `set_parent_hash`, and the parent is bad, the immediate child is set as bad. This PR also sets the entire chain of descendants as bad.
