### PR TITLE
Add async_tree::Config::blocks_capacity

### DIFF
--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -127,6 +127,7 @@ impl<TPlat: Platform> RuntimeService<TPlat> {
             let mut tree = async_tree::AsyncTree::new(async_tree::Config {
                 finalized_async_user_data: None,
                 retry_after_failed: Duration::from_secs(10),
+                blocks_capacity: 32,
             });
             let node_index = tree.input_insert_block(
                 Block {
@@ -1483,6 +1484,7 @@ async fn run_background<TPlat: Platform>(
                             async_tree::AsyncTree::<_, Block, _>::new(async_tree::Config {
                                 finalized_async_user_data: runtime,
                                 retry_after_failed: Duration::from_secs(10), // TODO: hardcoded
+                                blocks_capacity: 32,
                             });
 
                         for block in subscription.non_finalized_blocks_ancestry_order {
@@ -1521,6 +1523,7 @@ async fn run_background<TPlat: Platform>(
                         let mut tree = async_tree::AsyncTree::new(async_tree::Config {
                             finalized_async_user_data: None,
                             retry_after_failed: Duration::from_secs(10), // TODO: hardcoded
+                            blocks_capacity: 32,
                         });
                         let node_index = tree.input_insert_block(
                             Block {

--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -1614,6 +1614,7 @@ impl<TPlat: Platform> Background<TPlat> {
                             async_tree::AsyncTree::new(async_tree::Config {
                                 finalized_async_user_data: None,
                                 retry_after_failed: Duration::new(0, 0),
+                                blocks_capacity: 0,
                             }),
                         )
                         .map_async_op_user_data(|runtime_index| runtime_index.unwrap());

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -97,6 +97,7 @@ pub(super) async fn start_parachain<TPlat: Platform>(
                 async_tree::AsyncTree::<TPlat::Instant, [u8; 32], _>::new(async_tree::Config {
                     finalized_async_user_data: None,
                     retry_after_failed: Duration::from_secs(5),
+                    blocks_capacity: 32,
                 });
             let finalized_hash = header::hash_from_scale_encoded_header(
                 &relay_chain_subscribe_all.finalized_block_scale_encoded_header,

--- a/src/chain/async_tree.rs
+++ b/src/chain/async_tree.rs
@@ -114,6 +114,17 @@ pub struct Config<TAsync> {
 
     /// After an asynchronous operation fails, retry after this given duration.
     pub retry_after_failed: Duration,
+
+    /// Number of elements to initially allocate to store blocks.
+    ///
+    /// This is not a cap to the number of blocks, but merely the amount of memory to initially
+    /// reserve.
+    ///
+    /// This covers all blocks from the moment they're added as input to the moment they're
+    /// finalized in the output.
+    ///
+    /// It is legal to pass 0, in which case no memory is pre-allocated.
+    pub blocks_capacity: usize,
 }
 
 pub struct AsyncTree<TNow, TBl, TAsync> {
@@ -160,7 +171,7 @@ where
         AsyncTree {
             best_block_index: None,
             finalized_async_user_data: config.finalized_async_user_data,
-            non_finalized_blocks: fork_tree::ForkTree::with_capacity(32),
+            non_finalized_blocks: fork_tree::ForkTree::with_capacity(config.blocks_capacity),
             input_finalized_index: None,
             input_best_block_next_weight: 2,
             finalized_block_weight: 1, // `0` is reserved for blocks who are never best.

--- a/src/chain/async_tree.rs
+++ b/src/chain/async_tree.rs
@@ -35,6 +35,7 @@
 //! let mut tree = async_tree::AsyncTree::new(async_tree::Config {
 //!     finalized_async_user_data: "hello",
 //!     retry_after_failed: Duration::from_secs(5),
+//!     blocks_capacity: 32,
 //! });
 //!
 //! // Insert a new best block, parent of the finalized block.


### PR DESCRIPTION
In https://github.com/paritytech/smoldot/pull/2180 we're now creating a temporary `AsyncTree` that is dropped immediately after.
This is a bit wasteful, so this PR makes the capacity to reserve explicit. After https://github.com/paritytech/smoldot/pull/2180 is merged, I'll update this PR to pass `blocks_capacity: 0` at that location.