### PR TITLE
Only use database if it's more recent than checkpoint

### DIFF
--- a/bin/light-base/src/lib.rs
+++ b/bin/light-base/src/lib.rs
@@ -409,12 +409,16 @@ impl<TChain, TPlat: Platform> Client<TChain, TPlat> {
                 }),
                 finalized_serialize::decode_chain(config.database_content),
             ) {
-                (Ok(Ok(genesis_ci)), _, Ok((ci, _))) => {
+                (Ok(Ok(genesis_ci)), _, Ok((database, _))) => {
                     let genesis_header = genesis_ci.as_ref().finalized_block_header.clone();
-                    (ci, genesis_header.into())
+                    (database, genesis_header.into())
                 }
 
-                (Err(chain_spec::FromGenesisStorageError::UnknownStorageItems), _, Ok((ci, _))) => {
+                (
+                    Err(chain_spec::FromGenesisStorageError::UnknownStorageItems),
+                    _,
+                    Ok((database, _)),
+                ) => {
                     let genesis_header = header::Header {
                         parent_hash: [0; 32],
                         number: 0,
@@ -423,7 +427,7 @@ impl<TChain, TPlat: Platform> Client<TChain, TPlat> {
                         digest: header::DigestRef::empty().into(),
                     };
 
-                    (ci, genesis_header)
+                    (database, genesis_header)
                 }
 
                 (Err(chain_spec::FromGenesisStorageError::UnknownStorageItems), None, _) => {
@@ -438,7 +442,7 @@ impl<TChain, TPlat: Platform> Client<TChain, TPlat> {
 
                 (
                     Err(chain_spec::FromGenesisStorageError::UnknownStorageItems),
-                    Some(Ok(ci)),
+                    Some(Ok(checkpoint)),
                     _,
                 ) => {
                     let genesis_header = header::Header {
@@ -449,7 +453,7 @@ impl<TChain, TPlat: Platform> Client<TChain, TPlat> {
                         digest: header::DigestRef::empty().into(),
                     };
 
-                    (ci, genesis_header)
+                    (checkpoint, genesis_header)
                 }
 
                 (Err(err), _, _) => {
@@ -473,15 +477,15 @@ impl<TChain, TPlat: Platform> Client<TChain, TPlat> {
                     }));
                 }
 
-                (Ok(Ok(genesis_ci)), Some(Ok(ci)), _) => {
+                (Ok(Ok(genesis_ci)), Some(Ok(checkpoint)), _) => {
                     let genesis_header = genesis_ci.as_ref().finalized_block_header.clone();
-                    (ci, genesis_header.into())
+                    (checkpoint, genesis_header.into())
                 }
 
-                (Ok(Ok(ci)), None, _) => {
+                (Ok(Ok(genesis_ci)), None, _) => {
                     let genesis_header =
-                        header::Header::from(ci.as_ref().finalized_block_header.clone());
-                    (ci, genesis_header)
+                        header::Header::from(genesis_ci.as_ref().finalized_block_header.clone());
+                    (genesis_ci, genesis_header)
                 }
             }
         };

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- When a database and a chain specification checkpoint are both provided to `addChain`, the block in the database is used only if it has a higher block number than the block in the chain specification checkpoint. This makes it possible to bypass issues where smoldot is incapable of syncing over a certain block by updating the chain specification, without having to manually clear existing databases. ([#2401](https://github.com/paritytech/smoldot/pull/2401))
+
 ## 0.6.19 - 2022-06-14
 
 ### Fixed


### PR DESCRIPTION
At a chain initialization, we provide a chain spec and, generally, an existing database. The chain spec can contain a checkpoint where we start syncing from.

Before this PR, the database always took precedence. This means that if database contains block 10 but the chain spec contains block 50000, we'll start syncing at block 10.
After this PR, the database is ignored if its block is below the checkpoint's.

This is especially important in situations where some sudo operation happened on a chain which breaks the warp syncing, like it happened on Rococo a week ago. Basically, smoldot is incapable of syncing over the blocks that force-change the list of validators. Before this PR, even if we ship a more recent checkpoint to bypass this issue, users would still use their database and be stuck at the block in question.
