### PR TITLE
Add ClientOptions.cpuRateLimit

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add `ClientOptions.cpuRateLimit`, which lets the user put an upper bound on the amount of CPU that the client uses on average.
+- Add `ClientOptions.cpuRateLimit`, which lets the user put an upper bound on the amount of CPU that the client uses on average ([#2151](https://github.com/paritytech/smoldot/pull/2151)).
 
 ## 0.6.5 - 2022-17-03
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add `ClientOptions.cpuRateLimit`, which lets the user put an upper bound on the amount of CPU that the client uses on average.
+
 ## 0.6.5 - 2022-17-03
 
 ### Changed

--- a/bin/wasm-node/javascript/src/client.ts
+++ b/bin/wasm-node/javascript/src/client.ts
@@ -202,6 +202,19 @@ export interface ClientOptions {
   maxLogLevel?: number;
 
   /**
+   * Maximum amount of CPU that the client should consume on average.
+   *
+   * This must be a number between `0.0` and `1.0`. For example, passing `0.25` bounds the client
+   * to 25% of CPU power.
+   * Defaults to `1.0` if no value is provided.
+   *
+   * Note that this is implemented by sleeping for certain amounts of time in order for the average
+   * CPU consumption to not go beyond the given limit. It is therefore still possible for the
+   * client to use high amounts of CPU for short amounts of time.
+   */
+  cpuRateLimit?: number;
+
+  /**
    * If `true`, then the client will never open any TCP connection.
    * Defaults to `false`.
    *
@@ -552,6 +565,7 @@ export function start(options?: ClientOptions): Client {
     // 0 = Logging disabled, 1 = Error, 2 = Warn, 3 = Info, 4 = Debug, 5 = Trace
     maxLogLevel: options.maxLogLevel || 3,
     enableCurrentTask: true, // TODO: make this configurable? `true` slows things down but makes it easily debuggable
+    cpuRateLimit: options.cpuRateLimit || 1.0,
     forbidTcp: options.forbidTcp || false,
     forbidWs: options.forbidWs || false,
     forbidNonLocalWs: options.forbidNonLocalWs || false,

--- a/bin/wasm-node/javascript/src/worker/bindings.ts
+++ b/bin/wasm-node/javascript/src/worker/bindings.ts
@@ -23,7 +23,7 @@
  */
 export interface SmoldotWasmExports extends WebAssembly.Exports {
     memory: WebAssembly.Memory,
-    init: (maxLogLevel: number, enableCurrentTask: number) => void,
+    init: (maxLogLevel: number, enableCurrentTask: number, cpuRateLimit: number) => void,
     alloc: (len: number) => number,
     add_chain: (chainSpecPointer: number, chainSpecLen: number, databaseContentPointer: number, databaseContentLen: number, jsonRpcRunning: number, potentialRelayChainsPtr: number, potentialRelayChainsLen: number) => number;
     remove_chain: (chainId: number) => void,

--- a/bin/wasm-node/javascript/src/worker/instance.ts
+++ b/bin/wasm-node/javascript/src/worker/instance.ts
@@ -31,6 +31,7 @@ export interface Config {
     jsonRpcCallback: (response: string, chainId: number) => void,
     databaseContentCallback: (data: string, chainId: number) => void,
     currentTaskCallback?: (taskName: string | null) => void,
+    cpuRateLimit: number,
     forbidTcp: boolean,
     forbidWs: boolean,
     forbidNonLocalWs: boolean,

--- a/bin/wasm-node/javascript/src/worker/messages.ts
+++ b/bin/wasm-node/javascript/src/worker/messages.ts
@@ -38,6 +38,7 @@ export type FromWorker = FromWorkerChainAddedOk | FromWorkerChainAddedError | Fr
 export interface ToWorkerConfig {
   maxLogLevel: number;
   enableCurrentTask: boolean;
+  cpuRateLimit: number,
   forbidTcp: boolean;
   forbidWs: boolean;
   forbidNonLocalWs: boolean;

--- a/bin/wasm-node/rust/src/bindings.rs
+++ b/bin/wasm-node/rust/src/bindings.rs
@@ -244,9 +244,13 @@ extern "C" {
 /// If `enbable_current_task` is non-zero, smoldot will call the [`current_task_entered`] and
 /// [`current_task_exit`] functions to report when it enters and leaves tasks. This slightly
 /// slows everything down, but is useful for debugging purposes.
+///
+/// `cpu_rate_limit` can be used to limit the amount of CPU that smoldot will use on average.
+/// `u32::max_value()` represents "one CPU". For example passing `rate_limit / 2` represents
+/// "50% of one CPU".
 #[no_mangle]
-pub extern "C" fn init(max_log_level: u32, enable_current_task: u32) {
-    crate::init(max_log_level, enable_current_task)
+pub extern "C" fn init(max_log_level: u32, enable_current_task: u32, cpu_rate_limit: u32) {
+    crate::init(max_log_level, enable_current_task, cpu_rate_limit)
 }
 
 /// Allocates a buffer of the given length, with an alignment of 1.

--- a/bin/wasm-node/rust/src/cpu_rate_limiter.rs
+++ b/bin/wasm-node/rust/src/cpu_rate_limiter.rs
@@ -1,0 +1,103 @@
+// Smoldot
+// Copyright (C) 2019-2022  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use core::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+/// Wraps around a `Future` and enforces an upper bound to the CPU consumed by the polling of
+/// this `Future`.
+///
+/// This works by enforcing a delay after a polling operation has happened, so that the average
+/// polling time respects the upper bound. This struct doesn't protect against infinite loops or
+/// a single polling taking a long time.
+#[pin_project::pin_project]
+pub struct CpuRateLimiter<T> {
+    #[pin]
+    inner: T,
+    max_divided_by_rate_limit: u32,
+
+    /// Prevent `self.inner.poll` from being called before this `Delay` is ready.
+    #[pin]
+    prevent_poll_until: crate::timers::Delay,
+}
+
+impl<T> CpuRateLimiter<T> {
+    /// Wraps around `inner`. The `rate_limit` represents the upper bound, where
+    /// `u32::max_value()` represents "one CPU". For example passing `rate_limit / 2` represents
+    /// "50% of one CPU".
+    pub fn new(inner: T, rate_limit: u32) -> Self {
+        CpuRateLimiter {
+            inner,
+            max_divided_by_rate_limit: u32::max_value()
+                .checked_sub(rate_limit)
+                .unwrap_or(u32::max_value()),
+            prevent_poll_until: crate::timers::Delay::new(Duration::new(0, 0)),
+        }
+    }
+}
+
+impl<T: Future> Future for CpuRateLimiter<T> {
+    type Output = T::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        // Note that `crate::times::Delay` is a `FusedFuture`, making it ok to call `poll` even
+        // if it is possible for the `Delay` to already be resolved.
+        // We add a small zero-cost shim to ensure at compile time that this is indeed the case.
+        fn enforce_fused<T: futures::future::FusedFuture>(_: &T) {}
+        enforce_fused(&this.prevent_poll_until);
+        match Future::poll(this.prevent_poll_until.as_mut(), cx) {
+            Poll::Ready(()) => {}
+            Poll::Pending => return Poll::Pending,
+        }
+
+        let before_polling = crate::Instant::now();
+
+        match this.inner.poll(cx) {
+            Poll::Ready(value) => return Poll::Ready(value),
+            Poll::Pending => {
+                let after_polling = crate::Instant::now();
+
+                // Time it took to execute `poll`.
+                let poll_duration = after_polling - before_polling;
+
+                // In order to enforce the rate limiting, we prevent `poll` from executing
+                // for a certain amount of time.
+                // The base equation here is: `(after_poll_sleep + poll_duration) * rate_limit == poll_duration * u32::max_value()`
+                let after_poll_sleep = (poll_duration
+                    .saturating_mul(*this.max_divided_by_rate_limit))
+                .saturating_sub(poll_duration);
+
+                this.prevent_poll_until.set(crate::timers::Delay::new_at(
+                    after_polling + after_poll_sleep,
+                ));
+                Poll::Pending
+            }
+        }
+    }
+}
+
+impl<T: futures::future::FusedFuture> futures::future::FusedFuture for CpuRateLimiter<T> {
+    fn is_terminated(&self) -> bool {
+        self.inner.is_terminated()
+    }
+}

--- a/bin/wasm-node/rust/src/cpu_rate_limiter.rs
+++ b/bin/wasm-node/rust/src/cpu_rate_limiter.rs
@@ -65,9 +65,8 @@ impl<T: Future> Future for CpuRateLimiter<T> {
         // We add a small zero-cost shim to ensure at compile time that this is indeed the case.
         fn enforce_fused<T: futures::future::FusedFuture>(_: &T) {}
         enforce_fused(&this.prevent_poll_until);
-        match Future::poll(this.prevent_poll_until.as_mut(), cx) {
-            Poll::Ready(()) => {}
-            Poll::Pending => return Poll::Pending,
+        if let Poll::Pending = Future::poll(this.prevent_poll_until.as_mut(), cx) {
+            return Poll::Pending;
         }
 
         let before_polling = crate::Instant::now();

--- a/bin/wasm-node/rust/src/lib.rs
+++ b/bin/wasm-node/rust/src/lib.rs
@@ -32,6 +32,7 @@ use std::sync::Mutex;
 pub mod bindings;
 
 mod alloc;
+mod cpu_rate_limiter;
 mod init;
 mod platform;
 mod timers;
@@ -116,8 +117,8 @@ lazy_static::lazy_static! {
     static ref CLIENT: Mutex<Option<init::Client<Vec<future::AbortHandle>, platform::Platform>>> = Mutex::new(None);
 }
 
-fn init(max_log_level: u32, enable_current_task: u32) {
-    let init_out = init::init(max_log_level, enable_current_task != 0);
+fn init(max_log_level: u32, enable_current_task: u32, cpu_rate_limit: u32) {
+    let init_out = init::init(max_log_level, enable_current_task != 0, cpu_rate_limit);
 
     let mut client_lock = crate::CLIENT.lock().unwrap();
     assert!(client_lock.is_none());


### PR DESCRIPTION
Adding an option to limit the amount of CPU consumed by smoldot.

Warp syncing a long chain such as Kusama can use a lot of CPU for up to 10-15 seconds, and we'd rather not have a web page or the substrate-connect extension use up an entire CPU for this long, as it tends to cause systems to freeze.
After this change is merged and published, I'd cap the CPU to 50% in substrate-connect.
