### PR TITLE
Do not panic when passed an invalid bootnode address

### DIFF
--- a/bin/light-base/src/lib.rs
+++ b/bin/light-base/src/lib.rs
@@ -452,20 +452,35 @@ impl<TChain, TPlat: Platform> Client<TChain, TPlat> {
         };
 
         // Build the list of bootstrap nodes ahead of time.
-        // TODO: either leave this here if it's fallible, or move below if it's not fallible
-        let bootstrap_nodes = {
-            let mut list = Vec::with_capacity(chain_spec.boot_nodes().len());
+        // Because the specification of the format of a multiaddress is a bit flexible, it is
+        // not possible to firmly affirm that a multiaddress is invalid. For this reason, we
+        // simply ignore unparsable bootnode addresses rather than returning an error.
+        // A list of invalid bootstrap node addresses is kept in order to print a warning later
+        // in case it is non-empty. This list is sanitized in order to be safely printable as part
+        // of the logs.
+        let (bootstrap_nodes, invalid_bootstrap_nodes_sanitized) = {
+            let mut valid_list = Vec::with_capacity(chain_spec.boot_nodes().len());
+            let mut invalid_list = Vec::with_capacity(0);
             for node in chain_spec.boot_nodes() {
-                let mut address: multiaddr::Multiaddr = node.parse().unwrap(); // TODO: don't unwrap?
-                if let Some(multiaddr::ProtocolRef::P2p(peer_id)) = address.iter().last() {
-                    let peer_id = peer_id::PeerId::from_bytes(peer_id.to_vec()).unwrap(); // TODO: don't unwrap
-                    address.pop();
-                    list.push((peer_id, vec![address]));
-                } else {
-                    panic!() // TODO:
+                match node {
+                    chain_spec::Bootnode::Parsed { multiaddr, peer_id } => {
+                        if let Ok(multiaddr) = multiaddr.parse::<multiaddr::Multiaddr>() {
+                            let peer_id = peer_id::PeerId::from_bytes(peer_id).unwrap();
+                            valid_list.push((peer_id, vec![multiaddr]));
+                            continue;
+                        } else {
+                            invalid_list.push(multiaddr)
+                        }
+                    }
+                    chain_spec::Bootnode::UnrecognizedFormat(unparsed) => invalid_list.push(
+                        unparsed
+                            .chars()
+                            .filter(|c| c.is_ascii())
+                            .collect::<String>(),
+                    ),
                 }
             }
-            list
+            (valid_list, invalid_list)
         };
 
         // All the checks are performed above. Adding the chain can't fail anymore at this point.
@@ -650,6 +665,15 @@ impl<TChain, TPlat: Platform> Client<TChain, TPlat> {
                                 running_chain.network_identity,
                                 HashDisplay(&starting_block_hash),
                                 starting_block_number
+                            );
+                        }
+
+                        if !invalid_bootstrap_nodes_sanitized.is_empty() {
+                            log::warn!(
+                                target: "smoldot",
+                                "Failed to parse some of the bootnodes of {}. \
+                                These bootnodes have been ignored. List: {}",
+                                log_name, invalid_bootstrap_nodes_sanitized.join(",")
                             );
                         }
 

--- a/bin/light-base/src/lib.rs
+++ b/bin/light-base/src/lib.rs
@@ -668,15 +668,6 @@ impl<TChain, TPlat: Platform> Client<TChain, TPlat> {
                             );
                         }
 
-                        if !invalid_bootstrap_nodes_sanitized.is_empty() {
-                            log::warn!(
-                                target: "smoldot",
-                                "Failed to parse some of the bootnodes of {}. \
-                                These bootnodes have been ignored. List: {}",
-                                log_name, invalid_bootstrap_nodes_sanitized.join(", ")
-                            );
-                        }
-
                         running_chain
                     };
 
@@ -699,6 +690,15 @@ impl<TChain, TPlat: Platform> Client<TChain, TPlat> {
                 (&mut entry.services, &entry.log_name)
             }
         };
+
+        if !invalid_bootstrap_nodes_sanitized.is_empty() {
+            log::warn!(
+                target: "smoldot",
+                "Failed to parse some of the bootnodes of {}. \
+                These bootnodes have been ignored. List: {}",
+                log_name, invalid_bootstrap_nodes_sanitized.join(", ")
+            );
+        }
 
         // Print a warning if the list of bootnodes is empty, as this is a common mistake.
         if bootstrap_nodes.is_empty() {

--- a/bin/light-base/src/lib.rs
+++ b/bin/light-base/src/lib.rs
@@ -467,7 +467,6 @@ impl<TChain, TPlat: Platform> Client<TChain, TPlat> {
                         if let Ok(multiaddr) = multiaddr.parse::<multiaddr::Multiaddr>() {
                             let peer_id = peer_id::PeerId::from_bytes(peer_id).unwrap();
                             valid_list.push((peer_id, vec![multiaddr]));
-                            continue;
                         } else {
                             invalid_list.push(multiaddr)
                         }

--- a/bin/light-base/src/lib.rs
+++ b/bin/light-base/src/lib.rs
@@ -673,7 +673,7 @@ impl<TChain, TPlat: Platform> Client<TChain, TPlat> {
                                 target: "smoldot",
                                 "Failed to parse some of the bootnodes of {}. \
                                 These bootnodes have been ignored. List: {}",
-                                log_name, invalid_bootstrap_nodes_sanitized.join(",")
+                                log_name, invalid_bootstrap_nodes_sanitized.join(", ")
                             );
                         }
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- No longer panic if passed a chain specification containing an invalid bootnode address. Because the specification of the format of a multiaddress is flexible, invalid bootnode addresses do not trigger a hard error but instead are ignored and a warning is printed.
+- No longer panic if passed a chain specification containing an invalid bootnode address. Because the specification of the format of a multiaddress is flexible, invalid bootnode addresses do not trigger a hard error but instead are ignored and a warning is printed. ([#2207](https://github.com/paritytech/smoldot/pull/2207))
 
 ## 0.6.12 - 2022-04-04
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- No longer panic if passed a chain specification containing an invalid bootnode address. Because the specification of the format of a multiaddress is flexible, invalid bootnode addresses do not trigger a hard error but instead are ignored and a warning is printed.
+
 ## 0.6.12 - 2022-04-04
 
 ### Fixed

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -286,7 +286,7 @@ impl ChainSpec {
     }
 }
 
-/// See [`ChainSpec::bootnodes`].
+/// See [`ChainSpec::boot_nodes`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Bootnode<'a> {
     /// The address of the bootnode is valid.

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -38,8 +38,13 @@ use crate::chain::chain_information::{
     aura_config, babe_genesis_config, grandpa_genesis_config, BabeEpochInformation,
     ChainInformation, ChainInformationConsensus, ChainInformationFinality,
 };
+use crate::libp2p;
 
-use alloc::{borrow::ToOwned as _, string::String, vec::Vec};
+use alloc::{
+    borrow::ToOwned as _,
+    string::{String, ToString as _},
+    vec::Vec,
+};
 use core::num::NonZeroU64;
 
 mod light_sync_state;
@@ -190,10 +195,28 @@ impl ChainSpec {
         }
     }
 
-    /// Returns the list of bootnode addresses in the chain specs.
-    // TODO: more strongly typed?
-    pub fn boot_nodes(&self) -> &[String] {
-        &self.client_spec.boot_nodes
+    /// Returns the list of bootnode addresses found in the chain spec.
+    ///
+    /// Bootnode addresses that have failed to be parsed are returned as well in the form of
+    /// a [`Bootnode::UnrecognizedFormat`].
+    pub fn boot_nodes(&'_ self) -> impl ExactSizeIterator<Item = Bootnode<'_>> + '_ {
+        // Note that we intentionally don't expose types found in the `libp2p` module in order to
+        // not tie the code that parses chain specifications to the libp2p code.
+        self.client_spec.boot_nodes.iter().map(|unparsed| {
+            if let Ok(mut addr) = unparsed.parse::<libp2p::Multiaddr>() {
+                if let Some(libp2p::multiaddr::ProtocolRef::P2p(peer_id)) = addr.iter().last() {
+                    if let Ok(peer_id) = libp2p::peer_id::PeerId::from_bytes(peer_id.to_vec()) {
+                        addr.pop();
+                        return Bootnode::Parsed {
+                            multiaddr: addr.to_string(),
+                            peer_id: peer_id.into_bytes(),
+                        };
+                    }
+                }
+            }
+
+            Bootnode::UnrecognizedFormat(unparsed)
+        })
     }
 
     /// Returns the list of libp2p multiaddresses of the default telemetry servers of the chain.
@@ -261,6 +284,30 @@ impl ChainSpec {
                 inner: state.decode().unwrap(),
             })
     }
+}
+
+/// See [`ChainSpec::bootnodes`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Bootnode<'a> {
+    /// The address of the bootnode is valid.
+    Parsed {
+        /// String representation of the multiaddr that can be used to reach the bootnode.
+        ///
+        /// Does *not* contain the trailing `/p2p/...`.
+        multiaddr: String,
+
+        /// Bytes representation of the libp2p peer id of the bootnode.
+        ///
+        /// The format can be found in cthe libp2p specification:
+        /// <https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md>
+        peer_id: Vec<u8>,
+    },
+
+    /// The address of the bootnode couldn't be parsed.
+    ///
+    /// This could be due to the format being invalid, or to smoldot not supporting one of the
+    /// multiaddress components that is being used.
+    UnrecognizedFormat(&'a str),
 }
 
 /// See [`ChainSpec::genesis_storage`].
@@ -404,7 +451,7 @@ pub enum FromGenesisStorageError {
 
 #[cfg(test)]
 mod tests {
-    use super::ChainSpec;
+    use super::{Bootnode, ChainSpec};
 
     #[test]
     fn can_decode_polkadot_genesis() {
@@ -415,5 +462,29 @@ mod tests {
         // code_substitutes field
         assert_eq!(specs.client_spec.code_substitutes.get(&1), None);
         assert!(specs.client_spec.code_substitutes.get(&5203203).is_some());
+
+        // bootnodes field
+        assert_eq!(
+            specs.boot_nodes().collect::<Vec<_>>(),
+            vec![
+                Bootnode::Parsed {
+                    multiaddr: "/dns4/p2p.cc1-0.polkadot.network/tcp/30100".into(),
+                    peer_id: vec![
+                        0, 36, 8, 1, 18, 32, 71, 154, 61, 188, 212, 39, 215, 192, 217, 22, 168, 87,
+                        162, 148, 234, 176, 0, 195, 4, 31, 109, 123, 175, 185, 26, 169, 218, 92,
+                        192, 0, 126, 111
+                    ]
+                },
+                Bootnode::Parsed {
+                    multiaddr: "/dns4/cc1-1.parity.tech/tcp/30333".into(),
+                    peer_id: vec![
+                        0, 36, 8, 1, 18, 32, 82, 103, 22, 131, 223, 29, 166, 147, 119, 199, 217,
+                        185, 69, 70, 87, 73, 165, 110, 224, 141, 138, 44, 217, 75, 191, 55, 156,
+                        212, 204, 41, 11, 59
+                    ]
+                },
+                Bootnode::UnrecognizedFormat("/some/wrong/multiaddress")
+            ]
+        );
     }
 }


### PR DESCRIPTION
Close https://github.com/paritytech/smoldot/issues/2204

We no longer panic when the chain spec contains an invalid bootnode address.

As I've commented in the code, it is not possible to be sure that a bootnode address is actually invalid. We can only be sure that smoldot cannot parse it, but that's not the same as saying that it's invalid.
For this reason, invalid bootnode addresses are simply ignored in the light client.
