### PR TITLE
Correctly implement the cpuRateLimit feature

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix the `ClientOptions.cpuRateLimit` feature being misimplemented and treating any value other than 1.0 as extremely low.
+- Fix the `ClientOptions.cpuRateLimit` feature being misimplemented and treating any value other than 1.0 as extremely low. ([#2189](https://github.com/paritytech/smoldot/pull/2189))
 
 ## 0.6.10 - 2022-03-29
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix the `ClientOptions.cpuRateLimit` feature being misimplemented and treating any value other than 1.0 as extremely low.
+
 ## 0.6.10 - 2022-03-29
 
 ### Fixed

--- a/bin/wasm-node/javascript/demo/demo.js
+++ b/bin/wasm-node/javascript/demo/demo.js
@@ -38,6 +38,7 @@ const client = smoldot.start({
     forbidWs: false,
     forbidNonLocalWs: false,
     forbidWss: false,
+    cpuRateLimit: 0.5,
     logCallback: (level, target, message) => {
         // As incredible as it seems, there is currently no better way to print the current time
         // formatted in a certain way.


### PR DESCRIPTION
Correctly implements https://github.com/paritytech/smoldot/pull/2151

The code currently does `u32::max_value().checked_sub(rate_limit)`. This is wrong, it should be `checked_div`.
I remember that when I was testing https://github.com/paritytech/smoldot/pull/2151 I was doing `u32::max_value() / rate_limit`, and then at the last second before opening the PR I replaced this with the `checked_` function in order to handle the situation where `rate_limit` is 0.

In addition to fixing this mistake, I've also changed the code to use floating points instead of integers.
Right now the precision is actually very low: because we round the division to the nearest integer, the possible values for the CPU bound can only be 100%, 50%, 25%, 12.5%, etc. Using floating points fixes this.
