### PR TITLE
Refactor all forks a bit

### DIFF
--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -1138,7 +1138,12 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                             &block.scale_encoded_header,
                             block.scale_encoded_justifications.into_iter(),
                         ) {
-                            Ok(ba) => blocks_append = ba,
+                            Ok(all_forks::AddBlock::Vacant(ba)) => {
+                                blocks_append = ba.insert(block.user_data)
+                            }
+                            Ok(all_forks::AddBlock::Occupied(ba)) => {
+                                blocks_append = ba.replace(block.user_data)
+                            }
                             Err((
                                 all_forks::AncestrySearchResponseError::NotFinalizedChain {
                                     discarded_unverified_block_headers,

--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -1138,10 +1138,10 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                             &block.scale_encoded_header,
                             block.scale_encoded_justifications.into_iter(),
                         ) {
-                            Ok(all_forks::AddBlock::Vacant(ba)) => {
+                            Ok(all_forks::AddBlock::UnknownBlock(ba)) => {
                                 blocks_append = ba.insert(block.user_data)
                             }
-                            Ok(all_forks::AddBlock::Occupied(ba)) => {
+                            Ok(all_forks::AddBlock::AlreadyPending(ba)) => {
                                 blocks_append = ba.replace(block.user_data)
                             }
                             Ok(all_forks::AddBlock::AlreadyInChain(ba)) if block_index == 0 => {

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -949,6 +949,161 @@ impl<TBl, TRq, TSrc> FinishAncestrySearch<TBl, TRq, TSrc> {
         // as a whole to be useful.
         self.any_progress = true;
 
+        let block_from_source_result = {
+            debug_assert_eq!(header.hash(), *header_hash);
+
+            // Code below does `header.number - 1`. Make sure that `header.number` isn't 0.
+            if header.number == 0 {
+                return HeaderFromSourceOutcome::TooOld {
+                    announce_block_height: 0,
+                    finalized_block_height: self.chain.finalized_block_header().number,
+                };
+            }
+
+            // No matter what is done below, start by updating the view the state machine maintains
+            // for this source.
+            if known_to_be_source_best {
+                self.inner.blocks.add_known_block_to_source_and_set_best(
+                    source_id,
+                    header.number,
+                    *header_hash,
+                );
+            } else {
+                self.inner
+                    .blocks
+                    .add_known_block_to_source(source_id, header.number, *header_hash);
+            }
+
+            // Source also knows the parent of the announced block.
+            self.inner.blocks.add_known_block_to_source(
+                source_id,
+                header.number - 1,
+                *header.parent_hash,
+            );
+
+            // It is assumed that all sources will eventually agree on the same finalized chain. If
+            // the block number is lower or equal than the locally-finalized block number, it is
+            // assumed that this source is simply late compared to the local node, and that the block
+            // that has been received is either part of the finalized chain or belongs to a fork that
+            // will get discarded by this source in the future.
+            if header.number <= self.chain.finalized_block_header().number {
+                return HeaderFromSourceOutcome::TooOld {
+                    announce_block_height: header.number,
+                    finalized_block_height: self.chain.finalized_block_header().number,
+                };
+            }
+
+            // If the block is already part of the local tree of blocks, nothing more to do.
+            if self.chain.contains_non_finalized_block(header_hash) {
+                return HeaderFromSourceOutcome::AlreadyInChain;
+            }
+
+            // At this point, we have excluded blocks that are already part of the chain or too old.
+            // We insert the block in the list of unverified blocks so as to treat all blocks the
+            // same.
+            if !self
+                .inner
+                .blocks
+                .contains_unverified_block(header.number, header_hash)
+            {
+                self.inner.blocks.insert_unverified_block(
+                    header.number,
+                    *header_hash,
+                    if body.is_some() {
+                        pending_blocks::UnverifiedBlockState::HeaderBodyKnown {
+                            parent_hash: *header.parent_hash,
+                        }
+                    } else {
+                        pending_blocks::UnverifiedBlockState::HeaderKnown {
+                            parent_hash: *header.parent_hash,
+                        }
+                    },
+                    PendingBlock {
+                        body,
+                        header: Some(header.clone().into()),
+                        justifications: justifications
+                            .map(|(e, j)| (e, j.clone()))
+                            .collect::<Vec<_>>(),
+                    },
+                );
+
+                if self.inner.banned_blocks.contains(header_hash) {
+                    self.inner
+                        .blocks
+                        .mark_unverified_block_as_bad(header.number, header_hash);
+                }
+
+                // If there are too many blocks stored in the blocks list, remove unnecessary ones.
+                // Not doing this could lead to an explosion of the size of the collections.
+                // TODO: removing blocks should only be done explicitly through an API endpoint, because we want to store user datas in unverified blocks too; see https://github.com/paritytech/smoldot/issues/1572
+                while self.inner.blocks.num_unverified_blocks() >= 100 {
+                    // TODO: arbitrary constant
+                    let (height, hash) =
+                        match self.inner.blocks.unnecessary_unverified_blocks().next() {
+                            Some((n, h)) => (n, *h),
+                            None => break,
+                        };
+
+                    self.inner.blocks.remove_sources_known_block(height, &hash);
+                    self.inner.blocks.remove_unverified_block(height, &hash);
+                }
+            } else {
+                if body.is_some() {
+                    self.inner.blocks.set_unverified_block_header_body_known(
+                        header.number,
+                        header_hash,
+                        *header.parent_hash,
+                    );
+                } else {
+                    self.inner.blocks.set_unverified_block_header_known(
+                        header.number,
+                        header_hash,
+                        *header.parent_hash,
+                    );
+                }
+
+                let block_user_data = self
+                    .inner
+                    .blocks
+                    .unverified_block_user_data_mut(header.number, header_hash);
+                if block_user_data.header.is_none() {
+                    block_user_data.header = Some(header.clone().into()); // TODO: copying bytes :-/
+                }
+                // TODO: what if body was already known, but differs from what is stored?
+                if block_user_data.body.is_none() {
+                    if let Some(body) = body {
+                        block_user_data.body = Some(body);
+                    }
+                }
+            }
+
+            // TODO: what if the pending block already contains a justification and it is not the
+            //       same as here? since justifications aren't immediately verified, it is possible
+            //       for a malicious peer to send us bad justifications
+
+            // Block is not part of the finalized chain.
+            if header.number == self.chain.finalized_block_header().number + 1
+                && *header.parent_hash != self.chain.finalized_block_hash()
+            {
+                // TODO: remove_verify_failed
+                return HeaderFromSourceOutcome::NotFinalizedChain;
+            }
+
+            if *header.parent_hash == self.chain.finalized_block_hash()
+                || self
+                    .chain
+                    .non_finalized_block_by_hash(header.parent_hash)
+                    .is_some()
+            {
+                // TODO: ambiguous naming
+                return HeaderFromSourceOutcome::HeaderVerify;
+            }
+
+            // TODO: if pending_blocks.num_blocks() > some_max { remove uninteresting block }
+
+            HeaderFromSourceOutcome::Disjoint
+        };
+
         match self.inner.block_from_source(
             self.source_id,
             &self.expected_next_hash,

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -966,22 +966,6 @@ impl<TBl, TRq, TSrc> FinishAncestrySearch<TBl, TRq, TSrc> {
             return Err((AncestrySearchResponseError::TooOld, self.finish()));
         }
 
-        // No matter what is done next, update the view the state machine maintains for this
-        // source.
-        self.inner.inner.blocks.add_known_block_to_source(
-            self.source_id,
-            decoded_header.number,
-            self.expected_next_hash,
-        );
-
-        // Source also knows the parent of the announced block.
-        // TODO: do this for the entire chain of blocks if it is known locally?
-        self.inner.inner.blocks.add_known_block_to_source(
-            self.source_id,
-            decoded_header.number - 1,
-            *decoded_header.parent_hash,
-        );
-
         // If the block is already part of the local tree of blocks, nothing more to do.
         if self
             .inner
@@ -1076,6 +1060,21 @@ pub struct AddBlockOccupied<TBl, TRq, TSrc> {
 impl<TBl, TRq, TSrc> AddBlockOccupied<TBl, TRq, TSrc> {
     // TODO: return old user data
     pub fn replace(mut self, user_data: TBl) -> FinishAncestrySearch<TBl, TRq, TSrc> {
+        // Update the view the state machine maintains for this source.
+        self.inner.inner.inner.blocks.add_known_block_to_source(
+            self.inner.source_id,
+            self.decoded_header.number,
+            self.inner.expected_next_hash,
+        );
+
+        // Source also knows the parent of the announced block.
+        // TODO: do this for the entire chain of blocks if it is known locally?
+        self.inner.inner.inner.blocks.add_known_block_to_source(
+            self.inner.source_id,
+            self.decoded_header.number - 1,
+            self.decoded_header.parent_hash,
+        );
+
         self.inner
             .inner
             .inner
@@ -1121,6 +1120,21 @@ pub struct AddBlockVacant<TBl, TRq, TSrc> {
 
 impl<TBl, TRq, TSrc> AddBlockVacant<TBl, TRq, TSrc> {
     pub fn insert(mut self, user_data: TBl) -> FinishAncestrySearch<TBl, TRq, TSrc> {
+        // Update the view the state machine maintains for this source.
+        self.inner.inner.inner.blocks.add_known_block_to_source(
+            self.inner.source_id,
+            self.decoded_header.number,
+            self.inner.expected_next_hash,
+        );
+
+        // Source also knows the parent of the announced block.
+        // TODO: do this for the entire chain of blocks if it is known locally?
+        self.inner.inner.inner.blocks.add_known_block_to_source(
+            self.inner.source_id,
+            self.decoded_header.number - 1,
+            self.decoded_header.parent_hash,
+        );
+
         self.inner.inner.inner.blocks.insert_unverified_block(
             self.decoded_header.number,
             self.inner.expected_next_hash,

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -187,6 +187,7 @@ struct PendingBlock {
     header: Option<header::Header>,
     body: Option<Vec<Vec<u8>>>,
     justifications: Vec<([u8; 4], Vec<u8>)>,
+    // TODO: add user_data as soon as block announces and add_source APIs support passing a user data
 }
 
 struct Block<TBl> {
@@ -1073,6 +1074,7 @@ pub struct AddBlockOccupied<TBl, TRq, TSrc> {
 }
 
 impl<TBl, TRq, TSrc> AddBlockOccupied<TBl, TRq, TSrc> {
+    // TODO: return old user data
     pub fn replace(mut self, user_data: TBl) -> FinishAncestrySearch<TBl, TRq, TSrc> {
         self.inner
             .inner

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -960,17 +960,9 @@ impl<TBl, TRq, TSrc> FinishAncestrySearch<TBl, TRq, TSrc> {
 
             // No matter what is done below, start by updating the view the state machine maintains
             // for this source.
-            if false {
-                self.inner.inner.blocks.add_known_block_to_source_and_set_best(
-                    self.source_id,
-                    decoded_header.number,
-                    self.expected_next_hash,
-                );
-            } else {
-                self.inner.inner
-                    .blocks
-                    .add_known_block_to_source(self.source_id, decoded_header.number, self.expected_next_hash);
-            }
+            self.inner.inner
+                .blocks
+                .add_known_block_to_source(self.source_id, decoded_header.number, self.expected_next_hash);
 
             // Source also knows the parent of the announced block.
             self.inner.inner.blocks.add_known_block_to_source(
@@ -1007,10 +999,8 @@ impl<TBl, TRq, TSrc> FinishAncestrySearch<TBl, TRq, TSrc> {
                 self.inner.inner.blocks.insert_unverified_block(
                     decoded_header.number,
                     self.expected_next_hash,
-                    {
-                        pending_blocks::UnverifiedBlockState::HeaderKnown {
-                            parent_hash: *decoded_header.parent_hash,
-                        }
+                    pending_blocks::UnverifiedBlockState::HeaderKnown {
+                        parent_hash: *decoded_header.parent_hash,
                     },
                     PendingBlock {
                         body: None,
@@ -1042,13 +1032,11 @@ impl<TBl, TRq, TSrc> FinishAncestrySearch<TBl, TRq, TSrc> {
                     self.inner.inner.blocks.remove_unverified_block(height, &hash);
                 }
             } else {
-                {
-                    self.inner.inner.blocks.set_unverified_block_header_known(
-                        decoded_header.number,
-                        &self.expected_next_hash,
-                        *decoded_header.parent_hash,
-                    );
-                }
+                self.inner.inner.blocks.set_unverified_block_header_known(
+                    decoded_header.number,
+                    &self.expected_next_hash,
+                    *decoded_header.parent_hash,
+                );
 
                 let block_user_data = self.inner
                     .inner
@@ -1056,9 +1044,6 @@ impl<TBl, TRq, TSrc> FinishAncestrySearch<TBl, TRq, TSrc> {
                     .unverified_block_user_data_mut(decoded_header.number, &self.expected_next_hash);
                 if block_user_data.header.is_none() {
                     block_user_data.header = Some(decoded_header.clone().into()); // TODO: copying bytes :-/
-                }
-                // TODO: what if body was already known, but differs from what is stored?
-                if block_user_data.body.is_none() {
                 }
             }
 

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -91,7 +91,7 @@ use alloc::{
     borrow::ToOwned as _,
     vec::{self, Vec},
 };
-use core::{iter, num::NonZeroU32, ops, time::Duration};
+use core::{num::NonZeroU32, ops, time::Duration};
 
 mod disjoint;
 mod pending_blocks;
@@ -185,7 +185,7 @@ struct Inner<TRq, TSrc> {
 
 struct PendingBlock {
     header: Option<header::Header>,
-    body: Option<Vec<Vec<u8>>>,
+    // TODO: add body: Option<Vec<Vec<u8>>>, when adding full node support
     justifications: Vec<([u8; 4], Vec<u8>)>,
     // TODO: add user_data as soon as block announces and add_source APIs support passing a user data
 }
@@ -317,7 +317,6 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
                 pending_blocks::UnverifiedBlockState::HeightHashKnown,
                 PendingBlock {
                     header: None,
-                    body: None,
                     justifications: Vec::new(),
                 },
             );
@@ -635,7 +634,6 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
                     }
                 },
                 PendingBlock {
-                    body: None,
                     header: Some(announced_header.clone().into()),
                     justifications: Vec::new(),
                 },
@@ -1063,6 +1061,8 @@ impl<TBl, TRq, TSrc> AddBlockOccupied<TBl, TRq, TSrc> {
                 block_user_data.header = Some(self.decoded_header.clone().into());
                 // TODO: copying bytes :-/
             }
+
+            // TODO: update user_data here
         }
 
         // TODO: what if the pending block already contains a justification and it is not the
@@ -1090,7 +1090,7 @@ pub struct AddBlockVacant<TBl, TRq, TSrc> {
 }
 
 impl<TBl, TRq, TSrc> AddBlockVacant<TBl, TRq, TSrc> {
-    pub fn insert(mut self, user_data: TBl) -> FinishAncestrySearch<TBl, TRq, TSrc> {
+    pub fn insert(mut self, _user_data: TBl) -> FinishAncestrySearch<TBl, TRq, TSrc> {
         // Update the view the state machine maintains for this source.
         self.inner.inner.inner.blocks.add_known_block_to_source(
             self.inner.source_id,
@@ -1113,7 +1113,6 @@ impl<TBl, TRq, TSrc> AddBlockVacant<TBl, TRq, TSrc> {
                 parent_hash: self.decoded_header.parent_hash,
             },
             PendingBlock {
-                body: None,
                 header: Some(self.decoded_header.clone().into()),
                 justifications: self.justifications,
             },

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -1073,7 +1073,7 @@ pub struct AddBlockOccupied<TBl, TRq, TSrc> {
 }
 
 impl<TBl, TRq, TSrc> AddBlockOccupied<TBl, TRq, TSrc> {
-    pub fn replace(self, user_data: TBl) -> FinishAncestrySearch<TBl, TRq, TSrc> {
+    pub fn replace(mut self, user_data: TBl) -> FinishAncestrySearch<TBl, TRq, TSrc> {
         self.inner
             .inner
             .inner

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -1179,34 +1179,6 @@ impl<TBl, TRq, TSrc> AddBlockVacant<TBl, TRq, TSrc> {
     }
 }
 
-/// Outcome of calling [`AllForksSync::block_from_source`].
-///
-/// Not public.
-enum HeaderFromSourceOutcome {
-    /// Header is ready to be verified.
-    HeaderVerify,
-
-    /// Announced block is too old to be part of the finalized chain.
-    ///
-    /// It is assumed that all sources will eventually agree on the same finalized chain. Blocks
-    /// whose height is inferior to the height of the latest known finalized block should simply
-    /// be ignored. Whether or not this old block is indeed part of the finalized block isn't
-    /// verified, and it is assumed that the source is simply late.
-    TooOld {
-        /// Height of the announced block.
-        announce_block_height: u64,
-        /// Height of the currently finalized block.
-        finalized_block_height: u64,
-    },
-    /// Announced block has already been successfully verified and is part of the non-finalized
-    /// chain.
-    AlreadyInChain,
-    /// Announced block is known to not be a descendant of the finalized block.
-    NotFinalizedChain,
-    /// Header cannot be verified now, and has been stored for later.
-    Disjoint,
-}
-
 /// Outcome of calling [`AllForksSync::block_announce`].
 pub enum BlockAnnounceOutcome {
     /// Header is ready to be verified.

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -951,7 +951,7 @@ impl<TBl, TRq, TSrc> FinishAncestrySearch<TBl, TRq, TSrc> {
             .blocks
             .contains_unverified_block(decoded_header.number, &self.expected_next_hash)
         {
-            Ok(AddBlock::Vacant(AddBlockVacant {
+            Ok(AddBlock::UnknownBlock(AddBlockVacant {
                 inner: self,
                 decoded_header: decoded_header.into(),
                 justifications: scale_encoded_justifications
@@ -959,7 +959,7 @@ impl<TBl, TRq, TSrc> FinishAncestrySearch<TBl, TRq, TSrc> {
                     .collect::<Vec<_>>(),
             }))
         } else {
-            Ok(AddBlock::Occupied(AddBlockOccupied {
+            Ok(AddBlock::AlreadyPending(AddBlockOccupied {
                 inner: self,
                 decoded_header: decoded_header.into(),
                 is_verified: false,
@@ -995,8 +995,8 @@ impl<TBl, TRq, TSrc> FinishAncestrySearch<TBl, TRq, TSrc> {
 }
 
 pub enum AddBlock<TBl, TRq, TSrc> {
-    Occupied(AddBlockOccupied<TBl, TRq, TSrc>),
-    Vacant(AddBlockVacant<TBl, TRq, TSrc>),
+    AlreadyPending(AddBlockOccupied<TBl, TRq, TSrc>),
+    UnknownBlock(AddBlockVacant<TBl, TRq, TSrc>),
 
     /// The block is already in the list of verified blocks.
     ///


### PR DESCRIPTION
Continuation of https://github.com/paritytech/smoldot/pull/2123 and https://github.com/paritytech/smoldot/issues/1572

Instead of having `FinishAncestrySearch::add_block` immediately insert the block, we now instead return a new `AddBlock` enum that indicates whether the block has already been inserted before, and that lets you actually do the block insertion.

The diff is moderately large, but this PR should be easy to review commit by commit.

It still doesn't finish this whole "user data saga". The next steps will be to update `block_announce` and `add_source`, as they also manipulate blocks. I didn't want to bloat this single PR too much.
