### PR TITLE
Update Rust to v1.61

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
   test-64bits:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.60
+      image: rust:1.61
     steps:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v1
@@ -36,7 +36,7 @@ jobs:
   test-32bits:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.60
+      image: rust:1.61
     steps:
     - run: apt-get update && apt install -y libc6-dev-i386
     - uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
   wasm-node-check:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.60
+      image: rust:1.61
     steps:
     - run: apt-get update && apt install -y binaryen # For `wasm-opt`
     - uses: actions/checkout@v3
@@ -60,7 +60,7 @@ jobs:
   wasm-node-size-diff:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.60
+      image: rust:1.61
     steps:
     - run: apt-get update && apt install -y cmake # TODO: remove; temporarily needed to build the `prost-build` library in the "before" comparison
     - uses: actions/checkout@v3
@@ -95,7 +95,7 @@ jobs:
   check-features:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.60
+      image: rust:1.61
     steps:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v1
@@ -126,7 +126,7 @@ jobs:
   check-rustdoc-links:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.60
+      image: rust:1.61
     steps:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
   npm-publish:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.60
+      image: rust:1.61
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.3.0

--- a/bin/wasm-node/javascript/prepare.js
+++ b/bin/wasm-node/javascript/prepare.js
@@ -39,7 +39,7 @@ if (buildProfile != 'debug' && buildProfile != 'min-size-release')
 // The Rust version is pinned because the wasi target is still unstable. Without pinning, it is
 // possible for the wasm-js bindings to change between two Rust versions. Feel free to update
 // this version pin whenever you like, provided it continues to build.
-const rustVersion = '1.60.0';
+const rustVersion = '1.61.0';
 
 // Assume that the user has `rustup` installed and make sure that `rust_version` is available.
 // Because `rustup install` requires an Internet connection, check whether the toolchain is


### PR DESCRIPTION
I've encountered a very annoying bug with incremental compilation on Rust 1.60 where you get very weird compilation errors that go away if you do a `cargo clean`. Upgrading to Rust 1.61 seems to fix it.