### PR TITLE
Cap the maximum value passed to setTimeout

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed a `TimeoutOverflowWarning` caused by calling `setTimeout` with a value that is too large.
+- Fixed a `TimeoutOverflowWarning` caused by calling `setTimeout` with a value that is too large. ([#2188](https://github.com/paritytech/smoldot/pull/2188))
 
 ## 0.6.10 - 2022-03-29
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed a `TimeoutOverflowWarning` caused by calling `setTimeout` with a value that is too large.
+
 ## 0.6.10 - 2022-03-29
 
 ### Fixed

--- a/bin/wasm-node/javascript/src/worker/bindings-smoldot-light.ts
+++ b/bin/wasm-node/javascript/src/worker/bindings-smoldot-light.ts
@@ -110,6 +110,13 @@ export default function (config: Config): compat.WasmModuleImports {
         start_timer: (id: number, ms: number) => {
             const instance = config.instance!;
 
+            // In both NodeJS and browsers, if `setTimeout` is called with a value larger than
+            // 2147483647, the delay is for some reason instead set to 1.
+            // As mentioned in the documentation of `start_timer`, it is acceptable to end the
+            // timer before the given number of milliseconds has passed.
+            if (ms > 2147483647)
+                ms = 2147483647;
+
             // In browsers, `setTimeout` works as expected when `ms` equals 0. However, NodeJS
             // requires a minimum of 1 millisecond (if `0` is passed, it is automatically replaced
             // with `1`) and wants you to use `setImmediate` instead.

--- a/bin/wasm-node/rust/src/bindings.rs
+++ b/bin/wasm-node/rust/src/bindings.rs
@@ -144,6 +144,10 @@ extern "C" {
     /// After at least `milliseconds` milliseconds have passed, must call [`timer_finished`] with
     /// the `id` passed as parameter.
     ///
+    /// It is not a logic error to call [`timer_finished`] *before* `milliseconds` milliseconds
+    /// have passed, and this will likely cause smoldot to restart a new timer for the remainder
+    /// of the duration.
+    ///
     /// When [`timer_finished`] is called, the value of [`monotonic_clock_ms`] must have increased
     /// by at least the given number of `milliseconds`.
     ///


### PR DESCRIPTION
Yet another surprise factor from JavaScript:

- https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
- https://nodejs.org/api/timers.html#settimeoutcallback-delay-args
