### PR TITLE
Fix hack in the block announces format

### DIFF
--- a/bin/full-node/src/run.rs
+++ b/bin/full-node/src/run.rs
@@ -472,11 +472,10 @@ pub async fn run(cli_options: cli::CliOptionsRun) {
                 // We expect the network events channel to never shut down.
                 let network_event = network_event.unwrap();
 
-                if let network_service::Event::BlockAnnounce { chain_index: 0, announce, .. } = network_event {
-                    let decoded = announce.decode();
+                if let network_service::Event::BlockAnnounce { chain_index: 0, header, .. } = network_event {
                     match network_known_best {
-                        Some(n) if n >= decoded.header.number => {},
-                        _ => network_known_best = Some(decoded.header.number),
+                        Some(n) if n >= header.number => {},
+                        _ => network_known_best = Some(header.number),
                     }
                 }
             }

--- a/bin/full-node/src/run/consensus_service.rs
+++ b/bin/full-node/src/run/consensus_service.rs
@@ -476,18 +476,16 @@ impl SyncBackground {
                                 abort.abort();
                             }
                         },
-                        network_service::Event::BlockAnnounce { chain_index, peer_id, announce }
+                        network_service::Event::BlockAnnounce { chain_index, peer_id, header, is_best }
                             if chain_index == self.network_chain_index =>
                         {
-                            let decoded = announce.decode();
-
                             let _jaeger_span = self
                                 .jaeger_service
-                                .block_announce_process_span(&decoded.header.hash());
+                                .block_announce_process_span(&header.hash());
 
                             let id = *self.peers_source_id_map.get(&peer_id).unwrap();
                             // TODO: log the outcome
-                            match self.sync.block_announce(id, decoded.scale_encoded_header.to_owned(), decoded.is_best) {
+                            match self.sync.block_announce(id, header.scale_encoding_vec(), is_best) {
                                 all::BlockAnnounceOutcome::HeaderVerify => {},
                                 all::BlockAnnounceOutcome::TooOld { .. } => {},
                                 all::BlockAnnounceOutcome::AlreadyInChain => {},

--- a/bin/light-base/src/network_service.rs
+++ b/bin/light-base/src/network_service.rs
@@ -50,7 +50,7 @@ use smoldot::{
         peer_id::PeerId,
         read_write::ReadWrite,
     },
-    network::{protocol, service},
+    network::{protocol, service}, header,
 };
 use std::{collections::HashSet, sync::Arc};
 
@@ -227,7 +227,7 @@ impl<TPlat: Platform> NetworkService<TPlat> {
                                         "Connection({}, {}) => BlockAnnounce(best_hash={}, is_best={})",
                                         peer_id,
                                         &network_service.log_chain_names[chain_index],
-                                        HashDisplay(&announce.decode().header.hash()),
+                                        HashDisplay(&header::hash_from_scale_encoded_header(&announce.decode().scale_encoded_header)),
                                         announce.decode().is_best
                                     );
                                     break Event::BlockAnnounce {

--- a/bin/light-base/src/network_service.rs
+++ b/bin/light-base/src/network_service.rs
@@ -42,6 +42,7 @@ use core::{cmp, num::NonZeroUsize, task::Poll, time::Duration};
 use futures::{channel::mpsc, lock::Mutex, prelude::*};
 use itertools::Itertools as _;
 use smoldot::{
+    header,
     informant::{BytesDisplay, HashDisplay},
     libp2p::{
         collection::{ConnectionError, HandshakeError},
@@ -50,7 +51,7 @@ use smoldot::{
         peer_id::PeerId,
         read_write::ReadWrite,
     },
-    network::{protocol, service}, header,
+    network::{protocol, service},
 };
 use std::{collections::HashSet, sync::Arc};
 

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -483,16 +483,15 @@ pub(super) async fn start_parachain<TPlat: Platform>(
                                 let decoded_header_hash = header::hash_from_scale_encoded_header(
                                     &decoded.scale_encoded_header
                                 );
-                                let decoded_header_number = decoded_header.number;
                                 sync_sources.add_known_block(
                                     local_id,
-                                    decoded_header_number,
+                                    decoded_header.number,
                                     decoded_header_hash
                                 );
                                 if decoded.is_best {
                                     sync_sources.add_known_block_and_set_best(
                                         local_id,
-                                        decoded_header_number,
+                                        decoded_header.number,
                                         decoded_header_hash
                                     );
                                 }

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -479,10 +479,23 @@ pub(super) async fn start_parachain<TPlat: Platform>(
                         {
                             let local_id = *sync_sources_map.get(&peer_id).unwrap();
                             let decoded = announce.decode();
-                            let decoded_header_hash = decoded.header.hash();
-                            sync_sources.add_known_block(local_id, decoded.header.number, decoded_header_hash);
-                            if decoded.is_best {
-                                sync_sources.add_known_block_and_set_best(local_id, decoded.header.number, decoded_header_hash);
+                            if let Ok(decoded_header) = header::decode(&decoded.scale_encoded_header) {
+                                let decoded_header_hash = header::hash_from_scale_encoded_header(
+                                    &decoded.scale_encoded_header
+                                );
+                                let decoded_header_number = decoded_header.number;
+                                sync_sources.add_known_block(
+                                    local_id,
+                                    decoded_header_number,
+                                    decoded_header_hash
+                                );
+                                if decoded.is_best {
+                                    sync_sources.add_known_block_and_set_best(
+                                        local_id,
+                                        decoded_header_number,
+                                        decoded_header_hash
+                                    );
+                                }
                             }
                         },
                         _ => {

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -807,7 +807,6 @@ where
         let buffers_to_send = protocol::encode_block_announce(protocol::BlockAnnounceRef {
             scale_encoded_header,
             is_best,
-            header: header::decode(scale_encoded_header).unwrap(), // TODO: hack
         });
 
         let notification = buffers_to_send.fold(Vec::new(), |mut a, b| {


### PR DESCRIPTION
At the moment the decoded block announces struct contains at the same time `header` (decoded) and `scale_encoded_header` (encoded)

The reason why there are two is because the block announces format concatenates the header with the other fields, meaning that it is not possible to decode block announces without decoding the header. In other words, if a block announces has been successfully decoded, then the header is necessarily decodable successfully as well.
However, this fact should be seen as a quirk in the block announces format. It would be better if you could decode the announce without decoding the header, and it's not completely impossible that we do this in the long future.

This PR removes `header` and commits to the fact that `scale_encoded_header` might be undecodable. It is still the case that the header is always decodable, but it is not longer guaranteed in the API.
