### PR TITLE
Add fake out requests system in peers.rs

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix another panic in case of a carefully-crafted LEB128 length. ([#2337](https://github.com/paritytech/smoldot/pull/2337))
 - Fix a panic when decoding a block header containing a large number of Aura authorities. ([#2338](https://github.com/paritytech/smoldot/pull/2338))
 - Fix multiple panics when decoding network messages in case where these messages were truncated. ([#2340](https://github.com/paritytech/smoldot/pull/2340), [#2355](https://github.com/paritytech/smoldot/pull/2355))
+- Fix panic when the Kademlia random discovery process initiates a request on a connection that has just started shutting down. ([#2369](https://github.com/paritytech/smoldot/pull/2369))
 
 ## 0.6.17 - 2022-05-31
 


### PR DESCRIPTION
Fix https://github.com/paritytech/smoldot/issues/2361

This PR solves a tricky problem in `peers.rs`.

A connection can be in three phases: handshaking, established, or shutting down (and, later, completely shut down, but that doesn't count as a phase because when the connection is shut down it no longer exists).
Once a connection starts its shutdown phase, it is forbidden to start new requests on this connection, but incoming notifications can still arrive.

This is not a problem in `connection.rs` because we simply indicate when a connection starts shutting down, and the upper layers of the code are aware of the fact that they shouldn't start any new request but can still receiving incoming notifications.

But in `peers.rs` this is problematic, because `peers.rs` groups together multiple connections belonging to the same peer and exposes them as just one. It is for example possible to have one connection to a peer shutting down but another connection to the same peer is still established. For this reason, `peers.rs` doesn't report shut downs, and instead simply says "we are connected to a peer" or "we are no longer connected to a peer".

But this causes another problem: if you have only one connection left and it is shutting down, should you still tell the upper API layers that you're connected? The answer is yes, otherwise it would be weird potentially receive incoming notifications from peers you are not connected to.
But if the upper API layers think that you are connected to a peer despite having only one connection that is shutting down, what happens if these upper API layers start new requests? This is the problem that this PR solves.

This PR introduces a fake requests system in `peers.rs`. When a request is started and all the connections to that peer are shutting down, we create a fake request and later report as event that the request has failed.
