### PR TITLE
Fix panic with unpinning pruned blocks

### DIFF
--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -310,8 +310,7 @@ impl<TPlat: Platform> RuntimeService<TPlat> {
             0 | 1
         ));
 
-        all_blocks_subscriptions
-            .insert(subscription_id, (tx, max_pinned_blocks.get() - 1));
+        all_blocks_subscriptions.insert(subscription_id, (tx, max_pinned_blocks.get() - 1));
 
         SubscribeAll {
             finalized_block_scale_encoded_header: finalized_block.scale_encoded_header.clone(),

--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -182,12 +182,12 @@ impl<TPlat: Platform> RuntimeService<TPlat> {
     /// Only up to `buffer_size` block notifications are buffered in the channel. If the channel
     /// is full when a new notification is attempted to be pushed, the channel gets closed.
     ///
-    /// A maximum number of finalized or non-canonical pinned blocks must be passed, indicating
-    /// the maximum number of blocks that are finalized or non-canonical that the runtime service
-    /// will pin at the same time for this subscription. If this maximum is reached, the channel
-    /// will get closed. In situations where the subscriber is guaranteed to always properly
-    /// unpin blocks, a value of  `usize::max_value()` can be passed in order to ignore this
-    /// maximum.
+    /// A maximum number of finalized or non-canonical (i.e. not part of the finalized chain)
+    /// pinned blocks must be passed, indicating the maximum number of blocks that are finalized
+    /// or non-canonical that the runtime service will pin at the same time for this subscription.
+    /// If this maximum is reached, the channel will get closed. In situations where the subscriber
+    /// is guaranteed to always properly unpin blocks, a value of  `usize::max_value()` can be
+    /// passed in order to ignore this maximum.
     ///
     /// The channel also gets closed if a gap in the finality happens, such as after a Grandpa
     /// warp syncing.

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix panic introduced in v0.6.18 in case of a fork in the chain related to tracking the number of blocks kept alive in the node's memory. ([#2386](https://github.com/paritytech/smoldot/pull/2386))
+
 ## 0.6.18 - 2022-06-14
 
 ### Added


### PR DESCRIPTION
Fixes a panic introduced in https://github.com/paritytech/smoldot/pull/2373

Imagine the following situation:
Block A has two children: block B and block C. The latest finalized block is currently block A. All three blocks are pinned.

Now, imagine that block B gets finalized. Block A, B, and C all stay pinned. The number of pinned blocks remaining is decreased by 1.

When the user then unpins block C, we check `height(block_C) <= height(current_finalized_block)`, which returns `true`, and we add 1 to the number of pinned blocks remaining.
When the user then unpins block A, the same happens, and we add 1 again to the number of pinned blocks remaining.

This leads to an overflow when that number of pinned blocks is `usize::max_value()`.


This PR fixes this problem by tracking in `pinned_blocks` whether the block counts towards the limit.

