### PR TITLE
Fix call proof responses not decoded properly

### DIFF
--- a/bin/fuzz/fuzz_targets/protocol-storage-call-proof-response-decode.rs
+++ b/bin/fuzz/fuzz_targets/protocol-storage-call-proof-response-decode.rs
@@ -18,5 +18,9 @@
 #![no_main]
 
 libfuzzer_sys::fuzz_target!(|data: &[u8]| {
-    let _ = smoldot::network::protocol::decode_storage_or_call_proof_response(data);
+    // Note that the type of response has no influence on the code of the implementation.
+    let _ = smoldot::network::protocol::decode_storage_or_call_proof_response(
+        smoldot::network::protocol::StorageOrCallProof::CallProof,
+        data,
+    );
 });

--- a/src/network/protocol/storage_call_proof.rs
+++ b/src/network/protocol/storage_call_proof.rs
@@ -96,11 +96,17 @@ pub fn build_call_proof_request<'a>(
 ///
 /// On success, contains a list of Merkle proof entries.
 pub fn decode_storage_or_call_proof_response(
+    ty: StorageOrCallProof,
     response_bytes: &[u8],
 ) -> Result<Vec<&[u8]>, DecodeStorageCallProofResponseError> {
+    let field_num = match ty {
+        StorageOrCallProof::CallProof => 1,
+        StorageOrCallProof::StorageProof => 2,
+    };
+
     let mut parser = nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(
         nom::combinator::complete(protobuf::message_decode((protobuf::message_tag_decode(
-            2,
+            field_num,
             protobuf::message_decode((protobuf::bytes_tag_decode(2),)),
         ),))),
     );
@@ -131,4 +137,12 @@ pub enum DecodeStorageCallProofResponseError {
     BadResponseTy,
     /// Failed to decode response as a storage proof.
     ProofDecodeError,
+}
+
+/// Passed as parameter to [`decode_storage_or_call_proof_response`] to indicate what kind of
+/// request the response corresponds to.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum StorageOrCallProof {
+    StorageProof,
+    CallProof,
 }

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -1318,12 +1318,16 @@ where
                         let response = response
                             .map_err(StorageProofRequestError::Request)
                             .and_then(|payload| {
-                                if let Err(err) =
-                                    protocol::decode_storage_or_call_proof_response(&payload)
-                                {
+                                if let Err(err) = protocol::decode_storage_or_call_proof_response(
+                                    protocol::StorageOrCallProof::StorageProof,
+                                    &payload,
+                                ) {
                                     Err(StorageProofRequestError::Decode(err))
                                 } else {
-                                    Ok(EncodedMerkleProof(payload))
+                                    Ok(EncodedMerkleProof(
+                                        payload,
+                                        protocol::StorageOrCallProof::StorageProof,
+                                    ))
                                 }
                             });
 
@@ -1338,11 +1342,17 @@ where
                                 .map_err(CallProofRequestError::Request)
                                 .and_then(|payload| {
                                     if let Err(err) =
-                                        protocol::decode_storage_or_call_proof_response(&payload)
+                                        protocol::decode_storage_or_call_proof_response(
+                                            protocol::StorageOrCallProof::CallProof,
+                                            &payload,
+                                        )
                                     {
                                         Err(CallProofRequestError::Decode(err))
                                     } else {
-                                        Ok(EncodedMerkleProof(payload))
+                                        Ok(EncodedMerkleProof(
+                                            payload,
+                                            protocol::StorageOrCallProof::CallProof,
+                                        ))
                                     }
                                 });
 
@@ -2361,12 +2371,12 @@ impl fmt::Debug for EncodedBlockAnnounce {
 
 /// Undecoded but valid Merkle proof.
 #[derive(Clone)]
-pub struct EncodedMerkleProof(Vec<u8>);
+pub struct EncodedMerkleProof(Vec<u8>, protocol::StorageOrCallProof);
 
 impl EncodedMerkleProof {
     /// Returns the decoded version of the proof.
     pub fn decode(&self) -> Vec<&[u8]> {
-        protocol::decode_storage_or_call_proof_response(&self.0).unwrap()
+        protocol::decode_storage_or_call_proof_response(self.1, &self.0).unwrap()
     }
 }
 


### PR DESCRIPTION
Fix https://github.com/paritytech/smoldot/issues/2413

This fixes a bug introduced in https://github.com/paritytech/smoldot/pull/2406
It turns out that decoding call proofs or storage proofs is not exactly the same, as one "tag" byte diverges between the two.

No changelog entry is added, since this fixes a bug that was never in a released version.
