### PR TITLE
Implement block announces in full node

### DIFF
--- a/bin/full-node/src/run/consensus_service.rs
+++ b/bin/full-node/src/run/consensus_service.rs
@@ -987,6 +987,18 @@ impl SyncBackground {
                                 }
 
                                 self.sync = sync_out;
+
+                                // Announce the block to all the sources that aren't aware of it.
+                                // TODO: sources that do *not* know the block
+                                let sources_to_announce_to = self
+                                    .sync
+                                    .knows_non_finalized_block(height_to_verify, &hash_to_verify)
+                                    .collect::<Vec<_>>();
+                                for source_id in sources_to_announce_to {
+                                    // TODO: self.network_service.send_block_announce();
+                                    // TODO: add_source_known_block
+                                }
+
                                 break;
                             }
 

--- a/bin/full-node/src/run/consensus_service.rs
+++ b/bin/full-node/src/run/consensus_service.rs
@@ -1033,7 +1033,15 @@ impl SyncBackground {
                                         .await
                                         .is_ok()
                                     {
-                                        // TODO: add_source_known_block
+                                        // Note that `try_add_known_block_to_source` might have
+                                        // no effect, which is not a problem considering that this
+                                        // block tracking is mostly about optimizations and
+                                        // politeness.
+                                        self.sync.try_add_known_block_to_source(
+                                            source_id,
+                                            height_to_verify,
+                                            hash_to_verify,
+                                        );
                                     }
                                 }
 

--- a/bin/full-node/src/run/network_service.rs
+++ b/bin/full-node/src/run/network_service.rs
@@ -40,6 +40,7 @@ use smoldot::{
         async_std_connection, connection,
         multiaddr::{Multiaddr, ProtocolRef},
         peer_id::{self, PeerId},
+        peers,
     },
     network::{protocol, service},
 };
@@ -702,6 +703,19 @@ impl NetworkService {
         self.inner
             .network
             .set_local_best_block(chain_index, best_hash, best_number)
+            .await
+    }
+
+    pub async fn send_block_announce(
+        self: Arc<Self>,
+        target: &PeerId,
+        chain_index: usize,
+        scale_encoded_header: &[u8],
+        is_best: bool,
+    ) -> Result<(), peers::QueueNotificationError> {
+        self.inner
+            .network
+            .send_block_announce(&target, chain_index, scale_encoded_header, is_best)
             .await
     }
 

--- a/src/network/protocol/block_announces.rs
+++ b/src/network/protocol/block_announces.rs
@@ -60,6 +60,7 @@ impl Role {
 }
 
 /// Decoded block announcement notification.
+// TODO: this has both the scale_encoded and decoded header, which makes it weird if you want to build the struct manually
 #[derive(Debug)]
 pub struct BlockAnnounceRef<'a> {
     /// SCALE-encoded header in the announce. Same as [`BlockAnnounceRef::header`].
@@ -84,6 +85,7 @@ pub fn encode_block_announce(
         .scale_encoding()
         .map(either::Left)
         .chain(iter::once(either::Right(is_best)))
+        .chain(iter::once(either::Right([0u8])))
 }
 
 /// Decodes a block announcement.

--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -1976,6 +1976,13 @@ impl<TRq, TSrc, TBl> HeaderBodyVerify<TRq, TSrc, TBl> {
         }
     }
 
+    /// Returns the SCALE-encoded header of the block about to be verified.
+    pub fn scale_encoded_header(&self) -> &[u8] {
+        match &self.inner {
+            HeaderBodyVerifyInner::Optimistic(verify) => verify.scale_encoded_header(),
+        }
+    }
+
     /// Start the verification process.
     pub fn start(
         self,

--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -715,6 +715,40 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         }
     }
 
+    /// Try register a new block that the source is aware of.
+    ///
+    /// Some syncing strategies do not track blocks known to sources, in which case this function
+    /// has no effect
+    ///
+    /// Has no effect if `height` is inferior or equal to the finalized block height, or if the
+    /// source was already known to know this block.
+    ///
+    /// The block does not need to be known by the data structure.
+    ///
+    /// This is automatically done for the blocks added through block announces or block requests..
+    ///
+    /// # Panic
+    ///
+    /// Panics if the [`SourceId`] is out of range.
+    ///
+    pub fn try_add_known_block_to_source(
+        &mut self,
+        source_id: SourceId,
+        height: u64,
+        hash: [u8; 32],
+    ) {
+        debug_assert!(self.shared.sources.contains(source_id.0));
+        match (
+            &mut self.inner,
+            self.shared.sources.get(source_id.0).unwrap(),
+        ) {
+            (AllSyncInner::AllForks(sync), SourceMapping::AllForks(src)) => {
+                sync.add_known_block_to_source(*src, height, hash)
+            }
+            _ => {}
+        }
+    }
+
     /// Returns the details of a request to start towards a source.
     ///
     /// This method doesn't modify the state machine in any way. [`AllSync::add_request`] must be

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -401,6 +401,26 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
         self.inner.blocks.knows_non_finalized_block(height, hash)
     }
 
+    /// Registers a new block that the source is aware of.
+    ///
+    /// Has no effect if `height` is inferior or equal to the finalized block height, or if the
+    /// source was already known to know this block.
+    ///
+    /// The block does not need to be known by the data structure.
+    ///
+    /// This is automatically done for the blocks added through [`AllForksSync::block_announce`],
+    /// [`AllForksSync::add_source`] or [`FinishAncestrySearch::add_block`].
+    ///
+    /// # Panic
+    ///
+    /// Panics if the [`SourceId`] is out of range.
+    ///
+    pub fn add_known_block_to_source(&mut self, source_id: SourceId, height: u64, hash: [u8; 32]) {
+        self.inner
+            .blocks
+            .add_known_block_to_source(source_id, height, hash);
+    }
+
     /// Returns the current best block of the given source.
     ///
     /// This corresponds either the latest call to [`AllForksSync::block_announce`] where

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -406,7 +406,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     /// The block does not need to be known by the data structure.
     ///
     /// This is automatically done for the blocks added through [`AllForksSync::block_announce`],
-    /// [`AllForksSync::add_source`] or [`FinishAncestrySearch::add_block`].
+    /// [`AllForksSync::prepare_add_source`] or [`FinishAncestrySearch::add_block`].
     ///
     /// # Panic
     ///

--- a/src/sync/optimistic.rs
+++ b/src/sync/optimistic.rs
@@ -723,12 +723,12 @@ impl<TRq, TSrc, TBl> BlockVerify<TRq, TSrc, TBl> {
     /// Returns the height of the block about to be verified.
     pub fn height(&self) -> u64 {
         // TODO: unwrap?
-        header::decode(self.header()).unwrap().number
+        header::decode(self.scale_encoded_header()).unwrap().number
     }
 
     /// Returns the hash of the block about to be verified.
     pub fn hash(&self) -> [u8; 32] {
-        header::hash_from_scale_encoded_header(self.header())
+        header::hash_from_scale_encoded_header(self.scale_encoded_header())
     }
 
     /// Returns true if [`Config::full`] was `Some` at initialization.
@@ -737,7 +737,7 @@ impl<TRq, TSrc, TBl> BlockVerify<TRq, TSrc, TBl> {
     }
 
     /// Returns the SCALE-encoded header of the block about to be verified.
-    fn header(&self) -> &[u8] {
+    pub fn scale_encoded_header(&self) -> &[u8] {
         &self
             .inner
             .verification_queue


### PR DESCRIPTION
This PR implements announcing blocks to other peers when in full mode.
In other words, if node A is connected to B, and B is connected C, when A announces a block to B, B will now announce it to C.

After this PR, it is now possible to launch two smoldot full nodes and have them produce a chain.
The CLI flags I use for that are:
> ./full-node run --chain ./bin/substrate-node-template.json --tmp --listen-addr /ip4/127.0.0.1/tcp/30333 --libp2p-key 0x0000000000000000000000000000000000000000000000000000000000000000 --keystore-memory //Alice --jaeger 127.0.0.1:6831

And:

> ./full-node run --chain ./bin/substrate-node-template.json --tmp --additional-bootnode /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN --jaeger 127.0.0.1:6831 --json-rpc-address 127.0.0.1:0

The way it's done is rather simple: as soon as we import a block, we determine which sources to announce the block to by doing `all_sources - sources_that_we_know_know_the_block`. Once announced, we track the fact that this source knows this block.
