### PR TITLE
Tweak runtime_service::RuntimeLock::specification

### DIFF
--- a/bin/light-base/src/json_rpc_service/state_chain.rs
+++ b/bin/light-base/src/json_rpc_service/state_chain.rs
@@ -985,7 +985,7 @@ impl<TPlat: Platform> Background<TPlat> {
             if cache_lock.recent_pinned_blocks.contains(&block_hash) {
                 // The runtime service has the block pinned, meaning that we can ask the runtime
                 // service for the specification.
-                let mut runtime_call_lock = self
+                let runtime_call_lock = self
                     .runtime_service
                     .pinned_block_runtime_lock(
                         cache_lock.subscription_id.clone().unwrap(),
@@ -1045,7 +1045,7 @@ impl<TPlat: Platform> Background<TPlat> {
                     .compile_and_pin_runtime(storage_code, storage_heap_pages)
                     .await;
 
-                let mut runtime = self
+                let runtime = self
                     .runtime_service
                     .pinned_runtime_lock(
                         pinned_runtime_id.clone(),

--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -708,10 +708,10 @@ impl<'a, TPlat: Platform> RuntimeLock<'a, TPlat> {
     }
 
     /// Returns the specification of the given runtime.
-    pub fn specification(&mut self) -> Result<executor::CoreVersion, RuntimeCallError> {
+    pub fn specification(&self) -> Result<executor::CoreVersion, RuntimeError> {
         match self.runtime.runtime.as_ref() {
             Ok(r) => Ok(r.runtime_spec.clone()),
-            Err(err) => Err(RuntimeCallError::InvalidRuntime(err.clone())),
+            Err(err) => Err(err.clone()),
         }
     }
 


### PR DESCRIPTION
The function doesn't need to take `&mut self`.
Also changes the error type. The error right now is only used to be turned into a string and sent back as a JSON-RPC error in case the runtime is invalid.