### PR TITLE
Decode the block number directly into a `u64` into of going through a `usize`

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -142,11 +142,9 @@ pub fn decode_partial(mut scale_encoded: &[u8]) -> Result<(HeaderRef, &[u8]), Er
     let parent_hash: &[u8; 32] = TryFrom::try_from(&scale_encoded[0..32]).unwrap();
     scale_encoded = &scale_encoded[32..];
 
-    // TODO: don't go through a usize when decoding the block number, otherwise 32 bits platforms can't support blocks about 4 billion
     let (mut scale_encoded, number) =
-        crate::util::nom_scale_compact_usize::<nom::error::Error<&[u8]>>(scale_encoded)
+        crate::util::nom_scale_compact_u64::<nom::error::Error<&[u8]>>(scale_encoded)
             .map_err(|_| Error::BlockNumberDecodeError)?;
-    let number = u64::try_from(number).map_err(|_| Error::BlockNumberDecodeError)?;
 
     if scale_encoded.len() < 32 + 32 + 1 {
         return Err(Error::TooShort);

--- a/src/util.rs
+++ b/src/util.rs
@@ -88,6 +88,8 @@ pub(crate) fn nom_bool_decode<'a, E: nom::error::ParseError<&'a [u8]>>(
     ))(bytes)
 }
 
+macro_rules! decode_scale_compact {
+    () => {
 /// Decodes a SCALE-compact-encoded `usize`.
 ///
 /// > **Note**: When using this function outside of a `nom` "context", you might have to explicit
@@ -194,6 +196,10 @@ pub(crate) fn nom_scale_compact_usize<'a, E: nom::error::ParseError<&'a [u8]>>(
         _ => unreachable!(),
     }
 }
+    };
+}
+
+decode_scale_compact!();
 
 macro_rules! encode_scale_compact {
     ($fn_name:ident, $num_ty:ty) => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -152,7 +152,7 @@ pub(crate) fn $fn_name<'a, E: nom::error::ParseError<&'a [u8]>>(
             Ok((&bytes[4..], value))
         }
         0b11 => {
-            let num_bytes = <$num_ty>::from(bytes[0] >> 2) + 4;
+            let num_bytes = usize::from(bytes[0] >> 2) + 4;
 
             if bytes.len() < num_bytes + 1 {
                 return Err(nom::Err::Error(nom::error::make_error(

--- a/src/util.rs
+++ b/src/util.rs
@@ -200,6 +200,7 @@ pub(crate) fn $fn_name<'a, E: nom::error::ParseError<&'a [u8]>>(
 }
 
 decode_scale_compact!(nom_scale_compact_usize, usize);
+decode_scale_compact!(nom_scale_compact_u64, u64);
 
 macro_rules! encode_scale_compact {
     ($fn_name:ident, $num_ty:ty) => {


### PR DESCRIPTION
Fixes a TODO in `header.rs`

Can be reviewed commit by commit