### PR TITLE
Fix a panic if Noise frame length is too low

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fix a panic in case of a Noise message with an invalid length. ([#2219](https://github.com/paritytech/smoldot/pull/2219))
+- Fix a panic in case of a Noise message with an invalid length. ([#2321](https://github.com/paritytech/smoldot/pull/2321))
 
 ## 0.6.16 - 2022-05-16
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - The networking code has been considerably refactored. Due to the large size of the change it is possible that unintended changes in behaviour have been introduced. ([#2264](https://github.com/paritytech/smoldot/pull/2264))
 
+### Fixed
+
+- Fix a panic in case of a Noise message with an invalid length. ([#2219](https://github.com/paritytech/smoldot/pull/2219))
+
 ## 0.6.16 - 2022-05-16
 
 ### Added

--- a/src/libp2p/connection/noise.rs
+++ b/src/libp2p/connection/noise.rs
@@ -272,9 +272,12 @@ impl Noise {
             // Allocate the space to decode to.
             // Each frame consists of the payload plus 16 bytes of authentication data, therefore
             // the payload size is `expected_len - 16`.
+            // We use ̀`saturating_sub` in order to avoid panicking in case the `expected_len` is
+            // invalid. An invalid `expected_len` should trigger an error when decoding the
+            // message below.
             let len_before = self.rx_buffer_decrypted.len();
             self.rx_buffer_decrypted
-                .resize(len_before + expected_len - 16, 0);
+                .resize(len_before + expected_len.saturating_sub(16), 0);
 
             // Finally decoding the data.
             let written = self

--- a/src/libp2p/connection/noise.rs
+++ b/src/libp2p/connection/noise.rs
@@ -272,7 +272,7 @@ impl Noise {
             // Allocate the space to decode to.
             // Each frame consists of the payload plus 16 bytes of authentication data, therefore
             // the payload size is `expected_len - 16`.
-            // We use ̀`saturating_sub` in order to avoid panicking in case the `expected_len` is
+            // We use `saturating_sub` in order to avoid panicking in case the `expected_len` is
             // invalid. An invalid `expected_len` should trigger an error when decoding the
             // message below.
             let len_before = self.rx_buffer_decrypted.len();


### PR DESCRIPTION
The value in `expected_len` is read from an incoming networking packet. The networking packet is invalid if `expected_len < 16`, however it is unwise to do `expected_len - 16` as a malicious peer might send an invalid value on purpose.

Rust only detects underflow errors in debug mode. However, in release mode this will lead to a very high value being passed to `resize`, which will lead to an allocation error.

This bug is technically a vulnerability, as anyone can crash a smoldot light client if it connects to their node. However, since we're not widely used at the moment and that an attacker has nothing to gain except being a nuisance, I'm going to assume that nobody is going to exploit this and skip the non-disclosure period.
