### PR TITLE
Change max number of pinned blocks to max number of finalized pinned blocks

### DIFF
--- a/bin/light-base/src/json_rpc_service.rs
+++ b/bin/light-base/src/json_rpc_service.rs
@@ -57,7 +57,7 @@ use smoldot::{
 use std::{
     collections::HashMap,
     iter,
-    num::NonZeroU32,
+    num::{NonZeroU32, NonZeroUsize},
     str,
     sync::{atomic, Arc},
     time::Duration,
@@ -602,7 +602,7 @@ impl<TPlat: Platform> Background<TPlat> {
                     // malicious.
                     let mut subscribe_all = me
                         .runtime_service
-                        .subscribe_all(32, usize::max_value())
+                        .subscribe_all(32, NonZeroUsize::new(usize::max_value()).unwrap())
                         .await;
 
                     cache.subscription_id = Some(subscribe_all.new_blocks.id());

--- a/bin/light-base/src/json_rpc_service/chain_head.rs
+++ b/bin/light-base/src/json_rpc_service/chain_head.rs
@@ -33,7 +33,7 @@ use std::{
     cmp,
     collections::HashMap,
     iter,
-    num::NonZeroU32,
+    num::{NonZeroU32, NonZeroUsize},
     str,
     sync::{atomic, Arc},
     time::Duration,
@@ -379,8 +379,10 @@ impl<TPlat: Platform> Background<TPlat> {
         };
 
         let (mut subscribe_all, runtime_subscribe_all) = if runtime_updates {
-            // TODO: it is possible that the maximum number of pinned blocks is lower than the current number of finalized blocks; the logic of subscribe_all should be slightly changed to avoid this situation
-            let subscribe_all = self.runtime_service.subscribe_all(32, 48).await;
+            let subscribe_all = self
+                .runtime_service
+                .subscribe_all(32, NonZeroUsize::new(32).unwrap())
+                .await;
             let id = subscribe_all.new_blocks.id();
             (either::Left(subscribe_all), Some(id))
         } else {

--- a/bin/light-base/src/json_rpc_service/getters.rs
+++ b/bin/light-base/src/json_rpc_service/getters.rs
@@ -24,7 +24,7 @@ use smoldot::{
     json_rpc::{methods, requests_subscriptions},
     network::protocol,
 };
-use std::{str, sync::Arc};
+use std::{num::NonZeroUsize, str, sync::Arc};
 
 impl<TPlat: Platform> Background<TPlat> {
     /// Handles a call to [`methods::MethodCall::chain_getFinalizedHead`].
@@ -38,7 +38,7 @@ impl<TPlat: Platform> Background<TPlat> {
             header::hash_from_scale_encoded_header(
                 &self
                     .runtime_service
-                    .subscribe_all(16, 32)
+                    .subscribe_all(16, NonZeroUsize::new(24).unwrap())
                     .await
                     .finalized_block_scale_encoded_header,
             ),

--- a/bin/light-base/src/json_rpc_service/state_chain.rs
+++ b/bin/light-base/src/json_rpc_service/state_chain.rs
@@ -30,7 +30,7 @@ use smoldot::{
 };
 use std::{
     iter,
-    num::NonZeroU32,
+    num::{NonZeroU32, NonZeroUsize},
     str,
     sync::{atomic, Arc},
     time::Duration,
@@ -403,7 +403,7 @@ impl<TPlat: Platform> Background<TPlat> {
             // malicious behaviors. This code is by definition not considered malicious.
             let subscribe_all = self
                 .runtime_service
-                .subscribe_all(32, usize::max_value())
+                .subscribe_all(32, NonZeroUsize::new(usize::max_value()).unwrap())
                 .await;
 
             // The finalized and already-known blocks aren't reported to the user, but we need

--- a/bin/light-base/src/json_rpc_service/state_chain/sub_utils.rs
+++ b/bin/light-base/src/json_rpc_service/state_chain/sub_utils.rs
@@ -25,7 +25,7 @@ use crate::{
 
 use futures::prelude::*;
 use smoldot::{executor, header};
-use std::sync::Arc;
+use std::{num::NonZeroUsize, sync::Arc};
 
 /// Returns the current runtime version, plus an unlimited stream that produces one item every
 /// time the specs of the runtime of the best block are changed.
@@ -43,7 +43,9 @@ pub async fn subscribe_runtime_version<TPlat: Platform>(
     stream::BoxStream<'static, Result<executor::CoreVersion, RuntimeError>>,
 ) {
     let mut master_stream = stream::unfold(runtime_service.clone(), |runtime_service| async move {
-        let subscribe_all = runtime_service.subscribe_all(16, 32).await;
+        let subscribe_all = runtime_service
+            .subscribe_all(16, NonZeroUsize::new(24).unwrap())
+            .await;
 
         // Map of runtimes by hash. Contains all non-finalized blocks runtimes.
         let mut non_finalized_headers = hashbrown::HashMap::<
@@ -202,7 +204,9 @@ pub async fn subscribe_finalized<TPlat: Platform>(
     runtime_service: &Arc<RuntimeService<TPlat>>,
 ) -> (Vec<u8>, stream::BoxStream<'static, Vec<u8>>) {
     let mut master_stream = stream::unfold(runtime_service.clone(), |runtime_service| async move {
-        let subscribe_all = runtime_service.subscribe_all(16, 48).await;
+        let subscribe_all = runtime_service
+            .subscribe_all(16, NonZeroUsize::new(32).unwrap())
+            .await;
 
         // Map of block headers by hash. Contains all non-finalized blocks headers.
         let mut non_finalized_headers =
@@ -282,7 +286,9 @@ pub async fn subscribe_best<TPlat: Platform>(
     runtime_service: &Arc<RuntimeService<TPlat>>,
 ) -> (Vec<u8>, stream::BoxStream<'static, Vec<u8>>) {
     let mut master_stream = stream::unfold(runtime_service.clone(), |runtime_service| async move {
-        let subscribe_all = runtime_service.subscribe_all(16, 48).await;
+        let subscribe_all = runtime_service
+            .subscribe_all(16, NonZeroUsize::new(32).unwrap())
+            .await;
 
         // Map of block headers by hash. Contains all non-finalized blocks headers.
         let mut non_finalized_headers =

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -29,7 +29,13 @@ use smoldot::{
     network::protocol,
     sync::{all_forks::sources, para},
 };
-use std::{collections::HashMap, iter, num::NonZeroU32, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    iter,
+    num::{NonZeroU32, NonZeroUsize},
+    sync::Arc,
+    time::Duration,
+};
 
 /// Starts a sync service background task to synchronize a parachain.
 pub(super) async fn start_parachain<TPlat: Platform>(
@@ -74,8 +80,9 @@ pub(super) async fn start_parachain<TPlat: Platform>(
         // become full before the execution of the sync service resumes.
         // The maximum number of pinned block is ignored, as this maximum is a way to avoid
         // malicious behaviors. This code is by definition not considered malicious.
-        let mut relay_chain_subscribe_all =
-            relay_chain_sync.subscribe_all(32, usize::max_value()).await;
+        let mut relay_chain_subscribe_all = relay_chain_sync
+            .subscribe_all(32, NonZeroUsize::new(usize::max_value()).unwrap())
+            .await;
         log::debug!(
             target: &log_target,
             "RelayChain => NewSubscription(finalized_hash={})",

--- a/bin/light-base/src/transactions_service.rs
+++ b/bin/light-base/src/transactions_service.rs
@@ -78,7 +78,13 @@ use smoldot::{
     network::protocol,
     transactions::{light_pool, validate},
 };
-use std::{cmp, iter, marker::PhantomData, num::NonZeroU32, sync::Arc, time::Duration};
+use std::{
+    cmp, iter,
+    marker::PhantomData,
+    num::{NonZeroU32, NonZeroUsize},
+    sync::Arc,
+    time::Duration,
+};
 
 /// Configuration for a [`TransactionsService`].
 pub struct Config<TPlat: Platform> {
@@ -326,7 +332,7 @@ async fn background_task<TPlat: Platform>(
         // malicious behaviors. This code is by definition not considered malicious.
         let mut subscribe_all = worker
             .runtime_service
-            .subscribe_all(32, usize::max_value())
+            .subscribe_all(32, NonZeroUsize::new(usize::max_value()).unwrap())
             .await;
         let initial_finalized_block_hash = header::hash_from_scale_encoded_header(
             &subscribe_all.finalized_block_scale_encoded_header,


### PR DESCRIPTION
Close https://github.com/paritytech/smoldot/issues/2217

As suggested here: https://github.com/paritytech/smoldot/pull/2215#issuecomment-1091100870

Since the user can't control the number of non-finalized blocks, it makes sense for the non-finalized blocks to not be counted towards the limit. It is entirely smoldot's fault if the number of non-finalized blocks becomes too high (well, it might be because of a problem with the chain itself, but basically it's smoldot's problem and not the JSON-RPC client's problem).

Note that this doesn't require any change to https://github.com/paritytech/json-rpc-interface-spec/, as the number of pinned blocks is at the discretion of the implementation.