### PR TITLE
Fix #2088 again

### DIFF
--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -247,11 +247,12 @@ pub(super) async fn start_parachain<TPlat: Platform>(
                         // past. This covers situations where the parahead is identical to the
                         // relay chain's parent's parahead, but also situations where multiple
                         // sibling relay chain blocks have the same parahead.
-                        if async_tree
-                            .input_iter_unordered()
-                            .filter(|item| item.id != block_index)
-                            .filter_map(|item| item.async_op_user_data)
-                            .any(|item| item.as_ref() == Some(&scale_encoded_header))
+                        if finalized_parahead == scale_encoded_header
+                            || async_tree
+                                .input_iter_unordered()
+                                .filter(|item| item.id != block_index)
+                                .filter_map(|item| item.async_op_user_data)
+                                .any(|item| item.as_ref() == Some(&scale_encoded_header))
                         {
                             continue;
                         }

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix parachain blocks being reported multiple times in case they have been finalized in-between ([#2106](https://github.com/paritytech/smoldot/pull/2106)).
+
 ## 0.6.9 - 2022-03-25
 
 ### Fixed

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix parachain blocks being reported multiple times in case they have been finalized in-between ([#2106](https://github.com/paritytech/smoldot/pull/2106)).
+- Fix parachain blocks being reported multiple times in case they have been finalized in-between ([#2182](https://github.com/paritytech/smoldot/pull/2182)).
 
 ## 0.6.9 - 2022-03-25
 


### PR DESCRIPTION
Fix #2088 again
Fix #2147 as well

This is a fix of https://github.com/paritytech/smoldot/pull/2106, which was the previous attempt at fixing #2088 

What https://github.com/paritytech/smoldot/pull/2106 didn't do is check whether the block to report is equal to the finalized block.

What happens is:

- When the parachain sync service initializes, it starts to fetch the parahead corresponding the latest relay chain finalized block and to fetch the parahead corresponding to each relay chain non-finalized block
- The fetch of the relay chain finalized block succeeds, and we report this block. We not only reports it as new block but also as finalized.
- The fetch of one of the relay chain non-finalized blocks succeeds, and the code that this PR modifies runs. But because the code before this PR only looks at non-finalized blocks, it doesn't detect that we have already reports this new block, and thus we report it again.

As a result, we have two different blocks with the same hash, which isn't supposed to happen, and triggers a panic in the state machines on top.
