### PR TITLE
Fix missing match blocks in collection.rs

### DIFF
--- a/src/libp2p/collection/multi_stream.rs
+++ b/src/libp2p/collection/multi_stream.rs
@@ -418,6 +418,7 @@ where
             (
                 CoordinatorToConnectionInner::AcceptInNotifications { .. }
                 | CoordinatorToConnectionInner::RejectInNotifications { .. }
+                | CoordinatorToConnectionInner::StartRequest { .. }
                 | CoordinatorToConnectionInner::AnswerRequest { .. }
                 | CoordinatorToConnectionInner::OpenOutNotifications { .. }
                 | CoordinatorToConnectionInner::CloseOutNotifications { .. }
@@ -427,6 +428,7 @@ where
             (
                 CoordinatorToConnectionInner::AcceptInNotifications { .. }
                 | CoordinatorToConnectionInner::RejectInNotifications { .. }
+                | CoordinatorToConnectionInner::StartRequest { .. }
                 | CoordinatorToConnectionInner::AnswerRequest { .. }
                 | CoordinatorToConnectionInner::OpenOutNotifications { .. }
                 | CoordinatorToConnectionInner::CloseOutNotifications { .. }
@@ -451,7 +453,12 @@ where
                     was_api_reset: *was_reset,
                 };
             }
-            _ => todo!(), // TODO:
+            (
+                CoordinatorToConnectionInner::StartShutdown,
+                MultiStreamConnectionTaskInner::ShutdownWaitingAck { .. }
+                | MultiStreamConnectionTaskInner::ShutdownAcked { .. },
+            ) => unreachable!(),
+            (CoordinatorToConnectionInner::ShutdownFinishedAck, _) => unreachable!(),
         }
     }
 

--- a/src/libp2p/collection/multi_stream.rs
+++ b/src/libp2p/collection/multi_stream.rs
@@ -434,6 +434,13 @@ where
                 | CoordinatorToConnectionInner::CloseOutNotifications { .. }
                 | CoordinatorToConnectionInner::QueueNotification { .. },
                 MultiStreamConnectionTaskInner::ShutdownWaitingAck { .. },
+            )
+            | (
+                CoordinatorToConnectionInner::StartShutdown,
+                MultiStreamConnectionTaskInner::ShutdownWaitingAck {
+                    was_api_reset: true,
+                    ..
+                },
             ) => {
                 // There might still be some messages coming from the coordinator after the
                 // connection task has sent a message indicating that it has shut down. This is

--- a/src/libp2p/collection/single_stream.rs
+++ b/src/libp2p/collection/single_stream.rs
@@ -338,6 +338,7 @@ where
             (
                 CoordinatorToConnectionInner::AcceptInNotifications { .. }
                 | CoordinatorToConnectionInner::RejectInNotifications { .. }
+                | CoordinatorToConnectionInner::StartRequest { .. }
                 | CoordinatorToConnectionInner::AnswerRequest { .. }
                 | CoordinatorToConnectionInner::OpenOutNotifications { .. }
                 | CoordinatorToConnectionInner::CloseOutNotifications { .. }
@@ -348,6 +349,7 @@ where
             (
                 CoordinatorToConnectionInner::AcceptInNotifications { .. }
                 | CoordinatorToConnectionInner::RejectInNotifications { .. }
+                | CoordinatorToConnectionInner::StartRequest { .. }
                 | CoordinatorToConnectionInner::AnswerRequest { .. }
                 | CoordinatorToConnectionInner::OpenOutNotifications { .. }
                 | CoordinatorToConnectionInner::CloseOutNotifications { .. }
@@ -369,7 +371,13 @@ where
                     was_api_reset: *was_reset,
                 };
             }
-            _ => todo!(), // TODO:
+            (
+                CoordinatorToConnectionInner::StartShutdown,
+                SingleStreamConnectionTaskInner::ShutdownWaitingAck { .. }
+                | SingleStreamConnectionTaskInner::ShutdownAcked { .. },
+            ) => unreachable!(),
+            (CoordinatorToConnectionInner::ShutdownFinishedAck, _) => unreachable!(),
+            (_, SingleStreamConnectionTaskInner::Poisoned) => unreachable!(),
         }
     }
 

--- a/src/libp2p/collection/single_stream.rs
+++ b/src/libp2p/collection/single_stream.rs
@@ -355,6 +355,12 @@ where
                 | CoordinatorToConnectionInner::CloseOutNotifications { .. }
                 | CoordinatorToConnectionInner::QueueNotification { .. },
                 SingleStreamConnectionTaskInner::ShutdownWaitingAck { .. },
+            )
+            | (
+                CoordinatorToConnectionInner::StartShutdown,
+                SingleStreamConnectionTaskInner::ShutdownWaitingAck {
+                    was_api_reset: true,
+                },
             ) => {
                 // There might still be some messages coming from the coordinator after the
                 // connection task has sent a message indicating that it has shut down. This is


### PR DESCRIPTION
Fixes the two `_ => todo!()` blocks.

I initially left them as `_ => todo!()` because I thought that these were only invalid states, and so didn't really need much caring.

However it turns out I forgot to handle the `(StartRequest, ShutdownWaitingAck)` combination (which, before this PR would panic, and after this PR does nothing), so it's a good thing that they are now explicitly laid out.

While this fixes a potential panic, I've never actually seen this panic happen and it might not actually be possible for it to happen, so I don't think it's worth mentioning in the CHANGELOG.
