### PR TITLE
Make sure we're connected before starting requests

### DIFF
--- a/bin/full-node/src/run/consensus_service.rs
+++ b/bin/full-node/src/run/consensus_service.rs
@@ -37,7 +37,7 @@ use smoldot::{
     identity::keystore,
     informant::HashDisplay,
     libp2p,
-    network::{self, protocol::BlockData, service::BlocksRequestError},
+    network::{self, protocol::BlockData},
     sync::all,
 };
 use std::{
@@ -323,7 +323,10 @@ struct SyncBackground {
             'static,
             (
                 all::RequestId,
-                Result<Result<Vec<BlockData>, BlocksRequestError>, future::Aborted>,
+                Result<
+                    Result<Vec<BlockData>, network_service::BlocksRequestError>,
+                    future::Aborted,
+                >,
             ),
         >,
     >,

--- a/bin/full-node/src/run/network_service.rs
+++ b/bin/full-node/src/run/network_service.rs
@@ -529,19 +529,17 @@ impl NetworkService {
         is_best: bool,
     ) -> Result<(), QueueNotificationError> {
         let mut guarded = self.inner.guarded.lock().await;
-    
+
         // The call to `send_block_announce` below panics if we have no active connection.
         // TODO: not the correct check; must make sure that we have a substream open
         if !guarded.network.has_established_connection(&target) {
             return Err(QueueNotificationError::NoConnection);
         }
-    
-        let result = guarded.network.send_block_announce(
-            &target,
-            chain_index,
-            scale_encoded_header,
-            is_best,
-        ).map_err(QueueNotificationError::Queue);
+
+        let result = guarded
+            .network
+            .send_block_announce(&target, chain_index, scale_encoded_header, is_best)
+            .map_err(QueueNotificationError::Queue);
 
         self.inner.wake_up_main_background_task.notify(1);
         result

--- a/bin/light-base/src/sync_service.rs
+++ b/bin/light-base/src/sync_service.rs
@@ -546,9 +546,11 @@ impl<TPlat: Platform> SyncService<TPlat> {
             match result {
                 Ok(value) if !value.is_empty() => return Ok(value),
                 // TODO: this check of emptiness is a bit of a hack; it is necessary because Substrate responds to requests about blocks it doesn't know with an empty proof
-                Ok(_) => outcome_errors.push(service::CallProofRequestError::Request(
-                    smoldot::libp2p::peers::RequestError::Substream(
-                        smoldot::libp2p::connection::established::RequestError::SubstreamClosed,
+                Ok(_) => outcome_errors.push(network_service::CallProofRequestError::Request(
+                    service::CallProofRequestError::Request(
+                        smoldot::libp2p::peers::RequestError::Substream(
+                            smoldot::libp2p::connection::established::RequestError::SubstreamClosed,
+                        ),
                     ),
                 )),
                 Err(err) => {
@@ -576,8 +578,19 @@ impl StorageQueryError {
     /// issue.
     pub fn is_network_problem(&self) -> bool {
         self.errors.iter().all(|err| match err {
-            StorageQueryErrorDetail::Network(service::StorageProofRequestError::Request(_)) => true,
-            StorageQueryErrorDetail::Network(service::StorageProofRequestError::Decode(_)) => false,
+            StorageQueryErrorDetail::Network(
+                network_service::StorageProofRequestError::Request(
+                    service::StorageProofRequestError::Request(_),
+                ),
+            )
+            | StorageQueryErrorDetail::Network(
+                network_service::StorageProofRequestError::NoConnection,
+            ) => true,
+            StorageQueryErrorDetail::Network(
+                network_service::StorageProofRequestError::Request(
+                    service::StorageProofRequestError::Decode(_),
+                ),
+            ) => false,
             // TODO: as a temporary hack, we consider `TrieRootNotFound` as the remote not knowing about the requested block; see https://github.com/paritytech/substrate/pull/8046
             StorageQueryErrorDetail::ProofVerification(proof_verify::Error::TrieRootNotFound) => {
                 true
@@ -606,7 +619,7 @@ impl fmt::Display for StorageQueryError {
 pub enum StorageQueryErrorDetail {
     /// Error during the network request.
     #[display(fmt = "{}", _0)]
-    Network(service::StorageProofRequestError),
+    Network(network_service::StorageProofRequestError),
     /// Error verifying the proof.
     #[display(fmt = "{}", _0)]
     ProofVerification(proof_verify::Error),
@@ -617,7 +630,7 @@ pub enum StorageQueryErrorDetail {
 pub struct CallProofQueryError {
     /// Contains one error per peer that has been contacted. If this list is empty, then we
     /// aren't connected to any node.
-    pub errors: Vec<service::CallProofRequestError>,
+    pub errors: Vec<network_service::CallProofRequestError>,
 }
 
 impl CallProofQueryError {

--- a/bin/light-base/src/sync_service/standalone.rs
+++ b/bin/light-base/src/sync_service/standalone.rs
@@ -394,7 +394,7 @@ struct Task<TPlat: Platform> {
             (
                 all::RequestId,
                 Result<
-                    Result<Vec<protocol::BlockData>, network::service::BlocksRequestError>,
+                    Result<Vec<protocol::BlockData>, network_service::BlocksRequestError>,
                     future::Aborted,
                 >,
             ),
@@ -410,7 +410,7 @@ struct Task<TPlat: Platform> {
                 Result<
                     Result<
                         protocol::GrandpaWarpSyncResponse,
-                        network::service::GrandpaWarpSyncRequestError,
+                        network_service::GrandpaWarpSyncRequestError,
                     >,
                     future::Aborted,
                 >,

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -1180,8 +1180,7 @@ where
 
         self.connections_by_peer
             .range(
-                (peer_index, ConnectionId::min_value())
-                    ..=(peer_index, ConnectionId::max_value()),
+                (peer_index, ConnectionId::min_value())..=(peer_index, ConnectionId::max_value()),
             )
             .any(|(_, established)| *established)
     }

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -1172,8 +1172,8 @@ where
     }
 
     /// Returns `true` if there exists an established connection with the given peer.
-    pub fn has_established_connection(&self, peer: &PeerId) -> bool {
-        let peer_index = match self.peer_indices.get(peer) {
+    pub fn has_established_connection(&self, peer_id: &PeerId) -> bool {
+        let peer_index = match self.peer_indices.get(peer_id) {
             Some(idx) => *idx,
             None => return false,
         };

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -1171,6 +1171,21 @@ where
         self.inner.respond_in_request(id.0, response)
     }
 
+    /// Returns `true` if there exists an established connection with the given peer.
+    pub fn has_established_connection(&self, peer: &PeerId) -> bool {
+        let peer_index = match self.peer_indices.get(peer) {
+            Some(idx) => *idx,
+            None => return false,
+        };
+
+        self.connections_by_peer
+            .range(
+                (peer_index, ConnectionId::min_value())
+                    ..=(peer_index, ConnectionId::max_value()),
+            )
+            .any(|(_, established)| *established)
+    }
+
     /// Returns an iterator to the list of [`PeerId`]s that we have an established connection
     /// with.
     pub fn peers_list(&self) -> impl Iterator<Item = &PeerId> {

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -1920,8 +1920,8 @@ where
     }
 
     /// Returns `true` if there exists an established connection with the given peer.
-    pub fn has_established_connection(&self, peer: &PeerId) -> bool {
-        self.inner.has_established_connection(peer)
+    pub fn has_established_connection(&self, peer_id: &PeerId) -> bool {
+        self.inner.has_established_connection(peer_id)
     }
 
     /// Returns an iterator to the list of [`PeerId`]s that we have an established connection

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -1919,6 +1919,11 @@ where
         None
     }
 
+    /// Returns `true` if there exists an established connection with the given peer.
+    pub fn has_established_connection(&self, peer: &PeerId) -> bool {
+        self.inner.has_established_connection(peer)
+    }
+
     /// Returns an iterator to the list of [`PeerId`]s that we have an established connection
     /// with.
     pub fn peers_list(&self) -> impl Iterator<Item = &PeerId> {


### PR DESCRIPTION
Fix https://github.com/paritytech/smoldot/issues/2295

After https://github.com/paritytech/smoldot/pull/2264, we now panic if starting a request on a peer we're not connected to because this is an invalid usage of the API.
The reason why this wouldn't panic before is because there was always a chance of a race condition where a connection started being closed in parallel of the request being started.
We simply do the check for connectivity in the network service, as it is now possible to do so.
