### PR TITLE
Add support for the "fron" log item

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add support for parsing the "fron" (Frontier) consensus log items in headers. The content of these log items is ignored by the client.
+
 ## 0.6.5 - 2022-17-03
 
 ### Changed


### PR DESCRIPTION
Close https://github.com/paritytech/smoldot/issues/2139

I wanted to add a unit test, but we have no good way to obtain a SCALE-encoded header from a Substrate node.
Since the code is just copy-pasted from the one of the Beefy and Polkadot log items, it should work.