### PR TITLE
Properly save justifications and GrandPa commits for later

### DIFF
--- a/bin/full-node/src/run/network_service.rs
+++ b/bin/full-node/src/run/network_service.rs
@@ -916,10 +916,11 @@ async fn update_round(inner: &Arc<Inner>, event_senders: &mut [mpsc::Sender<Even
                 }
                 service::Event::GrandpaCommitMessage {
                     chain_index,
+                    peer_id,
                     message,
                 } => {
                     tracing::debug!(
-                        %chain_index,
+                        %chain_index, %peer_id,
                         target_hash = %HashDisplay(message.decode().message.target_hash),
                         "grandpa-commit-message"
                     );

--- a/bin/light-base/src/network_service.rs
+++ b/bin/light-base/src/network_service.rs
@@ -829,6 +829,7 @@ pub enum Event {
     },
     /// Received a GrandPa commit message from the network.
     GrandpaCommitMessage {
+        peer_id: PeerId,
         chain_index: usize,
         message: service::EncodedGrandpaCommitMessage,
     },
@@ -1159,6 +1160,7 @@ async fn update_round<TPlat: Platform>(
                 }
                 service::Event::GrandpaCommitMessage {
                     chain_index,
+                    peer_id,
                     message,
                 } => {
                     log::debug!(
@@ -1169,6 +1171,7 @@ async fn update_round<TPlat: Platform>(
                     );
                     break Event::GrandpaCommitMessage {
                         chain_index,
+                        peer_id,
                         message,
                     };
                 }

--- a/bin/light-base/src/sync_service/standalone.rs
+++ b/bin/light-base/src/sync_service/standalone.rs
@@ -95,7 +95,7 @@ pub(super) async fn start_standalone_chain<TPlat: Platform>(
 
     // Main loop of the syncing logic.
     //
-    // This loop contains some CPU-heavy operations (e.g. verifying justifications and warp sync
+    // This loop contains some CPU-heavy operations (e.g. verifying finality proofs and warp sync
     // proofs) but also responding to messages sent by the foreground sync service. In order to
     // avoid long delays in responding to foreground messages, the CPU-heavy operations are split
     // into small chunks, and each iteration of the loop processes at most one of these chunks and
@@ -575,7 +575,7 @@ impl<TPlat: Platform> Task<TPlat> {
         true
     }
 
-    /// Verifies one block, or justification, or warp sync fragment, etc. that is queued for
+    /// Verifies one block, or finality proof, or warp sync fragment, etc. that is queued for
     /// verification.
     ///
     /// Returns `self` and a boolean indicating whether something has been processed.
@@ -748,12 +748,12 @@ impl<TPlat: Platform> Task<TPlat> {
                 }
             }
 
-            all::ProcessOne::VerifyJustification(verify) => {
-                // Justification to verify.
+            all::ProcessOne::VerifyFinalityProof(verify) => {
+                // Finality proof to verify.
                 match verify.perform() {
                     (
                         sync,
-                        all::JustificationVerifyOutcome::NewFinalized {
+                        all::FinalityProofVerifyOutcome::NewFinalized {
                             updates_best_block,
                             finalized_blocks,
                             ..
@@ -763,7 +763,7 @@ impl<TPlat: Platform> Task<TPlat> {
 
                         log::debug!(
                             target: &self.log_target,
-                            "Sync => JustificationVerified(finalized_blocks={})",
+                            "Sync => FinalityProofVerified(finalized_blocks={})",
                             finalized_blocks.len(),
                         );
 
@@ -778,10 +778,18 @@ impl<TPlat: Platform> Task<TPlat> {
                         });
                     }
 
-                    (sync, all::JustificationVerifyOutcome::Error(error)) => {
+                    (
+                        sync,
+                        all::FinalityProofVerifyOutcome::AlreadyFinalized
+                        | all::FinalityProofVerifyOutcome::GrandpaCommitPending,
+                    ) => {
+                        self.sync = sync;
+                    }
+
+                    (sync, all::FinalityProofVerifyOutcome::JustificationError(error)) => {
                         self.sync = sync;
 
-                        // TODO: print which peer sent the justification
+                        // TODO: print which peer sent the proof
                         log::debug!(
                             target: &self.log_target,
                             "Sync => JustificationVerificationError(error={:?})",
@@ -791,6 +799,23 @@ impl<TPlat: Platform> Task<TPlat> {
                         log::warn!(
                             target: &self.log_target,
                             "Error while verifying justification: {}",
+                            error
+                        );
+                    }
+
+                    (sync, all::FinalityProofVerifyOutcome::GrandpaCommitError(error)) => {
+                        self.sync = sync;
+
+                        // TODO: print which peer sent the proof
+                        log::debug!(
+                            target: &self.log_target,
+                            "Sync => GrandpaCommitVerificationError(error={:?})",
+                            error,
+                        );
+
+                        log::warn!(
+                            target: &self.log_target,
+                            "Error while verifying GrandPa commit: {}",
                             error
                         );
                     }
@@ -1032,9 +1057,14 @@ impl<TPlat: Platform> Task<TPlat> {
 
             network_service::Event::GrandpaCommitMessage {
                 chain_index,
+                peer_id,
                 message,
             } if chain_index == self.network_chain_index => {
-                match self.sync.grandpa_commit_message(&message.as_encoded()) {
+                let sync_source_id = *self.peers_source_id_map.get(&peer_id).unwrap();
+                match self
+                    .sync
+                    .grandpa_commit_message(sync_source_id, &message.as_encoded())
+                {
                     Ok(()) => {
                         // TODO: print more details
                         log::debug!(

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixed
 
-- Fix errors about verifying justifications. Justifications and Grandpa commits that can't be verified yet are now properly stored in memory in order to be verified later, instead of producing errors.
-- Fix issue where unverified justifications would overwrite one another, meaning that an invalid justification could potentially prevent a valid justification from being taken into account.
+- Fix errors about verifying justifications. Justifications and Grandpa commits that can't be verified yet are now properly stored in memory in order to be verified later, instead of producing errors. ([#2400](https://github.com/paritytech/smoldot/pull/2400))
+- Fix issue where unverified justifications would overwrite one another, meaning that an invalid justification could potentially prevent a valid justification from being taken into account. ([#2400](https://github.com/paritytech/smoldot/pull/2400))
 
 ## 0.6.19 - 2022-06-14
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix errors about verifying justifications. Justifications and Grandpa commits that can't be verified yet are now properly stored in memory in order to be verified later, instead of producing errors.
+- Fix issue where unverified justifications would overwrite one another, meaning that an invalid justification could potentially prevent a valid justification from being taken into account.
+
 ## 0.6.19 - 2022-06-14
 
 ### Fixed

--- a/src/chain/blocks_tree/finality.rs
+++ b/src/chain/blocks_tree/finality.rs
@@ -372,7 +372,9 @@ impl<T> NonFinalizedTreeInner<T> {
                     });
                 }
                 grandpa::commit::verify::InProgress::FinishedUnknown => {
-                    return Err(CommitVerifyError::NotEnoughKnownBlocks)
+                    return Err(CommitVerifyError::NotEnoughKnownBlocks {
+                        target_block_number: u64::from(decoded_commit.message.target_number),
+                    })
                 }
                 grandpa::commit::verify::InProgress::Finished(Err(error)) => {
                     return Err(CommitVerifyError::VerificationFailed(error))
@@ -639,7 +641,11 @@ pub enum CommitVerifyError {
     ///
     /// This doesn't mean that the commit is bad, but that it can't be verified without adding
     /// more blocks to the tree.
-    NotEnoughKnownBlocks,
+    #[display(fmt = "Not enough blocks are known to verify this commit")]
+    NotEnoughKnownBlocks {
+        /// Block number that the commit targets.
+        target_block_number: u64,
+    },
     /// The commit verification has failed. The commit is invalid and should be thrown away.
     #[display(fmt = "{}", _0)]
     VerificationFailed(grandpa::commit::verify::Error),

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -1595,6 +1595,7 @@ where
                     if let protocol::GrandpaNotificationRef::Commit(_) = decoded_notif {
                         break Some(Event::GrandpaCommitMessage {
                             chain_index,
+                            peer_id,
                             message: EncodedGrandpaCommitMessage(notification),
                         });
                     }
@@ -2237,6 +2238,8 @@ pub enum Event {
 
     /// Received a GrandPa commit message from the network.
     GrandpaCommitMessage {
+        /// Identity of the sender of the message.
+        peer_id: PeerId,
         /// Index of the chain the commit message relates to.
         chain_index: usize,
         message: EncodedGrandpaCommitMessage,

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -87,10 +87,7 @@ use crate::{
     header, verify,
 };
 
-use alloc::{
-    borrow::ToOwned as _,
-    vec::{self, Vec},
-};
+use alloc::{borrow::ToOwned as _, vec::Vec};
 use core::{mem, num::NonZeroU32, ops, time::Duration};
 
 mod disjoint;
@@ -171,13 +168,7 @@ pub struct AllForksSync<TBl, TRq, TSrc> {
 
 /// Extra fields. In a separate structure in order to be moved around.
 struct Inner<TBl, TRq, TSrc> {
-    blocks: pending_blocks::PendingBlocks<PendingBlock<TBl>, TRq, TSrc>,
-
-    /// Justifications waiting to be verified.
-    ///
-    /// These justifications came with a block header that has been successfully verified in the
-    /// past.
-    pending_justifications_verify: vec::IntoIter<([u8; 4], Vec<u8>)>,
+    blocks: pending_blocks::PendingBlocks<PendingBlock<TBl>, TRq, Source<TSrc>>,
 
     /// Same value as [`Config::banned_blocks`].
     banned_blocks: hashbrown::HashSet<[u8; 32], fnv::FnvBuildHasher>,
@@ -186,8 +177,226 @@ struct Inner<TBl, TRq, TSrc> {
 struct PendingBlock<TBl> {
     header: Option<header::Header>,
     // TODO: add body: Option<Vec<Vec<u8>>>, when adding full node support
-    justifications: Vec<([u8; 4], Vec<u8>)>,
     user_data: TBl,
+}
+
+struct Source<TSrc> {
+    /// Each source stores between zero and two finality proofs that haven't been verified yet.
+    ///
+    /// If more than two finality proofs are received from the same source, only the one with the
+    /// lowest target block and the one with the highest target block are kept in memory. This is
+    /// done in order to have a maximum bound to the amount of memory that is allocated per source
+    /// and avoid DoS attack vectors.
+    ///
+    /// The finality proof with the highest target block is the "best" finality proof. However,
+    /// keeping the finality proof with the lowest target block guarantees that, assuming the
+    /// source isn't malicious, we will able to make *some* progress in the finality.
+    unverified_finality_proofs: SourcePendingJustificationProofs,
+
+    /// Similar to [`Source::unverified_finality_proofs`]. Contains proofs that have been checked
+    /// and have been determined to not be verifiable right now.
+    pending_finality_proofs: SourcePendingJustificationProofs,
+
+    /// Opaque data chosen by the API user.
+    user_data: TSrc,
+}
+
+enum SourcePendingJustificationProofs {
+    None,
+    One {
+        target_height: u64,
+        proof: FinalityProofs,
+    },
+    Two {
+        low_target_height: u64,
+        low_proof: FinalityProofs,
+        high_target_height: u64,
+        high_proof: FinalityProofs,
+    },
+}
+
+impl SourcePendingJustificationProofs {
+    fn is_none(&self) -> bool {
+        matches!(self, SourcePendingJustificationProofs::None)
+    }
+
+    fn insert(&mut self, new_target_height: u64, new_proof: FinalityProofs) {
+        // An empty list of justifications is an invalid state.
+        debug_assert!(match &new_proof {
+            FinalityProofs::Justifications(list) if list.is_empty() => false,
+            _ => true,
+        });
+
+        match mem::replace(self, SourcePendingJustificationProofs::None) {
+            SourcePendingJustificationProofs::None => {
+                *self = SourcePendingJustificationProofs::One {
+                    target_height: new_target_height,
+                    proof: new_proof,
+                };
+            }
+            SourcePendingJustificationProofs::One {
+                target_height,
+                proof,
+            } if target_height < new_target_height => {
+                *self = SourcePendingJustificationProofs::Two {
+                    low_target_height: target_height,
+                    low_proof: proof,
+                    high_target_height: new_target_height,
+                    high_proof: new_proof,
+                };
+            }
+            SourcePendingJustificationProofs::One {
+                target_height,
+                proof,
+            } if target_height > new_target_height => {
+                *self = SourcePendingJustificationProofs::Two {
+                    low_target_height: new_target_height,
+                    low_proof: new_proof,
+                    high_target_height: target_height,
+                    high_proof: proof,
+                };
+            }
+            SourcePendingJustificationProofs::One { .. } => {
+                *self = SourcePendingJustificationProofs::One {
+                    target_height: new_target_height,
+                    proof: new_proof,
+                };
+            }
+            SourcePendingJustificationProofs::Two {
+                high_target_height,
+                low_proof,
+                low_target_height,
+                ..
+            } if new_target_height >= high_target_height => {
+                *self = SourcePendingJustificationProofs::Two {
+                    high_proof: new_proof,
+                    high_target_height: new_target_height,
+                    low_proof,
+                    low_target_height,
+                };
+            }
+            SourcePendingJustificationProofs::Two {
+                high_proof,
+                high_target_height,
+                low_target_height,
+                ..
+            } if new_target_height <= low_target_height => {
+                *self = SourcePendingJustificationProofs::Two {
+                    high_proof,
+                    high_target_height,
+                    low_proof: new_proof,
+                    low_target_height: new_target_height,
+                };
+            }
+            val @ SourcePendingJustificationProofs::Two { .. } => {
+                *self = val;
+            }
+        }
+    }
+
+    fn take_one(&mut self) -> Option<FinalityProof> {
+        match mem::replace(self, SourcePendingJustificationProofs::None) {
+            SourcePendingJustificationProofs::None => {
+                *self = SourcePendingJustificationProofs::None;
+                None
+            }
+            SourcePendingJustificationProofs::One {
+                proof: FinalityProofs::GrandpaCommit(commit),
+                ..
+            } => {
+                *self = SourcePendingJustificationProofs::None;
+                Some(FinalityProof::GrandpaCommit(commit))
+            }
+            SourcePendingJustificationProofs::One {
+                proof: FinalityProofs::Justifications(justifications),
+                ..
+            } if justifications.len() == 1 => {
+                *self = SourcePendingJustificationProofs::None;
+                let j = justifications.into_iter().next().unwrap();
+                Some(FinalityProof::Justification(j))
+            }
+            SourcePendingJustificationProofs::One {
+                target_height,
+                proof: FinalityProofs::Justifications(mut justifications),
+            } => {
+                let j = justifications.pop().unwrap();
+                *self = SourcePendingJustificationProofs::One {
+                    target_height,
+                    proof: FinalityProofs::Justifications(justifications),
+                };
+                Some(FinalityProof::Justification(j))
+            }
+            SourcePendingJustificationProofs::Two {
+                high_proof: FinalityProofs::GrandpaCommit(commit),
+                low_proof,
+                low_target_height,
+                ..
+            } => {
+                *self = SourcePendingJustificationProofs::One {
+                    target_height: low_target_height,
+                    proof: low_proof,
+                };
+                Some(FinalityProof::GrandpaCommit(commit))
+            }
+            SourcePendingJustificationProofs::Two {
+                high_proof: FinalityProofs::Justifications(justifications),
+                low_proof,
+                low_target_height,
+                ..
+            } if justifications.len() == 1 => {
+                let j = justifications.into_iter().next().unwrap();
+                *self = SourcePendingJustificationProofs::One {
+                    target_height: low_target_height,
+                    proof: low_proof,
+                };
+                Some(FinalityProof::Justification(j))
+            }
+            SourcePendingJustificationProofs::Two {
+                high_proof: FinalityProofs::Justifications(mut justifications),
+                high_target_height,
+                low_proof,
+                low_target_height,
+            } => {
+                let j = justifications.pop().unwrap();
+                *self = SourcePendingJustificationProofs::Two {
+                    high_proof: FinalityProofs::Justifications(justifications),
+                    high_target_height,
+                    low_proof,
+                    low_target_height,
+                };
+                Some(FinalityProof::Justification(j))
+            }
+        }
+    }
+
+    fn merge(&mut self, other: Self) {
+        match other {
+            SourcePendingJustificationProofs::None => {}
+            SourcePendingJustificationProofs::One {
+                target_height,
+                proof,
+            } => self.insert(target_height, proof),
+            SourcePendingJustificationProofs::Two {
+                high_proof,
+                high_target_height,
+                low_proof,
+                low_target_height,
+            } => {
+                self.insert(high_target_height, high_proof);
+                self.insert(low_target_height, low_proof);
+            }
+        }
+    }
+}
+
+enum FinalityProofs {
+    GrandpaCommit(Vec<u8>),
+    Justifications(Vec<([u8; 4], Vec<u8>)>),
+}
+
+enum FinalityProof {
+    GrandpaCommit(Vec<u8>),
+    Justification(([u8; 4], Vec<u8>)),
 }
 
 struct Block<TBl> {
@@ -219,7 +428,6 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
                     sources_capacity: config.sources_capacity,
                     verify_bodies: config.full,
                 }),
-                pending_justifications_verify: Vec::new().into_iter(),
                 banned_blocks: config.banned_blocks.collect(),
             },
         }
@@ -384,7 +592,8 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
         &mut self,
         source_id: SourceId,
     ) -> (TSrc, impl Iterator<Item = (RequestId, RequestParams, TRq)>) {
-        self.inner.blocks.remove_source(source_id)
+        let (user_data, iter) = self.inner.blocks.remove_source(source_id);
+        (user_data.user_data, iter)
     }
 
     /// Returns the list of sources in this state machine.
@@ -497,7 +706,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
             .map(move |rq| {
                 (
                     rq.source_id,
-                    &self.inner.blocks[rq.source_id],
+                    &self.inner.blocks[rq.source_id].user_data,
                     rq.request_params,
                 )
             })
@@ -690,28 +899,51 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     /// Update the state machine with a Grandpa commit message received from the network.
     ///
     /// On success, the finalized block has been updated.
+    ///
+    /// # Panic
+    ///
+    /// Panics if `source_id` is invalid.
+    ///
     // TODO: return which blocks are removed as finalized
+    // TODO: this should probably just insert the commit in the state machine and not verify it immediately
     pub fn grandpa_commit_message(
         &mut self,
-        scale_encoded_message: &[u8],
+        source_id: SourceId,
+        scale_encoded_commit: &[u8],
     ) -> Result<(), blocks_tree::CommitVerifyError> {
-        // TODO: must also handle the `NotEnoughBlocks` error separately
-        match self
+        // Grabbing the source is done early on in order to panic if the `source_id` is invalid.
+        let source = &mut self.inner.blocks[source_id];
+
+        let block_number = match self
             .chain
-            .verify_grandpa_commit_message(scale_encoded_message)
+            .verify_grandpa_commit_message(scale_encoded_commit)
         {
             Ok(apply) => {
                 apply.apply();
-                Ok(())
+                return Ok(());
             }
             // In case where the commit message concerns a block older or equal to the finalized
             // block, the operation is silently considered successful.
             Err(blocks_tree::CommitVerifyError::FinalityVerify(
                 blocks_tree::FinalityVerifyError::EqualToFinalized
                 | blocks_tree::FinalityVerifyError::BelowFinalized,
-            )) => Ok(()),
-            Err(err) => Err(err),
-        }
+            )) => return Ok(()),
+            Err(blocks_tree::CommitVerifyError::FinalityVerify(
+                blocks_tree::FinalityVerifyError::UnknownTargetBlock { block_number, .. },
+            )) => block_number,
+            Err(blocks_tree::CommitVerifyError::NotEnoughKnownBlocks) => {
+                todo!() // TODO:
+            }
+            Err(err) => return Err(err),
+        };
+
+        // If we reach here, the commit can't be verified yet. The commit is stored for later.
+        source.pending_finality_proofs.insert(
+            block_number,
+            FinalityProofs::GrandpaCommit(scale_encoded_commit.to_vec()),
+        );
+
+        Ok(())
     }
 
     /// Process the next block in the queue of verification.
@@ -719,10 +951,22 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     /// This method takes ownership of the [`AllForksSync`] and starts a verification
     /// process. The [`AllForksSync`] is yielded back at the end of this process.
     pub fn process_one(mut self) -> ProcessOne<TBl, TRq, TSrc> {
-        if let Some(justification_to_verify) = self.inner.pending_justifications_verify.next() {
-            return ProcessOne::JustificationVerify(JustificationVerify {
+        // TODO: O(n)
+        let source_id_with_finality_proof = self
+            .inner
+            .blocks
+            .sources()
+            .find(|id| !self.inner.blocks[*id].unverified_finality_proofs.is_none());
+
+        if let Some(source_id_with_finality_proof) = source_id_with_finality_proof {
+            let finality_proof_to_verify = self.inner.blocks[source_id_with_finality_proof]
+                .unverified_finality_proofs
+                .take_one()
+                .unwrap(); // `take()` always returns `Some` because we've checked `is_none()` above
+            return ProcessOne::FinalityProofVerify(FinalityProofVerify {
                 parent: self,
-                justification_to_verify,
+                source_id: source_id_with_finality_proof,
+                finality_proof_to_verify,
             });
         }
 
@@ -802,14 +1046,14 @@ impl<TBl, TRq, TSrc> ops::Index<SourceId> for AllForksSync<TBl, TRq, TSrc> {
 
     #[track_caller]
     fn index(&self, id: SourceId) -> &TSrc {
-        &self.inner.blocks[id]
+        &self.inner.blocks[id].user_data
     }
 }
 
 impl<TBl, TRq, TSrc> ops::IndexMut<SourceId> for AllForksSync<TBl, TRq, TSrc> {
     #[track_caller]
     fn index_mut(&mut self, id: SourceId) -> &mut TSrc {
-        &mut self.inner.blocks[id]
+        &mut self.inner.blocks[id].user_data
     }
 }
 
@@ -1133,10 +1377,18 @@ impl<TBl, TRq, TSrc> AddBlockVacant<TBl, TRq, TSrc> {
             },
             PendingBlock {
                 header: Some(self.decoded_header.clone()),
-                justifications: self.justifications,
                 user_data,
             },
         );
+
+        if !self.justifications.is_empty() {
+            self.inner.inner.inner.blocks[self.inner.source_id]
+                .unverified_finality_proofs
+                .insert(
+                    self.decoded_header.number,
+                    FinalityProofs::Justifications(self.justifications),
+                );
+        }
 
         if self
             .inner
@@ -1179,10 +1431,6 @@ impl<TBl, TRq, TSrc> AddBlockVacant<TBl, TRq, TSrc> {
                 .blocks
                 .remove_unverified_block(height, &hash);
         }
-
-        // TODO: what if the pending block already contains a justification and it is not the
-        //       same as here? since justifications aren't immediately verified, it is possible
-        //       for a malicious peer to send us bad justifications
 
         // Update the state machine for the next iteration.
         // Note: this can't be reached if `expected_next_height` is 0, because that should have
@@ -1381,7 +1629,6 @@ impl<'a, TBl, TRq, TSrc> AnnouncedBlockUnknown<'a, TBl, TRq, TSrc> {
             },
             PendingBlock {
                 header: Some(self.announced_header_encoded),
-                justifications: Vec::new(),
                 user_data,
             },
         );
@@ -1501,7 +1748,11 @@ impl<'a, TBl, TRq, TSrc> AddSourceOldBlock<'a, TBl, TRq, TSrc> {
     /// retrieved using the `Index` trait implementation of the [`AllForksSync`].
     pub fn add_source(self, source_user_data: TSrc) -> SourceId {
         self.inner.inner.blocks.add_source(
-            source_user_data,
+            Source {
+                user_data: source_user_data,
+                unverified_finality_proofs: SourcePendingJustificationProofs::None,
+                pending_finality_proofs: SourcePendingJustificationProofs::None,
+            },
             self.best_block_number,
             self.best_block_hash,
         )
@@ -1543,7 +1794,11 @@ impl<'a, TBl, TRq, TSrc> AddSourceKnown<'a, TBl, TRq, TSrc> {
     /// retrieved using the `Index` trait implementation of the [`AllForksSync`].
     pub fn add_source(self, source_user_data: TSrc) -> SourceId {
         self.inner.inner.blocks.add_source(
-            source_user_data,
+            Source {
+                user_data: source_user_data,
+                unverified_finality_proofs: SourcePendingJustificationProofs::None,
+                pending_finality_proofs: SourcePendingJustificationProofs::None,
+            },
             self.best_block_number,
             self.best_block_hash,
         )
@@ -1574,7 +1829,11 @@ impl<'a, TBl, TRq, TSrc> AddSourceUnknown<'a, TBl, TRq, TSrc> {
         best_block_user_data: TBl,
     ) -> SourceId {
         let source_id = self.inner.inner.blocks.add_source(
-            source_user_data,
+            Source {
+                user_data: source_user_data,
+                unverified_finality_proofs: SourcePendingJustificationProofs::None,
+                pending_finality_proofs: SourcePendingJustificationProofs::None,
+            },
             self.best_block_number,
             self.best_block_hash,
         );
@@ -1585,7 +1844,6 @@ impl<'a, TBl, TRq, TSrc> AddSourceUnknown<'a, TBl, TRq, TSrc> {
             pending_blocks::UnverifiedBlockState::HeightHashKnown,
             PendingBlock {
                 header: None,
-                justifications: Vec::new(),
                 user_data: best_block_user_data,
             },
         );
@@ -1667,17 +1925,17 @@ impl<TBl, TRq, TSrc> HeaderVerify<TBl, TRq, TSrc> {
                 };
                 insert.insert(block);
 
-                // Store the justification in `pending_justification_verify`.
-                // A `HeaderVerify` can only exist if `pending_justification_verify` is `None`,
-                // meaning that there's no risk of accidental overwrite.
-                debug_assert!(self
-                    .parent
-                    .inner
-                    .pending_justifications_verify
-                    .as_slice()
-                    .is_empty());
-                self.parent.inner.pending_justifications_verify =
-                    pending_block.justifications.into_iter();
+                // Because a new block is now in the chain, all the previously-unverifiable
+                // finality proofs might have now become verifiable.
+                // TODO: this way of doing it is correct but quite inefficient
+                for source in self.parent.inner.blocks.sources_user_data_iter_mut() {
+                    let pending = mem::replace(
+                        &mut source.pending_finality_proofs,
+                        SourcePendingJustificationProofs::None,
+                    );
+
+                    source.unverified_finality_proofs.merge(pending)
+                }
 
                 Ok(is_new_best)
             }
@@ -1724,43 +1982,106 @@ impl<TBl, TRq, TSrc> HeaderVerify<TBl, TRq, TSrc> {
     }
 }
 
-/// Justification verification to be performed.
+/// Finality proof verification to be performed.
 ///
 /// Internally holds the [`AllForksSync`].
-pub struct JustificationVerify<TBl, TRq, TSrc> {
+pub struct FinalityProofVerify<TBl, TRq, TSrc> {
     parent: AllForksSync<TBl, TRq, TSrc>,
-    /// Justification that can be verified and its consensus engine id.
-    justification_to_verify: ([u8; 4], Vec<u8>),
+    /// Source that has sent the finality proof.
+    source_id: SourceId,
+    /// Justification and its consensus engine id, or commit that can be verified.
+    finality_proof_to_verify: FinalityProof,
 }
 
-impl<TBl, TRq, TSrc> JustificationVerify<TBl, TRq, TSrc> {
+impl<TBl, TRq, TSrc> FinalityProofVerify<TBl, TRq, TSrc> {
     /// Perform the verification.
     pub fn perform(
         mut self,
     ) -> (
         AllForksSync<TBl, TRq, TSrc>,
-        JustificationVerifyOutcome<TBl>,
+        FinalityProofVerifyOutcome<TBl>,
     ) {
-        let outcome = match self.parent.chain.verify_justification(
-            self.justification_to_verify.0,
-            &self.justification_to_verify.1,
-        ) {
-            Ok(success) => {
-                let finalized_blocks_iter = success.apply();
-                let updates_best_block = finalized_blocks_iter.updates_best_block();
-                let finalized_blocks = finalized_blocks_iter
-                    .map(|b| (b.header, b.user_data))
-                    .collect::<Vec<_>>();
-                self.parent
-                    .inner
-                    .blocks
-                    .set_finalized_block_height(finalized_blocks.last().unwrap().0.number);
-                JustificationVerifyOutcome::NewFinalized {
-                    finalized_blocks,
-                    updates_best_block,
+        let outcome = match self.finality_proof_to_verify {
+            FinalityProof::GrandpaCommit(scale_encoded_commit) => {
+                match self
+                    .parent
+                    .chain
+                    .verify_grandpa_commit_message(&scale_encoded_commit)
+                {
+                    Ok(success) => {
+                        // TODO: DRY
+                        let finalized_blocks_iter = success.apply();
+                        let updates_best_block = finalized_blocks_iter.updates_best_block();
+                        let finalized_blocks = finalized_blocks_iter
+                            .map(|b| (b.header, b.user_data))
+                            .collect::<Vec<_>>();
+                        self.parent
+                            .inner
+                            .blocks
+                            .set_finalized_block_height(finalized_blocks.last().unwrap().0.number);
+                        FinalityProofVerifyOutcome::NewFinalized {
+                            finalized_blocks,
+                            updates_best_block,
+                        }
+                    }
+                    // In case where the commit message concerns a block older or equal to the
+                    // finalized block, the operation is silently considered successful.
+                    Err(blocks_tree::CommitVerifyError::FinalityVerify(
+                        blocks_tree::FinalityVerifyError::EqualToFinalized
+                        | blocks_tree::FinalityVerifyError::BelowFinalized,
+                    )) => FinalityProofVerifyOutcome::AlreadyFinalized,
+                    Err(blocks_tree::CommitVerifyError::FinalityVerify(
+                        blocks_tree::FinalityVerifyError::UnknownTargetBlock {
+                            block_number, ..
+                        },
+                    )) => {
+                        self.parent.inner.blocks[self.source_id]
+                            .pending_finality_proofs
+                            .insert(
+                                block_number,
+                                FinalityProofs::GrandpaCommit(scale_encoded_commit),
+                            );
+                        FinalityProofVerifyOutcome::GrandpaCommitPending
+                    }
+                    Err(blocks_tree::CommitVerifyError::NotEnoughKnownBlocks) => {
+                        todo!() // TODO:
+                    }
+                    Err(err) => FinalityProofVerifyOutcome::GrandpaCommitError(err),
                 }
             }
-            Err(err) => JustificationVerifyOutcome::Error(err),
+            FinalityProof::Justification((consensus_engine_id, scale_encoded_justification)) => {
+                match self
+                    .parent
+                    .chain
+                    .verify_justification(consensus_engine_id, &scale_encoded_justification)
+                {
+                    Ok(success) => {
+                        let finalized_blocks_iter = success.apply();
+                        let updates_best_block = finalized_blocks_iter.updates_best_block();
+                        let finalized_blocks = finalized_blocks_iter
+                            .map(|b| (b.header, b.user_data))
+                            .collect::<Vec<_>>();
+                        self.parent
+                            .inner
+                            .blocks
+                            .set_finalized_block_height(finalized_blocks.last().unwrap().0.number);
+                        FinalityProofVerifyOutcome::NewFinalized {
+                            finalized_blocks,
+                            updates_best_block,
+                        }
+                    }
+                    // In case where the commit message concerns a block older or equal to the
+                    // finalized block, the operation is silently considered successful.
+                    Err(blocks_tree::JustificationVerifyError::FinalityVerify(
+                        blocks_tree::FinalityVerifyError::EqualToFinalized
+                        | blocks_tree::FinalityVerifyError::BelowFinalized,
+                    )) => FinalityProofVerifyOutcome::AlreadyFinalized,
+
+                    // Note that, contrary to commits, there's no such thing as a justification
+                    // that can't be verified yet.
+                    Err(err) => FinalityProofVerifyOutcome::JustificationError(err),
+                }
+            }
         };
 
         (self.parent, outcome)
@@ -1788,7 +2109,7 @@ pub enum ProcessOne<TBl, TRq, TSrc> {
     HeaderVerify(HeaderVerify<TBl, TRq, TSrc>),
 
     /// A justification is ready for verification.
-    JustificationVerify(JustificationVerify<TBl, TRq, TSrc>),
+    FinalityProofVerify(FinalityProofVerify<TBl, TRq, TSrc>),
 }
 
 /// Outcome of calling [`HeaderVerify::perform`].
@@ -1820,10 +2141,10 @@ pub enum HeaderVerifyError {
     VerificationFailed(verify::header_only::Error),
 }
 
-/// Information about the outcome of verifying a justification.
+/// Information about the outcome of verifying a finality proof.
 #[derive(Debug)]
-pub enum JustificationVerifyOutcome<TBl> {
-    /// Justification verification successful. The block and all its ancestors is now finalized.
+pub enum FinalityProofVerifyOutcome<TBl> {
+    /// Verification successful. The block and all its ancestors is now finalized.
     NewFinalized {
         /// List of finalized blocks, in decreasing block number.
         // TODO: use `Vec<u8>` instead of `Header`?
@@ -1834,8 +2155,14 @@ pub enum JustificationVerifyOutcome<TBl> {
         /// block.
         updates_best_block: bool,
     },
+    /// Finality proof concerns block that was already finalized.
+    AlreadyFinalized,
+    /// GrandPa commit cannot be verified yet and has been stored for later.
+    GrandpaCommitPending,
     /// Problem while verifying justification.
-    Error(blocks_tree::JustificationVerifyError),
+    JustificationError(blocks_tree::JustificationVerifyError),
+    /// Problem while verifying GrandPa commit.
+    GrandpaCommitError(blocks_tree::CommitVerifyError),
 }
 
 /// State of the processing of blocks.

--- a/src/sync/all_forks/pending_blocks.rs
+++ b/src/sync/all_forks/pending_blocks.rs
@@ -328,6 +328,13 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
         self.sources.keys()
     }
 
+    /// Returns the list of all user datas of all sources.
+    pub fn sources_user_data_iter_mut(
+        &'_ mut self,
+    ) -> impl ExactSizeIterator<Item = &'_ mut TSrc> + '_ {
+        self.sources.user_data_iter_mut().map(|s| &mut s.user_data)
+    }
+
     /// Registers a new block that the source is aware of.
     ///
     /// Has no effect if `height` is inferior or equal to the finalized block height.
@@ -755,7 +762,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
             .filter(|(height, hash)| {
                 !self
                     .sources
-                    .iter()
+                    .keys()
                     .any(|source_id| self.sources.best_block(source_id) == (*height, hash))
             })
     }

--- a/src/sync/all_forks/sources.rs
+++ b/src/sync/all_forks/sources.rs
@@ -92,14 +92,14 @@ impl<TSrc> AllForksSources<TSrc> {
         self.sources.is_empty()
     }
 
-    /// Iterates over all sources.
-    pub fn iter(&'_ self) -> impl Iterator<Item = SourceId> + '_ {
-        self.sources.keys().copied()
-    }
-
     /// Returns the number of sources in the data structure.
     pub fn len(&self) -> usize {
         self.sources.len()
+    }
+
+    /// Returns the list of all user datas of all sources.
+    pub fn user_data_iter_mut(&'_ mut self) -> impl ExactSizeIterator<Item = &'_ mut TSrc> + '_ {
+        self.sources.values_mut().map(|s| &mut s.user_data)
     }
 
     /// Returns the number of unique blocks in the data structure.


### PR DESCRIPTION
At the moment, when a chain is initialized, you will see messages saying "error while verifying grandpa commit message: commit targets a block not in the chain".
For context, a "Grandpa commit" is simply a proof of the finality of a block. It contains votes made by the validators.

What happens is: right after we have finished warp syncing to the current finalized block, a peer sends us a proof of finality. But the proof of finality targets a block that we haven't downloaded yet (as we've just finished warp syncing), and thus can't be verified.
In this context, the correct thing to do is instead to store the proof of finality and verify it later. This is what this PR does.

This however causes an issue, as sources could just send us hundreds of proofs of finality concerning unknown blocks. To prevent this from happening, we store for each peer only 2 proofs maximum: the one that target the lowest block number and the one that targets the higher block number.
If the peer is well behaving, then the one targeting the highest block number is likely the one we want to actually verify and apply in order to be up to date with the finality of the chain.

However, we also keep the one targeting the lowest block number, in order to make sure to be able to make _some_ progress at some point in the future. The idea behind this is that the lowest-block-number-targeting finality proof should never change (again, assuming that the peer is well behaving). And thus even if for example for some reason downloading blocks is suuuuper slow, at some point in the future we will manage to download the block necessary to verify the lowest-block-number-targeting finality proof. Whereas if we only kept the latest finality proof, which gets overwritten every time a new proof is received, we might never be able to catch up.

This PR also fixes a current issue, which is that we only keep one unverified justification per block. For context, a justification is the same thing as a finality proof, except that they need to be explicitly required and not received passively. Storing one unverified justification per block means that if for some reason we download the same block from two peers, the justification sent by the second one will overwrite the one sent by the first one, even though the justification sent by the second one might be incorrect and the justification sent by the first one correct.
Now, we store justifications per peer, as described above.

This is a big step towards making the full syncing feature-complete.

Due to all these changes, many of the functions or enums that said "justification" now also apply to Grandpa commit, and thus I've renamed them to "finality proof".
