### PR TITLE
Fix Rococo's chain ID

### DIFF
--- a/bin/rococo.json
+++ b/bin/rococo.json
@@ -1,6 +1,6 @@
 {
   "name": "Rococo 2",
-  "id": "rococo_v2",
+  "id": "rococo_v2_1",
   "chainType": "Live",
   "bootNodes": [
     "/ip4/34.90.151.124/tcp/30333/p2p/12D3KooWF7BUbG5ErMZ47ZdarRwtpZamgcZqxwpnFzkhjc1spHnP",


### PR DESCRIPTION
The demo broke after https://github.com/paritytech/smoldot/pull/2175 because Rococo's ID didn't match the value in the parachain anymore