### PR TITLE
Better Display impl for ProtocolError

### DIFF
--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -2409,16 +2409,24 @@ pub enum StateRequestError {
 #[derive(Debug, derive_more::Display)]
 pub enum ProtocolError {
     /// Error in an incoming substream.
+    #[display(fmt = "Error in an incoming substream: {}", _0)]
     InboundError(InboundError),
     /// Error while decoding the handshake of the block announces substream.
+    #[display(
+        fmt = "Error while decoding the handshake of the block announces substream: {}",
+        _0
+    )]
     BadBlockAnnouncesHandshake(protocol::BlockAnnouncesHandshakeDecodeError),
     /// Error while decoding a received block announce.
+    #[display(fmt = "Error while decoding a received block announce: {}", _0)]
     BadBlockAnnounce(protocol::DecodeBlockAnnounceError),
     /// Error while decoding a received Grandpa notification.
+    #[display(fmt = "Error while decoding a received Grandpa notification: {}", _0)]
     BadGrandpaNotification(protocol::DecodeGrandpaNotificationError),
     /// Received an invalid identify request.
     BadIdentifyRequest,
     /// Error while decoding a received blocks request.
+    #[display(fmt = "Error while decoding a received blocks request: {}", _0)]
     BadBlocksRequest(protocol::DecodeBlockRequestError),
 }
 


### PR DESCRIPTION
The derivation with `derive_more::Display` completely erases the description when there is a single field. This is a bit annoying.