### PR TITLE
Logs errors as Debug and not Display

### DIFF
--- a/bin/light-base/src/network_service.rs
+++ b/bin/light-base/src/network_service.rs
@@ -269,7 +269,7 @@ impl<TPlat: Platform> NetworkService<TPlat> {
                                 } => {
                                     log::debug!(
                                         target: "network",
-                                        "Connection({}, {}) => ChainConnectAttemptFailed(error={})",
+                                        "Connection({}, {}) => ChainConnectAttemptFailed(error={:?})",
                                         &network_service.log_chain_names[chain_index],
                                         peer_id, error,
                                     );
@@ -349,7 +349,7 @@ impl<TPlat: Platform> NetworkService<TPlat> {
                                     // TODO: handle properly?
                                     log::warn!(
                                         target: "network",
-                                        "Connection({}) => ProtocolError(error={})",
+                                        "Connection({}) => ProtocolError(error={:?})",
                                         peer_id,
                                         error,
                                     );
@@ -691,7 +691,7 @@ impl<TPlat: Platform> NetworkService<TPlat> {
             Err(err) => {
                 log::debug!(
                     target: "network",
-                    "Connection({}) => BlocksRequest(chain={}, error={})",
+                    "Connection({}) => BlocksRequest(chain={}, error={:?})",
                     target,
                     self.inner.log_chain_names[chain_index],
                     err
@@ -751,7 +751,7 @@ impl<TPlat: Platform> NetworkService<TPlat> {
             Err(err) => {
                 log::debug!(
                     target: "network",
-                    "Connection({}) => GrandpaWarpSyncRequest(chain={}, error={})",
+                    "Connection({}) => GrandpaWarpSyncRequest(chain={}, error={:?})",
                     target,
                     self.inner.log_chain_names[chain_index],
                     err,
@@ -832,7 +832,7 @@ impl<TPlat: Platform> NetworkService<TPlat> {
             Err(err) => {
                 log::debug!(
                     target: "network",
-                    "Connection({}) => StorageProofRequest(chain={}, error={})",
+                    "Connection({}) => StorageProofRequest(chain={}, error={:?})",
                     target,
                     self.inner.log_chain_names[chain_index],
                     err

--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -1676,7 +1676,7 @@ async fn run_background<TPlat: Platform>(
                         Err(error) => {
                             log::debug!(
                                 target: &log_target,
-                                "Worker <= FailedDownload(blocks=[{}], error={})",
+                                "Worker <= FailedDownload(blocks=[{}], error={:?})",
                                 concerned_blocks,
                                 error
                             );

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -374,7 +374,7 @@ pub(super) async fn start_parachain<TPlat: Platform>(
 
                             log::debug!(
                                 target: &log_target,
-                                "ParaheadFetchOperations => Error(relay_blocks={}, error={})",
+                                "ParaheadFetchOperations => Error(relay_blocks={}, error={:?})",
                                 async_tree.async_op_blocks(async_op_id).map(|b| HashDisplay(b)).join(","),
                                 error
                             );
@@ -594,7 +594,7 @@ async fn parahead<TPlat: Platform>(
     }
 }
 
-#[derive(derive_more::Display)]
+#[derive(Debug, derive_more::Display)]
 enum ParaheadError {
     Call(runtime_service::RuntimeCallError),
     StartError(host::StartErr),

--- a/bin/light-base/src/sync_service/standalone.rs
+++ b/bin/light-base/src/sync_service/standalone.rs
@@ -596,7 +596,7 @@ impl<TPlat: Platform> Task<TPlat> {
                             // TODO: print which peer sent the header
                             log::debug!(
                                 target: &self.log_target,
-                                "Sync => HeaderVerifyError(hash={}, error={})",
+                                "Sync => HeaderVerifyError(hash={}, error={:?})",
                                 HashDisplay(&verified_hash),
                                 error
                             );
@@ -644,7 +644,7 @@ impl<TPlat: Platform> Task<TPlat> {
                             // TODO: print which peer sent the justification
                             log::debug!(
                                 target: &self.log_target,
-                                "Sync => JustificationVerificationError(error={})",
+                                "Sync => JustificationVerificationError(error={:?})",
                                 error,
                             );
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Add `ClientOptions.cpuRateLimit`, which lets the user put an upper bound on the amount of CPU that the client uses on average ([#2151](https://github.com/paritytech/smoldot/pull/2151)).
 - Add support for parsing the "fron" (Frontier) consensus log items in headers. The content of these log items is ignored by the client. ([#2150](https://github.com/paritytech/smoldot/pull/2150))
 
+### Changed
+
+- Add more details to the debug and trace logs that happen in case of errors such as networking errors or block verification failures ([#2161](https://github.com/paritytech/smoldot/pull/2161)).
+
 ## 0.6.5 - 2022-03-17
 
 ### Changed


### PR DESCRIPTION
All the logs that look a bit "system-y" (which are all the debug and trace logs) now show errors through the `Debug` trait rather than `Display`

This fits the vibe of the log line more, and also provides additional information.

The `Display` trait is still used for warning and error logs that the user is expected to react to.
