### PR TITLE
Remove obsolete TODO in chain_information

### DIFF
--- a/src/chain/chain_information.rs
+++ b/src/chain/chain_information.rs
@@ -417,8 +417,6 @@ impl<'a> ChainInformationRef<'a> {
             }
         }
 
-        // TODO: also check that babe_finalized_block_epoch_information is None if and only if block is in epoch #0
-
         Ok(())
     }
 }


### PR DESCRIPTION
The TODO refers to something that is already done. See lines 379-381 and 395-399.