### PR TITLE
Pass a string in chainAddedErr to remove an as

### DIFF
--- a/bin/wasm-node/javascript/src/client.ts
+++ b/bin/wasm-node/javascript/src/client.ts
@@ -497,7 +497,7 @@ export function start(options?: ClientOptions): Client {
         const expected = pendingConfirmations.shift()!;
         // `expected` was pushed by the `addChain` method.
         // Reject the promise that `addChain` returned to the user.
-        expected.reject(message.error as AddChainError);
+        expected.reject(new AddChainError(message.error));
         break;
       }
 

--- a/bin/wasm-node/javascript/src/worker/messages.ts
+++ b/bin/wasm-node/javascript/src/worker/messages.ts
@@ -95,7 +95,7 @@ export interface FromWorkerChainAddedOk {
 
 export interface FromWorkerChainAddedError {
   kind: 'chainAddedErr',
-  error: Error,
+  error: string,
 }
 
 export interface FromWorkerLog {

--- a/bin/wasm-node/javascript/src/worker/worker.ts
+++ b/bin/wasm-node/javascript/src/worker/worker.ts
@@ -82,7 +82,7 @@ function injectMessage(instance: SmoldotWasmInstance, message: messages.ToWorker
         const errorMsg = Buffer.from(instance.exports.memory.buffer)
           .toString('utf8', errorMsgPtr, errorMsgPtr + errorMsgLen);
         instance.exports.remove_chain(chainId);
-        postMessage({ kind: 'chainAddedErr', error: new Error(errorMsg) });
+        postMessage({ kind: 'chainAddedErr', error: errorMsg });
       }
 
       break;


### PR DESCRIPTION
Very insubstantial change with the objective of removing an `as` in TypeScript