### PR TITLE
Implement trie version 1

### DIFF
--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -822,7 +822,11 @@ impl<'a> RuntimeCallLock<'a> {
             })
             .map_err(RuntimeCallError::StorageRetrieval)?;
 
-            if node_info.storage_value.is_some() {
+            if matches!(
+                node_info.storage_value,
+                proof_verify::StorageValue::Known(_)
+                    | proof_verify::StorageValue::HashKnownValueMissing(_)
+            ) {
                 assert_eq!(key.len() % 2, 0);
                 output.push(trie::nibbles_to_bytes_extend(key.iter().copied()).collect::<Vec<_>>());
             }

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added support for version 1 of the trie. Previously, it wasn't possible to connect to chains that were using version 1. ([#2277](https://github.com/paritytech/smoldot/pull/2277))
+
 ### Changed
 
 - The runtime of the genesis block is now only compiled once when a chain is added, decreasing the time this operation takes. ([#2270](https://github.com/paritytech/smoldot/pull/2270))

--- a/src/executor/runtime_host.rs
+++ b/src/executor/runtime_host.rs
@@ -39,7 +39,7 @@
 
 use crate::{
     executor::{self, host, storage_diff, vm},
-    trie::calculate_root,
+    trie::{self, calculate_root},
     util,
 };
 
@@ -259,7 +259,9 @@ impl StorageGet {
                 if let calculate_root::RootMerkleValueCalculation::StorageValue(value_request) =
                     self.inner.root_calculation.take().unwrap()
                 {
-                    self.inner.root_calculation = Some(value_request.inject(value));
+                    // TODO: we only support V0 for now, see https://github.com/paritytech/smoldot/issues/1967
+                    self.inner.root_calculation =
+                        Some(value_request.inject(trie::TrieEntryVersion::V0, value));
                 } else {
                     // We only create a `StorageGet` if the state is `StorageValue`.
                     panic!()
@@ -621,7 +623,9 @@ impl Inner {
                                 .top_trie_changes
                                 .diff_get(&value_request.key().collect::<Vec<_>>())
                             {
-                                self.root_calculation = Some(value_request.inject(overlay));
+                                // TODO: we only support V0 for now, see https://github.com/paritytech/smoldot/issues/1967
+                                self.root_calculation =
+                                    Some(value_request.inject(trie::TrieEntryVersion::V0, overlay));
                             } else {
                                 self.root_calculation =
                                     Some(calculate_root::RootMerkleValueCalculation::StorageValue(

--- a/src/header.rs
+++ b/src/header.rs
@@ -116,7 +116,8 @@ pub fn hash_from_scale_encoded_header_vectored(
 /// Returns the value appropriate for [`Header::extrinsics_root`]. Must be passed the list of
 /// transactions in that block.
 pub fn extrinsics_root(transactions: &[impl AsRef<[u8]>]) -> [u8; 32] {
-    trie::ordered_root(transactions)
+    // The extrinsics root is always calculated with V0 of the trie.
+    trie::ordered_root(trie::TrieEntryVersion::V0, transactions)
 }
 
 /// Attempt to decode the given SCALE-encoded header.

--- a/src/trie/calculate_root.rs
+++ b/src/trie/calculate_root.rs
@@ -28,7 +28,7 @@
 //!
 //! ```
 //! use std::collections::BTreeMap;
-//! use smoldot::trie::calculate_root;
+//! use smoldot::trie::{TrieEntryVersion, calculate_root};
 //!
 //! // In this example, the storage consists in a binary tree map.
 //! let mut storage = BTreeMap::<Vec<u8>, Vec<u8>>::new();
@@ -44,7 +44,7 @@
 //!             }
 //!             calculate_root::RootMerkleValueCalculation::StorageValue(value_request) => {
 //!                 let key = value_request.key().collect::<Vec<u8>>();
-//!                 calculation = value_request.inject(storage.get(&key));
+//!                 calculation = value_request.inject(TrieEntryVersion::V1, storage.get(&key));
 //!             }
 //!         }
 //!     }

--- a/src/trie/node_value.rs
+++ b/src/trie/node_value.rs
@@ -23,7 +23,7 @@
 //! # Example
 //!
 //! ```
-//! use smoldot::trie::{Nibble, node_value};
+//! use smoldot::trie::{Nibble, TrieEntryVersion, node_value};
 //!
 //! let merkle_value = {
 //!     // The example node whose value we calculate has three children.
@@ -55,6 +55,7 @@
 //!         },
 //!         children: children.iter().map(|opt| opt.as_ref()),
 //!         stored_value: Some(b"hello world"),
+//!         version: TrieEntryVersion::V1,
 //!     })
 //! };
 //!

--- a/src/trie/node_value.rs
+++ b/src/trie/node_value.rs
@@ -158,6 +158,7 @@ where
     // Push the header of the node to `merkle_value_sink`.
     {
         // The most significant bits of the header contain the type of node.
+        // See https://spec.polkadot.network/#defn-node-header
         let (header_msb, header_pkll_num_bytes): (u8, u8) =
             match (stored_value_to_be_hashed, has_children) {
                 (None, false) => {

--- a/src/trie/node_value.rs
+++ b/src/trie/node_value.rs
@@ -216,19 +216,16 @@ where
         if let Some(hash_stored_value) = stored_value_to_be_hashed {
             let stored_value = config.stored_value.unwrap();
 
-            // Doing something like `merkle_value_sink.update(stored_value.encode());` would be
-            // quite expensive because we would duplicate the storage value. Instead, we do the
-            // encoding manually by pushing the length then the value.
-            if !hash_stored_value {
-                merkle_value_sink
-                    .update(util::encode_scale_compact_usize(stored_value.as_ref().len()).as_ref());
-            }
-
             if hash_stored_value {
                 merkle_value_sink.update(
                     blake2_rfc::blake2b::blake2b(32, &[], stored_value.as_ref()).as_bytes(),
                 );
             } else {
+                // Doing something like `merkle_value_sink.update(stored_value.encode());` would be
+                // quite expensive because we would duplicate the storage value. Instead, we do the
+                // encoding manually by pushing the length then the value.
+                merkle_value_sink
+                    .update(util::encode_scale_compact_usize(stored_value.as_ref().len()).as_ref());
                 merkle_value_sink.update(stored_value.as_ref());
             }
         }
@@ -251,18 +248,15 @@ where
     if let Some(hash_stored_value) = stored_value_to_be_hashed {
         let stored_value = config.stored_value.unwrap();
 
-        // Doing something like `merkle_value_sink.update(stored_value.encode());` would be
-        // quite expensive because we would duplicate the storage value. Instead, we do the
-        // encoding manually by pushing the length then the value.
-        if !hash_stored_value {
-            merkle_value_sink
-                .update(util::encode_scale_compact_usize(stored_value.as_ref().len()).as_ref());
-        }
-
         if hash_stored_value {
             merkle_value_sink
                 .update(blake2_rfc::blake2b::blake2b(32, &[], stored_value.as_ref()).as_bytes());
         } else {
+            // Doing something like `merkle_value_sink.update(stored_value.encode());` would be
+            // quite expensive because we would duplicate the storage value. Instead, we do the
+            // encoding manually by pushing the length then the value.
+            merkle_value_sink
+                .update(util::encode_scale_compact_usize(stored_value.as_ref().len()).as_ref());
             merkle_value_sink.update(stored_value.as_ref());
         }
     }

--- a/src/trie/prefix_proof.rs
+++ b/src/trie/prefix_proof.rs
@@ -102,7 +102,11 @@ impl PrefixScan {
 
                 any_successful_proof = true;
 
-                if info.storage_value.is_some() {
+                if matches!(
+                    info.storage_value,
+                    proof_verify::StorageValue::Known(_)
+                        | proof_verify::StorageValue::HashKnownValueMissing(_)
+                ) {
                     // Trie nodes with a value are always aligned to "bytes-keys". In other words,
                     // the number of nibbles is always even.
                     debug_assert_eq!(query.len() % 2, 0);

--- a/src/trie/proof_node_decode.rs
+++ b/src/trie/proof_node_decode.rs
@@ -186,7 +186,7 @@ impl<'a> Decoded<'a> {
     }
 }
 
-/// See [`Decoded::StorageValue`].
+/// See [`Decoded::storage_value`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum StorageValue<'a> {
     /// Storage value of the item is present in the node value.

--- a/src/trie/proof_node_decode.rs
+++ b/src/trie/proof_node_decode.rs
@@ -41,7 +41,7 @@ pub fn decode(mut node_value: &[u8]) -> Result<Decoded, Error> {
         0b10 => (true, None, 6),
         0b01 => (false, Some(false), 6),
         0b11 => (true, Some(false), 6),
-        _ => unreachable!()
+        _ => unreachable!(),
     };
 
     // Length of the partial key, in nibbles.

--- a/src/trie/proof_node_decode.rs
+++ b/src/trie/proof_node_decode.rs
@@ -26,6 +26,7 @@ pub fn decode(mut node_value: &[u8]) -> Result<Decoded, Error> {
         return Err(Error::Empty);
     }
 
+    // See https://spec.polkadot.network/#defn-node-header
     let (has_children, storage_value_hashed, pk_len_first_byte_bits) = match node_value[0] >> 6 {
         0b00 => {
             if (node_value[0] >> 5) == 0b001 {

--- a/src/trie/proof_node_decode.rs
+++ b/src/trie/proof_node_decode.rs
@@ -19,19 +19,36 @@ use super::nibble;
 use core::{fmt, iter, slice};
 
 /// Decodes a node value found in a proof into its components.
+///
+/// This can decode nodes no matter their version.
 pub fn decode(mut node_value: &[u8]) -> Result<Decoded, Error> {
     if node_value.is_empty() {
         return Err(Error::Empty);
     }
 
-    let has_children = (node_value[0] & 0x80) != 0;
-    let has_storage_value = (node_value[0] & 0x40) != 0;
+    let (has_children, storage_value_hashed, pk_len_first_byte_bits) = match node_value[0] >> 6 {
+        0b00 => {
+            if (node_value[0] >> 5) == 0b001 {
+                (false, Some(true), 5)
+            } else if (node_value[0] >> 4) == 0b0001 {
+                (true, Some(true), 4)
+            } else if node_value[0] == 0 {
+                (false, None, 6)
+            } else {
+                return Err(Error::InvalidHeaderBits);
+            }
+        }
+        0b10 => (true, None, 6),
+        0b01 => (false, Some(false), 6),
+        0b11 => (true, Some(false), 6),
+        _ => unreachable!()
+    };
 
     // Length of the partial key, in nibbles.
     let pk_len = {
-        let mut accumulator = usize::from(node_value[0] & 0b11_1111);
+        let mut accumulator = usize::from(node_value[0] & ((1 << pk_len_first_byte_bits) - 1));
         node_value = &node_value[1..];
-        let mut continue_iter = accumulator == 63;
+        let mut continue_iter = accumulator == ((1 << pk_len_first_byte_bits) - 1);
         while continue_iter {
             if node_value.is_empty() {
                 return Err(Error::PartialKeyLenTooShort);
@@ -79,19 +96,28 @@ pub fn decode(mut node_value: &[u8]) -> Result<Decoded, Error> {
         0
     };
 
-    let storage_value = if has_storage_value {
-        // Now at the value that interests us.
-        let (node_value_update, len) = crate::util::nom_scale_compact_usize(node_value)
-            .map_err(|_: nom::Err<nom::error::Error<&[u8]>>| Error::StorageValueLenDecode)?;
-        node_value = node_value_update;
-        if node_value.len() < len {
-            return Err(Error::StorageValueTooShort);
+    // Now at the value that interests us.
+    let storage_value = match storage_value_hashed {
+        Some(false) => {
+            let (node_value_update, len) = crate::util::nom_scale_compact_usize(node_value)
+                .map_err(|_: nom::Err<nom::error::Error<&[u8]>>| Error::StorageValueLenDecode)?;
+            node_value = node_value_update;
+            if node_value.len() < len {
+                return Err(Error::StorageValueTooShort);
+            }
+            let storage_value = &node_value[..len];
+            node_value = &node_value[len..];
+            StorageValue::Unhashed(storage_value)
         }
-        let storage_value = &node_value[..len];
-        node_value = &node_value[len..];
-        Some(storage_value)
-    } else {
-        None
+        Some(true) => {
+            if node_value.len() < 32 {
+                return Err(Error::StorageValueTooShort);
+            }
+            let storage_value_hash = <&[u8; 32]>::try_from(&node_value[..32]).unwrap();
+            node_value = &node_value[32..];
+            StorageValue::Hashed(storage_value_hash)
+        }
+        None => StorageValue::None,
     };
 
     let mut children = [None; 16];
@@ -142,8 +168,8 @@ pub struct Decoded<'a> {
     ///
     pub children: [Option<&'a [u8]>; 16],
 
-    /// Storage value of this node, or `None` if there is no storage value.
-    pub storage_value: Option<&'a [u8]>,
+    /// Storage value of this node.
+    pub storage_value: StorageValue<'a>,
 }
 
 impl<'a> Decoded<'a> {
@@ -158,6 +184,17 @@ impl<'a> Decoded<'a> {
         }
         out
     }
+}
+
+/// See [`Decoded::StorageValue`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum StorageValue<'a> {
+    /// Storage value of the item is present in the node value.
+    Unhashed(&'a [u8]),
+    /// Blake2 hash of the storage value of the item is present in the node value.
+    Hashed(&'a [u8; 32]),
+    /// Item doesn't have any storage value.
+    None,
 }
 
 /// Iterator to the nibbles of the partial key. See [`Decoded::partial_key`].
@@ -210,6 +247,8 @@ impl<'a> fmt::Debug for PartialKey<'a> {
 pub enum Error {
     /// Node value is empty.
     Empty,
+    /// Bits in the header have an invalid format.
+    InvalidHeaderBits,
     /// Node value ends while parsing partial key length.
     PartialKeyLenTooShort,
     /// Length of partial key is too large to be reasonable.
@@ -253,7 +292,10 @@ mod tests {
                 nibble::Nibble::try_from(0x3).unwrap()
             ]
         );
-        assert_eq!(decoded.storage_value, Some(&[][..]));
+        assert_eq!(
+            decoded.storage_value,
+            super::StorageValue::Unhashed(&[][..])
+        );
 
         assert_eq!(decoded.children.iter().filter(|c| c.is_some()).count(), 2);
         assert_eq!(

--- a/src/trie/proof_verify.rs
+++ b/src/trie/proof_verify.rs
@@ -219,7 +219,11 @@ pub fn trie_node_info<'a, 'b>(
         } else {
             // The current node (as per `proof_iter`) exactly matches the requested key.
             return Ok(TrieNodeInfo {
-                storage_value: decoded_node_value.storage_value,
+                storage_value: match decoded_node_value.storage_value {
+                    proof_node_decode::StorageValue::Hashed(_) => todo!(), // TODO: /!\
+                    proof_node_decode::StorageValue::Unhashed(v) => Some(v),
+                    proof_node_decode::StorageValue::None => None,
+                },
                 children: Children::Multiple {
                     children_bitmap: decoded_node_value.children_bitmap(),
                 },


### PR DESCRIPTION
cc https://github.com/paritytech/smoldot/issues/1967

The first version of trie is called version 0. In version 1 of the trie, values that are longer than 32 bytes are hashed. Additionally, the header of each trie element has some additional bit patterns that indicate whether the value is hashed or not.

In order to know whether to use v0 or v1 of the trie, the runtime spec (found in the runtime) has an additional field called `state_version` (which was already parsed by smoldot since https://github.com/paritytech/smoldot/pull/1971 but ignored) indicating the version.

For this reason, it is no longer appropriate to have a standalone `calculate_genesis_block_header` function. Calculating the genesis block header requires knowing information from the genesis runtime, and building the genesis runtime is a very expensive operation. Instead, the genesis block header can now be obtained by higher-level code by building the genesis `ChainInformation`.

Note that technically each individual item of the trie is either v0 or v1. In other words, a trie can be in "hybrid" mode with some items in v0 and some items in v1. This happens if the chain was using v0 in the past and has switched to v1. When a chain switches to v1 (by modifying the `state_version` field), the updates are done lazily when items are written to the storage.
This means that Merkle proofs can also contain a hybrid of v0 and v1 items.

I have not implemented the full-node-related changes, as they are not straight forward and require some changes to the database. At the moment, the full node will error if you use it on a chain with a v1 trie or try to switch to v1. The places that need an update have been appropriately marked with `TODO`s.
