### PR TITLE
Introduce a CHANGELOG for the wasm node

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 ### Changed
 
-- Prune list of unverified blocks if it grows too much in order to resist spam attacks.
-- Log block's parent hash in case of block announce.
-- Only call `console.error` once in case of a Rust panic.
+- Prune list of unverified blocks if it grows too much in order to resist spam attacks ([#2114](https://github.com/paritytech/smoldot/pull/2114)).
+- Log block's parent hash in case of block announce ([#2105](https://github.com/paritytech/smoldot/pull/2105)).
+- Only call `console.error` once in case of a Rust panic ([#2093](https://github.com/paritytech/smoldot/pull/2093)).
 
 ### Fixed
 
-- Fix parachain blocks being reported multiple times in case of a relay chain fork.
-- Implement the `ext_crypto_ecdsa_sign_version_1` host function.
-- Implement the `ext_crypto_ecdsa_verify_version_1` host function.
-- Implement the `ext_crypto_ecdsa_sign_prehashed_version_1` host function.
-- Implement the `ext_crypto_ecdsa_verify_prehashed_version_1` host function.
+- Fix parachain blocks being reported multiple times in case of a relay chain fork ([#2106](https://github.com/paritytech/smoldot/pull/2106)).
+- Implement the `ext_crypto_ecdsa_sign_version_1` host function ([#2120](https://github.com/paritytech/smoldot/pull/2120)).
+- Implement the `ext_crypto_ecdsa_verify_version_1` host function ([#2120](https://github.com/paritytech/smoldot/pull/2120)).
+- Implement the `ext_crypto_ecdsa_sign_prehashed_version_1` host function ([#2120](https://github.com/paritytech/smoldot/pull/2120)).
+- Implement the `ext_crypto_ecdsa_verify_prehashed_version_1` host function ([#2120](https://github.com/paritytech/smoldot/pull/2120)).

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## Unreleased
+
+### Changed
+
+- Prune list of unverified blocks if it grows too much in order to resist spam attacks.
+- Log block's parent hash in case of block announce.
+- Only call `console.error` once in case of a Rust panic.
+
+### Fixed
+
+- Fix parachain blocks being reported multiple times in case of a relay chain fork.
+- Implement the `ext_crypto_ecdsa_sign_version_1` host function.
+- Implement the `ext_crypto_ecdsa_verify_version_1` host function.
+- Implement the `ext_crypto_ecdsa_sign_prehashed_version_1` host function.
+- Implement the `ext_crypto_ecdsa_verify_prehashed_version_1` host function.


### PR DESCRIPTION
After this PR is merged, every noticeable PR that concerns the wasm node should update this CHANGELOG.

I'm not including changes such as https://github.com/paritytech/smoldot/pull/2073 because they only concern the full node.

We could consider adding a CI action that checks whether the CHANGELOG respects a certain format, but I haven't found anything great.
We could also consider adding a CI action that reminds you to add a CHANGELOG entry if you didn't (unless you explicitly say "this doesn't need a changelog entry"), but that also seems kind of complicated.

