### PR TITLE
Fix warning in host.rs

### DIFF
--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -486,7 +486,6 @@ pub enum HostVm {
         /// Object used to resume execution.
         resume: EndStorageTransaction,
         /// If true, changes must be rolled back.
-        #[must_use]
         rollback: bool,
     },
     /// Need to provide the maximum log level.


### PR DESCRIPTION
This warning started appearing with Rust 1.61 I believe