### PR TITLE
Properly fix the regression again

### DIFF
--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -1159,6 +1159,10 @@ async fn run_background<TPlat: Platform>(
                     },
                 };
             } else {
+                if let GuardedInner::FinalizedBlockRuntimeUnknown { when_known, .. } = &lock.tree {
+                    when_known.notify(usize::max_value());
+                }
+
                 lock.tree = GuardedInner::FinalizedBlockRuntimeUnknown {
                     when_known: event_listener::Event::new(),
                     tree: {

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Properly fix the regression mentioned in v0.6.12. ([#2201](https://github.com/paritytech/smoldot/pull/2201))
+- Properly fix the regression that version 0.6.12 was supposed to fix. ([#2210](https://github.com/paritytech/smoldot/pull/2210))
 
 ## 0.6.12 - 2022-04-04
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Properly fix the regression mentioned in v0.6.12. ([#2201](https://github.com/paritytech/smoldot/pull/2201))
+
 ## 0.6.12 - 2022-04-04
 
 ### Fixed


### PR DESCRIPTION
This is https://github.com/paritytech/smoldot/pull/2201 again

This time I've made sure that `when_known` was indeed notified before every time we do `lock.tree = ...`.
