### PR TITLE
limit codegen-units to get the maximum optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,9 @@ codegen-units = 1
 inherits = "release"
 lto = true
 opt-level = "z"
+# https://github.com/rust-lang/rust/issues/47745
+# https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
+codegen-units = 1
 
 [[bench]]
 name = "header"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,9 @@ opt-level = 3
 [profile.release]
 panic = "abort"
 lto = true
+# https://github.com/rust-lang/rust/issues/47745
+# https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
+codegen-units = 1
 #strip = "symbols"      # TODO: uncomment once stable
 
 [profile.min-size-release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,11 +134,7 @@ codegen-units = 1
 
 [profile.min-size-release]
 inherits = "release"
-lto = true
 opt-level = "z"
-# https://github.com/rust-lang/rust/issues/47745
-# https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
-codegen-units = 1
 
 [[bench]]
 name = "header"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,8 @@ opt-level = 3
 [profile.release]
 panic = "abort"
 lto = true
-# https://github.com/rust-lang/rust/issues/47745
+# codegen-units set to 1 to avoid performance regressions when combined with LTO
+# See https://github.com/rust-lang/rust/issues/47745
 # https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
 codegen-units = 1
 #strip = "symbols"      # TODO: uncomment once stable


### PR DESCRIPTION
Hello,

There might be a performance regression due to enabling lto without limiting the number of code generation units (codegen-units = 1).

References:
https://github.com/rust-lang/rust/issues/47745
https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units