### PR TITLE
Ignore the maximum number of pinned blocks when irrelevant

### DIFF
--- a/bin/light-base/src/json_rpc_service.rs
+++ b/bin/light-base/src/json_rpc_service.rs
@@ -591,9 +591,14 @@ impl<TPlat: Platform> Background<TPlat> {
 
                     // Subscribe to new runtime service blocks in order to push them in the
                     // cache as soon as they are available.
+                    // The buffer size should be large enough so that, if the CPU is busy, it
+                    // doesn't become full before the execution of this task resumes.
+                    // The maximum number of pinned block is ignored, as this maximum is a way to
+                    // avoid malicious behaviors. This code is by definition not considered
+                    // malicious.
                     let mut subscribe_all = me
                         .runtime_service
-                        .subscribe_all(8, cache.recent_pinned_blocks.cap())
+                        .subscribe_all(32, cache.recent_pinned_blocks.cap())
                         .await;
 
                     cache.subscription_id = Some(subscribe_all.new_blocks.id());

--- a/bin/light-base/src/json_rpc_service.rs
+++ b/bin/light-base/src/json_rpc_service.rs
@@ -598,7 +598,7 @@ impl<TPlat: Platform> Background<TPlat> {
                     // malicious.
                     let mut subscribe_all = me
                         .runtime_service
-                        .subscribe_all(32, cache.recent_pinned_blocks.cap())
+                        .subscribe_all(32, usize::max_value())
                         .await;
 
                     cache.subscription_id = Some(subscribe_all.new_blocks.id());

--- a/bin/light-base/src/json_rpc_service/chain_head.rs
+++ b/bin/light-base/src/json_rpc_service/chain_head.rs
@@ -379,6 +379,7 @@ impl<TPlat: Platform> Background<TPlat> {
         };
 
         let (mut subscribe_all, runtime_subscribe_all) = if runtime_updates {
+            // TODO: it is possible that the maximum number of pinned blocks is lower than the current number of finalized blocks; the logic of subscribe_all should be slightly changed to avoid this situation
             let subscribe_all = self.runtime_service.subscribe_all(32, 48).await;
             let id = subscribe_all.new_blocks.id();
             (either::Left(subscribe_all), Some(id))

--- a/bin/light-base/src/json_rpc_service/state_chain.rs
+++ b/bin/light-base/src/json_rpc_service/state_chain.rs
@@ -394,7 +394,11 @@ impl<TPlat: Platform> Background<TPlat> {
             .await;
 
         let mut new_blocks = {
-            let subscribe_all = self.runtime_service.subscribe_all(16, 32).await;
+            // The buffer size should be large enough so that, if the CPU is busy, it doesn't
+            // become full before the execution of the runtime service resumes.
+            // The maximum number of pinned block is ignored, as this maximum is a way to avoid
+            // malicious behaviors. This code is by definition not considered malicious.
+            let subscribe_all = self.runtime_service.subscribe_all(32, usize::max_value()).await;
 
             // The finalized and already-known blocks aren't reported to the user, but we need
             // unpin them on to the runtime service.

--- a/bin/light-base/src/json_rpc_service/state_chain.rs
+++ b/bin/light-base/src/json_rpc_service/state_chain.rs
@@ -398,7 +398,10 @@ impl<TPlat: Platform> Background<TPlat> {
             // become full before the execution of the runtime service resumes.
             // The maximum number of pinned block is ignored, as this maximum is a way to avoid
             // malicious behaviors. This code is by definition not considered malicious.
-            let subscribe_all = self.runtime_service.subscribe_all(32, usize::max_value()).await;
+            let subscribe_all = self
+                .runtime_service
+                .subscribe_all(32, usize::max_value())
+                .await;
 
             // The finalized and already-known blocks aren't reported to the user, but we need
             // unpin them on to the runtime service.

--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -187,7 +187,9 @@ impl<TPlat: Platform> RuntimeService<TPlat> {
     ///
     /// A maximum number of pinned blocks must be passed, indicating the maximum number of blocks
     /// that the runtime service will pin at the same time for this subscription. If this maximum
-    /// is reached, the channel will get closed.
+    /// is reached, the channel will get closed. In situations where the subscriber is guaranteed
+    /// to always properly unpin blocks, a value of `usize::max_value()` can be passed in order
+    /// to ignore this maximum.
     ///
     /// The channel also gets closed if a gap in the finality happens, such as after a Grandpa
     /// warp syncing.

--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -1025,7 +1025,7 @@ async fn run_background<TPlat: Platform>(
     loop {
         // The buffer size should be large enough so that, if the CPU is busy, it doesn't
         // become full before the execution of the runtime service resumes.
-        let subscription = sync_service.subscribe_all(16, true).await;
+        let subscription = sync_service.subscribe_all(32, true).await;
 
         log::debug!(
             target: &log_target,

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -74,7 +74,8 @@ pub(super) async fn start_parachain<TPlat: Platform>(
         // become full before the execution of the sync service resumes.
         // The maximum number of pinned block is ignored, as this maximum is a way to avoid
         // malicious behaviors. This code is by definition not considered malicious.
-        let mut relay_chain_subscribe_all = relay_chain_sync.subscribe_all(32, usize::max_value()).await;
+        let mut relay_chain_subscribe_all =
+            relay_chain_sync.subscribe_all(32, usize::max_value()).await;
         log::debug!(
             target: &log_target,
             "RelayChain => NewSubscription(finalized_hash={})",

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -70,7 +70,11 @@ pub(super) async fn start_parachain<TPlat: Platform>(
     // we break out of the inner loop in order to reset everything.
     loop {
         // Stream of blocks of the relay chain this parachain is registered on.
-        let mut relay_chain_subscribe_all = relay_chain_sync.subscribe_all(32, 64).await;
+        // The buffer size should be large enough so that, if the CPU is busy, it doesn't
+        // become full before the execution of the sync service resumes.
+        // The maximum number of pinned block is ignored, as this maximum is a way to avoid
+        // malicious behaviors. This code is by definition not considered malicious.
+        let mut relay_chain_subscribe_all = relay_chain_sync.subscribe_all(32, usize::max_value()).await;
         log::debug!(
             target: &log_target,
             "RelayChain => NewSubscription(finalized_hash={})",

--- a/bin/light-base/src/transactions_service.rs
+++ b/bin/light-base/src/transactions_service.rs
@@ -318,7 +318,11 @@ async fn background_task<TPlat: Platform>(
         // after a Grandpa warp sync) or because the transactions service was too busy to process
         // the new blocks.
 
-        let mut subscribe_all = worker.runtime_service.subscribe_all(32, 32).await;
+        // The buffer size should be large enough so that, if the CPU is busy, it doesn't
+        // become full before the execution of the transactions service resumes.
+        // The maximum number of pinned block is ignored, as this maximum is a way to avoid
+        // malicious behaviors. This code is by definition not considered malicious.
+        let mut subscribe_all = worker.runtime_service.subscribe_all(32, usize::max_value()).await;
         let initial_finalized_block_hash = header::hash_from_scale_encoded_header(
             &subscribe_all.finalized_block_scale_encoded_header,
         );

--- a/bin/light-base/src/transactions_service.rs
+++ b/bin/light-base/src/transactions_service.rs
@@ -322,7 +322,10 @@ async fn background_task<TPlat: Platform>(
         // become full before the execution of the transactions service resumes.
         // The maximum number of pinned block is ignored, as this maximum is a way to avoid
         // malicious behaviors. This code is by definition not considered malicious.
-        let mut subscribe_all = worker.runtime_service.subscribe_all(32, usize::max_value()).await;
+        let mut subscribe_all = worker
+            .runtime_service
+            .subscribe_all(32, usize::max_value())
+            .await;
         let initial_finalized_block_hash = header::hash_from_scale_encoded_header(
             &subscribe_all.finalized_block_scale_encoded_header,
         );

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - No longer panic if passed a chain specification containing an invalid bootnode address. Because the specification of the format of a multiaddress is flexible, invalid bootnode addresses do not trigger a hard error but instead are ignored and a warning is printed. ([#2207](https://github.com/paritytech/smoldot/pull/2207))
+- Fix several potential infinite loops when finality lags behind too much ([#2215](https://github.com/paritytech/smoldot/pull/2215)).
 
 ## 0.6.13 - 2022-04-05
 


### PR DESCRIPTION
Fix https://github.com/paritytech/smoldot/issues/1920

This PR tweaks the calls to `RuntimeService::subscribe_all` to pass `usize::max_value()` for the maximum number of pinned blocks in situations where it is appropriate.
As a second minor change, this PR also adjusts all the buffer sizes to 32 in these situations.

## Context

The runtime service has a mechanism of "pinned blocks".
When the runtime service reports a new block, this block stays pinned in the memory of the runtime service and must later be unpinned. While a block is pinned, one can start runtime calls against this block.

The same logic of pinned blocks exists in the publicly-exposed JSON-RPC API. When a JSON-RPC client subscribes to blocks, these blocks stay pinned to guarantee that the client can access information about them, and must then be manually unpinned by the client.

This leads to a problem: a JSON-RPC client could simply never unpin blocks and grow the memory of the node forever.
To counter-act this, each subscription in the runtime service has a maximum number of pinned blocks. If any subscription grows over this limit, this subscription gets killed. In the case of the JSON-RPC API, this subscription being killed leads to a notification of type "dead" being sent to the client so that the client must resubscribe.

But this maximum number of pinned blocks has a flaw in its design: if you start a subscription with a maximum of N pinned blocks, and there's already more than N non-finalized blocks to report, then the subscription gets killed immediately.
Some pieces of code, such as the transactions service, react to a subscription being killed by resubscribing immediately. But doing so doesn't solve the problem, as this new subscription will also get killed immediately, and the service will be stuck in an infinite loop.

Because this maximum number of pinned blocks is a mechanism against malicious behavior, and that our own code is by definition not malicious (it properly unpins blocks), we're now passing `usize::max_value()` for the maximum number of pinned blocks, effectively removing any maximum.

There is still a problem, though: when a JSON-RPC client subscribes, the maximum number of pinned blocks is set to an arbitrary constant of 48. Of course this limit shouldn't be decided by the JSON-RPC client, as the point of this limit is precisely to prevent the client from doing stupid things. The same problem as described above can then happen: if there are already more than 48 non-finalized blocks, the subscription will be killed immediately. Fortunately this will not result in an infinite loop, but is still kind of crappy.
For this I've added a TODO and will figure out later how to adjust the API. I think that `subscribe_all` could automatically add the current number of non-finalized blocks to the provided limit.
In any case, passing `usize::max_value()` would still be the correct thing to do for non-malicious code.
