### PR TITLE
Don't remove source knows block after verification

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix regression introduced in version 0.6.5 where we erroneously removed entries in the mapping of which peer knows which blocks, leading to failures to request data. ([#2168](https://github.com/paritytech/smoldot/pull/2168))
+
 ## 0.6.7 - 2022-03-22
 
 ### Changed

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -1584,10 +1584,6 @@ impl<TBl, TRq, TSrc> HeaderVerify<TBl, TRq, TSrc> {
                 // Block is valid!
 
                 // Remove the block from `pending_blocks`.
-                self.parent.inner.blocks.remove_sources_known_block(
-                    self.block_to_verify.block_number,
-                    &self.block_to_verify.block_hash,
-                );
                 let pending_block = self.parent.inner.blocks.remove_unverified_block(
                     self.block_to_verify.block_number,
                     &self.block_to_verify.block_hash,


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/paritytech/smoldot/pull/2114

I don't know why I had added this call to `remove_sources_known_block` after a block has been successfully verified. Not only it is obviously wrong, but in #2114 I tried to not change the behavior and added this call that explicitly changes the behavior.

Unfortunately the lack of testing didn't help, but the problem got caught by https://github.com/paritytech/substrate-connect/runs/5590927994?check_suite_focus=true
