### PR TITLE
Yield between each request in the JSON-RPC service

### DIFF
--- a/bin/light-base/src/json_rpc_service.rs
+++ b/bin/light-base/src/json_rpc_service.rs
@@ -572,7 +572,11 @@ impl<TPlat: Platform> Background<TPlat> {
             tasks.push(
                 async move {
                     loop {
-                        me.handle_request().await
+                        me.handle_request().await;
+
+                        // We yield once between each request in order to politely let other tasks
+                        // do some work and not monopolize the CPU.
+                        crate::util::yield_once().await;
                     }
                 }
                 .boxed(),


### PR DESCRIPTION
In situations where there are many JSON-RPC requests queued up, the JSON-RPC service will currently process them all in a row without giving the chance to other tasks to do some work.

This PR changes that by yielding between each request.

Note that since there's a maximum number of requests that can be queued up, and that while the node is busy no new request can be queued up (new requests are queued up by pulling from a queue, which can't happen if we don't yield), this is not a way to DoS the node.
What this PR does is merely make sure that the tasks are properly interleaved and that the node can't "freeze" for long periods of time.
