### PR TITLE
Refactor block announces to allow for user datas

### DIFF
--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -1007,16 +1007,13 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                         finalized_block_height,
                     },
                     all_forks::BlockAnnounceOutcome::Unknown(source_update) => {
-                        source_update.insert();
+                        source_update.insert_and_update_source();
                         BlockAnnounceOutcome::Disjoint // TODO: arbitrary
                     }
                     all_forks::BlockAnnounceOutcome::AlreadyInChain(source_update)
                     | all_forks::BlockAnnounceOutcome::Known(source_update) => {
-                        source_update.update_source();
+                        source_update.update_source_and_block();
                         BlockAnnounceOutcome::Disjoint // TODO: arbitrary
-                    }
-                    all_forks::BlockAnnounceOutcome::NotFinalizedChain => {
-                        BlockAnnounceOutcome::NotFinalizedChain
                     }
                     all_forks::BlockAnnounceOutcome::InvalidHeader(error) => {
                         BlockAnnounceOutcome::InvalidHeader(error)

--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -999,9 +999,6 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         match (&mut self.inner, source_id) {
             (AllSyncInner::AllForks(sync), &SourceMapping::AllForks(source_id)) => {
                 match sync.block_announce(source_id, announced_scale_encoded_header, is_best) {
-                    all_forks::BlockAnnounceOutcome::HeaderVerify => {
-                        BlockAnnounceOutcome::HeaderVerify
-                    }
                     all_forks::BlockAnnounceOutcome::TooOld {
                         announce_block_height,
                         finalized_block_height,
@@ -1009,13 +1006,18 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                         announce_block_height,
                         finalized_block_height,
                     },
-                    all_forks::BlockAnnounceOutcome::AlreadyInChain => {
-                        BlockAnnounceOutcome::AlreadyInChain
+                    all_forks::BlockAnnounceOutcome::Unknown(source_update) => {
+                        source_update.insert();
+                        BlockAnnounceOutcome::Disjoint // TODO: arbitrary
+                    }
+                    all_forks::BlockAnnounceOutcome::AlreadyInChain(source_update)
+                    | all_forks::BlockAnnounceOutcome::Known(source_update) => {
+                        source_update.update_source();
+                        BlockAnnounceOutcome::Disjoint // TODO: arbitrary
                     }
                     all_forks::BlockAnnounceOutcome::NotFinalizedChain => {
                         BlockAnnounceOutcome::NotFinalizedChain
                     }
-                    all_forks::BlockAnnounceOutcome::Disjoint => BlockAnnounceOutcome::Disjoint,
                     all_forks::BlockAnnounceOutcome::InvalidHeader(error) => {
                         BlockAnnounceOutcome::InvalidHeader(error)
                     }

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -1221,7 +1221,8 @@ pub struct AnnouncedBlockUnknown<'a, TBl, TRq, TSrc> {
 }
 
 impl<'a, TBl, TRq, TSrc> AnnouncedBlockUnknown<'a, TBl, TRq, TSrc> {
-    pub fn insert(self, user_data: TBl) {
+    pub fn insert(self) {
+        // TODO: ^ add user_data: TBl parameter
         // No matter what is done below, start by updating the view the state machine maintains
         // for this source.
         if self.is_best {

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -1194,11 +1194,15 @@ impl<'a, TBl, TRq, TSrc> AnnouncedBlockKnown<'a, TBl, TRq, TSrc> {
                 block_user_data.header = Some(self.announced_header_encoded);
             }
 
-            // Block is not part of the finalized chain.
+            // Mark block as bad if it is not part of the finalized chain.
+            // This might not have been known before, as the header might not have been known.
             if self.announced_header_number == self.inner.chain.finalized_block_header().number + 1
                 && self.announced_header_parent_hash != self.inner.chain.finalized_block_hash()
             {
-                // TODO: remove_verify_failed
+                self.inner.inner.blocks.mark_unverified_block_as_bad(
+                    self.announced_header_number,
+                    &self.announced_header_hash,
+                );
             }
         }
 

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -1203,24 +1203,10 @@ impl<'a, TBl, TRq, TSrc> AnnouncedBlockKnown<'a, TBl, TRq, TSrc> {
                 && self.announced_header_parent_hash != self.inner.chain.finalized_block_hash()
             {
                 // TODO: remove_verify_failed
-                return BlockAnnounceOutcome::NotFinalizedChain;
-            }
-
-            if self.announced_header_parent_hash == self.inner.chain.finalized_block_hash()
-                || self
-                    .inner
-                    .chain
-                    .non_finalized_block_by_hash(&self.announced_header_parent_hash)
-                    .is_some()
-            {
-                // TODO: ambiguous naming
-                return BlockAnnounceOutcome::HeaderVerify;
             }
         }
 
         // TODO: if pending_blocks.num_blocks() > some_max { remove uninteresting block }
-
-        BlockAnnounceOutcome::Disjoint
     }
 }
 
@@ -1321,23 +1307,9 @@ impl<'a, TBl, TRq, TSrc> AnnouncedBlockUnknown<'a, TBl, TRq, TSrc> {
             && self.announced_header_parent_hash != self.inner.chain.finalized_block_hash()
         {
             // TODO: remove_verify_failed
-            return BlockAnnounceOutcome::NotFinalizedChain;
-        }
-
-        if self.announced_header_parent_hash == self.inner.chain.finalized_block_hash()
-            || self
-                .inner
-                .chain
-                .non_finalized_block_by_hash(&self.announced_header_parent_hash)
-                .is_some()
-        {
-            // TODO: ambiguous naming
-            return BlockAnnounceOutcome::HeaderVerify;
         }
 
         // TODO: if pending_blocks.num_blocks() > some_max { remove uninteresting block }
-
-        BlockAnnounceOutcome::Disjoint
     }
 }
 

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -1261,11 +1261,13 @@ impl<'a, TBl, TRq, TSrc> AnnouncedBlockUnknown<'a, TBl, TRq, TSrc> {
             },
         );
 
+        // Make sure that block isn't banned and that it is part of the finalized chain.
         if self
             .inner
             .inner
             .banned_blocks
-            .contains(&self.announced_header_hash)
+            .contains(&self.announced_header_hash) || self.announced_header_number == self.inner.chain.finalized_block_header().number + 1
+            && self.announced_header_parent_hash != self.inner.chain.finalized_block_hash()
         {
             self.inner.inner.blocks.mark_unverified_block_as_bad(
                 self.announced_header_number,
@@ -1301,14 +1303,7 @@ impl<'a, TBl, TRq, TSrc> AnnouncedBlockUnknown<'a, TBl, TRq, TSrc> {
 
         // TODO: what if the pending block already contains a justification and it is not the
         //       same as here? since justifications aren't immediately verified, it is possible
-        //       for a malicious peer to send us bad justifications
-
-        // Block is not part of the finalized chain.
-        if self.announced_header_number == self.inner.chain.finalized_block_header().number + 1
-            && self.announced_header_parent_hash != self.inner.chain.finalized_block_hash()
-        {
-            // TODO: remove_verify_failed
-        }
+        //       for a malicious peer to send us bad justificationsu
 
         // TODO: if pending_blocks.num_blocks() > some_max { remove uninteresting block }
     }

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -607,7 +607,6 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
             *announced_header.parent_hash,
         );
 
-
         // If the block is already part of the local tree of blocks, nothing more to do.
         if self
             .chain
@@ -627,14 +626,8 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
             self.inner.blocks.insert_unverified_block(
                 announced_header.number,
                 announced_header_hash,
-                if false {
-                    pending_blocks::UnverifiedBlockState::HeaderBodyKnown {
-                        parent_hash: *announced_header.parent_hash,
-                    }
-                } else {
-                    pending_blocks::UnverifiedBlockState::HeaderKnown {
-                        parent_hash: *announced_header.parent_hash,
-                    }
+                pending_blocks::UnverifiedBlockState::HeaderKnown {
+                    parent_hash: *announced_header.parent_hash,
                 },
                 PendingBlock {
                     header: Some(announced_header.clone().into()),
@@ -663,19 +656,11 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
                 self.inner.blocks.remove_unverified_block(height, &hash);
             }
         } else {
-            if false {
-                self.inner.blocks.set_unverified_block_header_body_known(
-                    announced_header.number,
-                    &announced_header_hash,
-                    *announced_header.parent_hash,
-                );
-            } else {
-                self.inner.blocks.set_unverified_block_header_known(
-                    announced_header.number,
-                    &announced_header_hash,
-                    *announced_header.parent_hash,
-                );
-            }
+            self.inner.blocks.set_unverified_block_header_known(
+                announced_header.number,
+                &announced_header_hash,
+                *announced_header.parent_hash,
+            );
 
             let block_user_data = self
                 .inner

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -1194,10 +1194,6 @@ impl<'a, TBl, TRq, TSrc> AnnouncedBlockKnown<'a, TBl, TRq, TSrc> {
                 block_user_data.header = Some(self.announced_header_encoded);
             }
 
-            // TODO: what if the pending block already contains a justification and it is not the
-            //       same as here? since justifications aren't immediately verified, it is possible
-            //       for a malicious peer to send us bad justifications
-
             // Block is not part of the finalized chain.
             if self.announced_header_number == self.inner.chain.finalized_block_header().number + 1
                 && self.announced_header_parent_hash != self.inner.chain.finalized_block_hash()
@@ -1300,10 +1296,6 @@ impl<'a, TBl, TRq, TSrc> AnnouncedBlockUnknown<'a, TBl, TRq, TSrc> {
                 .blocks
                 .remove_unverified_block(height, &hash);
         }
-
-        // TODO: what if the pending block already contains a justification and it is not the
-        //       same as here? since justifications aren't immediately verified, it is possible
-        //       for a malicious peer to send us bad justificationsu
 
         // TODO: if pending_blocks.num_blocks() > some_max { remove uninteresting block }
     }


### PR DESCRIPTION
This is the continuation of https://github.com/paritytech/smoldot/pull/2129 and https://github.com/paritytech/smoldot/issues/1572

The `block_announce` method now returns an enum, and in the enum you will find other objects that let you insert or update the block.
The changes are very similar to the ones in https://github.com/paritytech/smoldot/pull/2129

Can be reviewed commit by commit.

