### PR TITLE
Refactor AllForksSync::add_source

### DIFF
--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -372,7 +372,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                 let outer_source_id_entry = self.shared.sources.vacant_entry();
                 let outer_source_id = SourceId(outer_source_id_entry.key());
 
-                let source_id = all_forks.add_source(
+                let source_id = all_forks.prepare_add_source(
                     AllForksSourceExtra {
                         user_data,
                         outer_source_id,
@@ -2275,7 +2275,7 @@ impl<TRq> Shared<TRq> {
             .all(|(_, s)| matches!(s, SourceMapping::GrandpaWarpSync(_))));
 
         for source in grandpa.sources {
-            let updated_source_id = all_forks.add_source(
+            let updated_source_id = all_forks.prepare_add_source(
                 AllForksSourceExtra {
                     user_data: source.user_data,
                     outer_source_id: source.outer_source_id,

--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -372,19 +372,25 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                 let outer_source_id_entry = self.shared.sources.vacant_entry();
                 let outer_source_id = SourceId(outer_source_id_entry.key());
 
-                let source_id = match all_forks.prepare_add_source(
-                    AllForksSourceExtra {
-                        user_data,
-                        outer_source_id,
-                    },
-                    best_block_number,
-                    best_block_hash,
-                ) {
-                    all_forks::AddSource::BestBlockAlreadyVerified(b) => b.add_source(),
-                    all_forks::AddSource::BestBlockPendingVerification(b) => b.add_source(),
-                    all_forks::AddSource::OldBestBlock(b) => b.add_source(),
-                    all_forks::AddSource::UnknownBestBlock(b) => b.add_source_and_insert_block(),
+                let source_user_data = AllForksSourceExtra {
+                    user_data,
+                    outer_source_id,
                 };
+
+                let source_id =
+                    match all_forks.prepare_add_source(best_block_number, best_block_hash) {
+                        all_forks::AddSource::BestBlockAlreadyVerified(b) => {
+                            b.add_source(source_user_data)
+                        }
+                        all_forks::AddSource::BestBlockPendingVerification(b) => {
+                            b.add_source(source_user_data)
+                        }
+                        all_forks::AddSource::OldBestBlock(b) => b.add_source(source_user_data),
+                        all_forks::AddSource::UnknownBestBlock(b) => {
+                            b.add_source_and_insert_block(source_user_data)
+                        }
+                    };
+
                 outer_source_id_entry.insert(SourceMapping::AllForks(source_id));
 
                 self.inner = AllSyncInner::AllForks(all_forks);
@@ -2280,18 +2286,22 @@ impl<TRq> Shared<TRq> {
             .all(|(_, s)| matches!(s, SourceMapping::GrandpaWarpSync(_))));
 
         for source in grandpa.sources {
-            let updated_source_id = match all_forks.prepare_add_source(
-                AllForksSourceExtra {
-                    user_data: source.user_data,
-                    outer_source_id: source.outer_source_id,
-                },
-                source.best_block_number,
-                source.best_block_hash,
-            ) {
-                all_forks::AddSource::BestBlockAlreadyVerified(b) => b.add_source(),
-                all_forks::AddSource::BestBlockPendingVerification(b) => b.add_source(),
-                all_forks::AddSource::OldBestBlock(b) => b.add_source(),
-                all_forks::AddSource::UnknownBestBlock(b) => b.add_source_and_insert_block(),
+            let source_user_data = AllForksSourceExtra {
+                user_data: source.user_data,
+                outer_source_id: source.outer_source_id,
+            };
+
+            let updated_source_id = match all_forks
+                .prepare_add_source(source.best_block_number, source.best_block_hash)
+            {
+                all_forks::AddSource::BestBlockAlreadyVerified(b) => b.add_source(source_user_data),
+                all_forks::AddSource::BestBlockPendingVerification(b) => {
+                    b.add_source(source_user_data)
+                }
+                all_forks::AddSource::OldBestBlock(b) => b.add_source(source_user_data),
+                all_forks::AddSource::UnknownBestBlock(b) => {
+                    b.add_source_and_insert_block(source_user_data)
+                }
             };
 
             self.sources[source.outer_source_id.0] = SourceMapping::AllForks(updated_source_id);

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -288,7 +288,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     ///
     /// Returns the newly-created source entry, plus optionally a request that should be started
     /// towards this source.
-    pub fn add_source(
+    pub fn prepare_add_source(
         &mut self,
         user_data: TSrc,
         best_block_number: u64,

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -328,10 +328,6 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
                 best_block_number,
             }),
             (true, false, false) => {
-                let source_id =
-                    self.inner
-                        .blocks
-                        .add_source(user_data, best_block_number, best_block_hash);
                 AddSource::OldBestBlock(AddSourceOldBlock {
                     inner: self,
                     new_source_user_data: user_data,

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -1359,6 +1359,34 @@ pub enum AncestrySearchResponseError {
     TooOld,
 }
 
+pub enum AddSource<'a, TBl, TRq, TSrc> {
+    /// Source has been added.
+    OldBestBlock {
+        source_id: SourceId,
+    },
+    BestBlockAlreadyVerified(AddSourceKnown<'a, TBl, TRq, TSrc>),
+    BestBlockPendingVerification(AddSourceKnown<'a, TBl, TRq, TSrc>),
+    UnknownBestBlock(AddSourceUnknown<'a, TBl, TRq, TSrc>),
+}
+
+/// See [`AddSource`] and [`AllForksSync::add_source`].
+#[must_use]
+pub struct AddSourceKnown<'a, TBl, TRq, TSrc> {
+    inner: &'a mut AllForksSync<TBl, TRq, TSrc>,
+}
+
+impl<'a, TBl, TRq, TSrc> AddSourceKnown<'a, TBl, TRq, TSrc> {
+}
+
+/// See [`AddSource`] and [`AllForksSync::add_source`].
+#[must_use]
+pub struct AddSourceUnknown<'a, TBl, TRq, TSrc> {
+    inner: &'a mut AllForksSync<TBl, TRq, TSrc>,
+}
+
+impl<'a, TBl, TRq, TSrc> AddSourceUnknown<'a, TBl, TRq, TSrc> {
+}
+
 /// Header verification to be performed.
 ///
 /// Internally holds the [`AllForksSync`].

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -299,18 +299,17 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
             .blocks
             .add_source(user_data, best_block_number, best_block_hash);
 
-        let needs_verification = best_block_number > self.chain.finalized_block_header().number
-            && self
-                .chain
-                .non_finalized_block_by_hash(&best_block_hash)
-                .is_none();
-        let is_in_disjoints_list = self
+        let best_block_too_old = best_block_number <= self.chain.finalized_block_header().number;
+        let best_block_already_verified = self
+            .chain
+            .non_finalized_block_by_hash(&best_block_hash)
+            .is_some();
+        let best_block_in_disjoints_list = self
             .inner
             .blocks
             .contains_unverified_block(best_block_number, &best_block_hash);
-        debug_assert!(!(!needs_verification && is_in_disjoints_list));
 
-        if needs_verification && !is_in_disjoints_list {
+        if !best_block_too_old && !best_block_already_verified && !best_block_in_disjoints_list {
             self.inner.blocks.insert_unverified_block(
                 best_block_number,
                 best_block_hash,

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -187,7 +187,7 @@ struct PendingBlock {
     header: Option<header::Header>,
     // TODO: add body: Option<Vec<Vec<u8>>>, when adding full node support
     justifications: Vec<([u8; 4], Vec<u8>)>,
-    // TODO: add user_data as soon as block announces and add_source APIs support passing a user data
+    // TODO: add user_data as soon as block announces and prepare_add_source APIs support passing a user data
 }
 
 struct Block<TBl> {
@@ -281,13 +281,11 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
         self.chain.iter_ancestry_order()
     }
 
-    /// Inform the [`AllForksSync`] of a new potential source of blocks.
+    /// Starts the process of inserting a new source in the [`AllForksSync`].
     ///
-    /// The `user_data` parameter is opaque and decided entirely by the user. It can later be
-    /// retrieved using the `Index` trait implementation of this container.
-    ///
-    /// Returns the newly-created source entry, plus optionally a request that should be started
-    /// towards this source.
+    /// This function doesn't modify the state machine, but only looks at the current state of the
+    /// block referenced by `best_block_number` and `best_block_hash`. It returns an enum that
+    /// allows performing the actual insertion.
     pub fn prepare_add_source(
         &mut self,
         best_block_number: u64,
@@ -334,8 +332,8 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     ///
     /// Removing the source implicitly cancels the request that is associated to it (if any).
     ///
-    /// Returns the user data that was originally passed to [`AllForksSync::add_source`], plus
-    /// an `Option`.
+    /// Returns the user data that was originally passed when inserting the source, plus an
+    /// `Option`.
     /// If this `Option` is `Some`, it contains a request that must be started towards the source
     /// indicated by the [`SourceId`].
     ///
@@ -403,7 +401,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     /// Returns the current best block of the given source.
     ///
     /// This corresponds either the latest call to [`AllForksSync::block_announce`] where
-    /// `is_best` was `true`, or to the parameter passed to [`AllForksSync::add_source`].
+    /// `is_best` was `true`, or to the parameter passed to [`AllForksSync::prepare_add_source`].
     ///
     /// # Panic
     ///
@@ -1359,14 +1357,25 @@ pub enum AncestrySearchResponseError {
     TooOld,
 }
 
+/// Outcome of calling [`AllForksSync::prepare_add_source`].
+#[must_use]
 pub enum AddSource<'a, TBl, TRq, TSrc> {
+    /// The best block of the source is older or equal to the local latest finalized block. This
+    /// block isn't tracked by the state machine.
     OldBestBlock(AddSourceOldBlock<'a, TBl, TRq, TSrc>),
+
+    /// The best block of the source has already been verified by this state machine.
     BestBlockAlreadyVerified(AddSourceKnown<'a, TBl, TRq, TSrc>),
+
+    /// The best block of the source is already known to this state machine but hasn't been
+    /// verified yet.
     BestBlockPendingVerification(AddSourceKnown<'a, TBl, TRq, TSrc>),
+
+    /// The best block of the source isn't in this state machine yet and needs to be inserted.
     UnknownBestBlock(AddSourceUnknown<'a, TBl, TRq, TSrc>),
 }
 
-/// See [`AddSource`] and [`AllForksSync::add_source`].
+/// See [`AddSource`] and [`AllForksSync::prepare_add_source`].
 #[must_use]
 pub struct AddSourceOldBlock<'a, TBl, TRq, TSrc> {
     inner: &'a mut AllForksSync<TBl, TRq, TSrc>,
@@ -1375,6 +1384,12 @@ pub struct AddSourceOldBlock<'a, TBl, TRq, TSrc> {
 }
 
 impl<'a, TBl, TRq, TSrc> AddSourceOldBlock<'a, TBl, TRq, TSrc> {
+    /// Inserts a new source in the state machine.
+    ///
+    /// Returns the newly-allocated identifier for that source.
+    ///
+    /// The `user_data` parameter is opaque and decided entirely by the user. It can later be
+    /// retrieved using the `Index` trait implementation of the [`AllForksSync`].
     pub fn add_source(self, source_user_data: TSrc) -> SourceId {
         self.inner.inner.blocks.add_source(
             source_user_data,
@@ -1384,7 +1399,7 @@ impl<'a, TBl, TRq, TSrc> AddSourceOldBlock<'a, TBl, TRq, TSrc> {
     }
 }
 
-/// See [`AddSource`] and [`AllForksSync::add_source`].
+/// See [`AddSource`] and [`AllForksSync::prepare_add_source`].
 #[must_use]
 pub struct AddSourceKnown<'a, TBl, TRq, TSrc> {
     inner: &'a mut AllForksSync<TBl, TRq, TSrc>,
@@ -1393,6 +1408,12 @@ pub struct AddSourceKnown<'a, TBl, TRq, TSrc> {
 }
 
 impl<'a, TBl, TRq, TSrc> AddSourceKnown<'a, TBl, TRq, TSrc> {
+    /// Inserts a new source in the state machine.
+    ///
+    /// Returns the newly-allocated identifier for that source.
+    ///
+    /// The `user_data` parameter is opaque and decided entirely by the user. It can later be
+    /// retrieved using the `Index` trait implementation of the [`AllForksSync`].
     pub fn add_source(self, source_user_data: TSrc) -> SourceId {
         self.inner.inner.blocks.add_source(
             source_user_data,
@@ -1402,7 +1423,7 @@ impl<'a, TBl, TRq, TSrc> AddSourceKnown<'a, TBl, TRq, TSrc> {
     }
 }
 
-/// See [`AddSource`] and [`AllForksSync::add_source`].
+/// See [`AddSource`] and [`AllForksSync::prepare_add_source`].
 #[must_use]
 pub struct AddSourceUnknown<'a, TBl, TRq, TSrc> {
     inner: &'a mut AllForksSync<TBl, TRq, TSrc>,
@@ -1411,6 +1432,12 @@ pub struct AddSourceUnknown<'a, TBl, TRq, TSrc> {
 }
 
 impl<'a, TBl, TRq, TSrc> AddSourceUnknown<'a, TBl, TRq, TSrc> {
+    /// Inserts a new source in the state machine, plus the best block of that source.
+    ///
+    /// Returns the newly-allocated identifier for that source.
+    ///
+    /// The `user_data` parameter is opaque and decided entirely by the user. It can later be
+    /// retrieved using the `Index` trait implementation of the [`AllForksSync`].
     pub fn add_source_and_insert_block(self, source_user_data: TSrc) -> SourceId {
         let source_id = self.inner.inner.blocks.add_source(
             source_user_data,

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -290,14 +290,12 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     /// towards this source.
     pub fn prepare_add_source(
         &mut self,
-        user_data: TSrc,
         best_block_number: u64,
         best_block_hash: [u8; 32],
     ) -> AddSource<TBl, TRq, TSrc> {
         if best_block_number <= self.chain.finalized_block_header().number {
             return AddSource::OldBestBlock(AddSourceOldBlock {
                 inner: self,
-                new_source_user_data: user_data,
                 best_block_hash,
                 best_block_number,
             });
@@ -315,19 +313,16 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
         match (best_block_already_verified, best_block_in_disjoints_list) {
             (false, false) => AddSource::UnknownBestBlock(AddSourceUnknown {
                 inner: self,
-                new_source_user_data: user_data,
                 best_block_hash,
                 best_block_number,
             }),
             (true, false) => AddSource::BestBlockAlreadyVerified(AddSourceKnown {
                 inner: self,
-                new_source_user_data: user_data,
                 best_block_hash,
                 best_block_number,
             }),
             (false, true) => AddSource::BestBlockPendingVerification(AddSourceKnown {
                 inner: self,
-                new_source_user_data: user_data,
                 best_block_hash,
                 best_block_number,
             }),
@@ -1375,15 +1370,14 @@ pub enum AddSource<'a, TBl, TRq, TSrc> {
 #[must_use]
 pub struct AddSourceOldBlock<'a, TBl, TRq, TSrc> {
     inner: &'a mut AllForksSync<TBl, TRq, TSrc>,
-    new_source_user_data: TSrc,
     best_block_number: u64,
     best_block_hash: [u8; 32],
 }
 
 impl<'a, TBl, TRq, TSrc> AddSourceOldBlock<'a, TBl, TRq, TSrc> {
-    pub fn add_source(self) -> SourceId {
+    pub fn add_source(self, source_user_data: TSrc) -> SourceId {
         self.inner.inner.blocks.add_source(
-            self.new_source_user_data,
+            source_user_data,
             self.best_block_number,
             self.best_block_hash,
         )
@@ -1394,15 +1388,14 @@ impl<'a, TBl, TRq, TSrc> AddSourceOldBlock<'a, TBl, TRq, TSrc> {
 #[must_use]
 pub struct AddSourceKnown<'a, TBl, TRq, TSrc> {
     inner: &'a mut AllForksSync<TBl, TRq, TSrc>,
-    new_source_user_data: TSrc,
     best_block_number: u64,
     best_block_hash: [u8; 32],
 }
 
 impl<'a, TBl, TRq, TSrc> AddSourceKnown<'a, TBl, TRq, TSrc> {
-    pub fn add_source(self) -> SourceId {
+    pub fn add_source(self, source_user_data: TSrc) -> SourceId {
         self.inner.inner.blocks.add_source(
-            self.new_source_user_data,
+            source_user_data,
             self.best_block_number,
             self.best_block_hash,
         )
@@ -1413,15 +1406,14 @@ impl<'a, TBl, TRq, TSrc> AddSourceKnown<'a, TBl, TRq, TSrc> {
 #[must_use]
 pub struct AddSourceUnknown<'a, TBl, TRq, TSrc> {
     inner: &'a mut AllForksSync<TBl, TRq, TSrc>,
-    new_source_user_data: TSrc,
     best_block_number: u64,
     best_block_hash: [u8; 32],
 }
 
 impl<'a, TBl, TRq, TSrc> AddSourceUnknown<'a, TBl, TRq, TSrc> {
-    pub fn add_source_and_insert_block(self) -> SourceId {
+    pub fn add_source_and_insert_block(self, source_user_data: TSrc) -> SourceId {
         let source_id = self.inner.inner.blocks.add_source(
-            self.new_source_user_data,
+            source_user_data,
             self.best_block_number,
             self.best_block_hash,
         );


### PR DESCRIPTION
Continuation of https://github.com/paritytech/smoldot/pull/2140

The changes are the same: the function only looks at the state of the block, then returns an enum that allows inserting the block.

Can be reviewed commit by commit.