### PR TITLE
Optimize multiaddr::as_bytes a bit

### DIFF
--- a/src/libp2p/multiaddr.rs
+++ b/src/libp2p/multiaddr.rs
@@ -339,9 +339,13 @@ impl<'a> ProtocolRef<'a> {
             _ => Vec::new(),
         };
 
-        let mut out = crate::util::leb128::encode_usize(code).collect::<Vec<_>>();
-        out.extend(extra);
-        iter::once(out.into_iter())
+        // Combine `code` and `extra`.
+        [
+            either::Left(crate::util::leb128::encode_usize(code).map(|b| either::Left([b]))),
+            either::Right(iter::once(either::Right(extra))),
+        ]
+        .into_iter()
+        .flat_map(|b| b)
     }
 }
 

--- a/src/libp2p/multiaddr.rs
+++ b/src/libp2p/multiaddr.rs
@@ -340,12 +340,9 @@ impl<'a> ProtocolRef<'a> {
         };
 
         // Combine `code` and `extra`.
-        [
-            either::Left(crate::util::leb128::encode_usize(code).map(|b| either::Left([b]))),
-            either::Right(iter::once(either::Right(extra))),
-        ]
-        .into_iter()
-        .flat_map(|b| b)
+        crate::util::leb128::encode_usize(code)
+            .map(|b| either::Left([b]))
+            .chain(iter::once(either::Right(extra)))
     }
 }
 


### PR DESCRIPTION
Removes one `Vec` allocation by directly returning the two iterators that we merge into one.