### PR TITLE
Adding a fork tree fuzzing code

### DIFF
--- a/bin/fuzz/Cargo.lock
+++ b/bin/fuzz/Cargo.lock
@@ -54,9 +54,9 @@ checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "arbitrary"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38b6b6b79f671c25e1a3e785b7b82d7562ffc9cd3efdc98627e5668a2472490"
+checksum = "25e0a02cf12f1b1f48b14cb7f8217b876d09992b39c816ffb3b1ba64dd979a87"
 
 [[package]]
 name = "arrayref"
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52580991739c5cdb36cde8b2a516371c0a3b70dda36d916cc08b82372916808c"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
  "async-channel",
  "async-global-executor",
@@ -166,7 +166,6 @@ dependencies = [
  "kv-log-macro",
  "log",
  "memchr",
- "num_cpus",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
@@ -1309,9 +1308,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.1.2"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b44461635bbb1a0300f100a841e571e7d919c81c73075ef5d152ffdb521066"
+checksum = "9182e4a71cae089267ab03e67c99368db7cd877baf50f931e5d6d4b71e195ac0"
 dependencies = [
  "arrayvec 0.7.2",
  "byte-slice-cast",
@@ -1321,9 +1320,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c45ed1f39709f5a89338fab50e59816b2e8815f5bb58276e7ddf9afd495f73f8"
+checksum = "9299338969a3d2f491d65f140b00ddec470858402f888af98e8642fb5e8965cd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1795,6 +1794,9 @@ dependencies = [
 name = "smoldot-fuzz"
 version = "0.0.0"
 dependencies = [
+ "arbitrary",
+ "fnv",
+ "hashbrown 0.12.1",
  "libfuzzer-sys",
  "smoldot",
 ]

--- a/bin/fuzz/Cargo.toml
+++ b/bin/fuzz/Cargo.toml
@@ -9,10 +9,11 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
+arbitrary = "1.1.2"
+fnv = { version = "1.0.7", default-features = false }
+hashbrown = { version = "0.12.1", default-features = false }
 libfuzzer-sys = "0.4"
-
-[dependencies.smoldot]
-path = "../.."
+smoldot = { path = "../.." }
 
 # Prevent this from interfering with workspaces
 [workspace]
@@ -21,6 +22,12 @@ members = ["."]
 [[bin]]
 name = "chain-spec"
 path = "fuzz_targets/chain-spec.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fork-tree"
+path = "fuzz_targets/fork-tree.rs"
 test = false
 doc = false
 

--- a/bin/fuzz/fuzz_targets/fork-tree.rs
+++ b/bin/fuzz/fuzz_targets/fork-tree.rs
@@ -125,8 +125,8 @@ impl<'a> arbitrary::Arbitrary<'a> for OperationsList {
                 return Ok(ControlFlow::Continue(()));
             }
 
-            // 9/10th of the time, insert a new node in the tree.
-            if u.ratio(9, 10)? {
+            // 9/10th of the time, or if the tree is empty, insert a new node in the tree.
+            if tree_root.children.borrow().is_empty() || u.ratio(9, 10)? {
                 let index = u.choose_index(all_nodes.len())?;
 
                 operations.push(Operation::Insert {
@@ -145,6 +145,7 @@ impl<'a> arbitrary::Arbitrary<'a> for OperationsList {
             }
 
             // The remaining half of the time, we prune ancestors. Otherwise, we prune uncles.
+            // Note that this path is never reached if the tree is empty.
             if u.ratio(1, 2)? {
                 let index = u.choose_index(all_nodes.len() - 1)? + 1; // Avoid the tree root
                 operations.push(Operation::PruneAncestors(

--- a/bin/fuzz/fuzz_targets/fork-tree.rs
+++ b/bin/fuzz/fuzz_targets/fork-tree.rs
@@ -1,0 +1,166 @@
+// Smoldot
+// Copyright (C) 2019-2022  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#![no_main]
+
+use smoldot::chain::fork_tree;
+use std::{
+    cell::{Cell, RefCell},
+    ops::ControlFlow,
+    rc::{Rc, Weak},
+};
+
+// This fuzzing test generates a list of operations that are then applied on a fork tree.
+
+// Because the list of operations is generated ahead of time, we can't use `NodeIndex` as these
+// are unpredictable. Instead, we use locally-assigned `u32`s and applying the operations will
+// keep a mapping between `u32`s and `NodeIndex`es.
+#[derive(Debug)]
+enum Operation {
+    Clear,
+    Insert { parent: Option<u32>, new_id: u32 },
+    PruneAncestors(u32),
+    PruneUncles(u32),
+}
+
+libfuzzer_sys::fuzz_target!(|operations: OperationsList| {
+    let mut tree = fork_tree::ForkTree::new();
+
+    let mut ext_to_in_mapping =
+        hashbrown::HashMap::<u32, fork_tree::NodeIndex, _>::with_capacity_and_hasher(
+            0,
+            fnv::FnvBuildHasher::default(),
+        );
+
+    for operation in operations.0 {
+        match operation {
+            Operation::Clear => {
+                tree.clear();
+            }
+            Operation::Insert { parent, new_id } => {
+                let in_id = tree.insert(parent.map(|id| ext_to_in_mapping[&id]), ());
+                ext_to_in_mapping.insert(new_id, in_id);
+            }
+            Operation::PruneAncestors(id) => {
+                let _ = tree.prune_ancestors(ext_to_in_mapping[&id]);
+            }
+            Operation::PruneUncles(id) => {
+                let _ = tree.prune_uncles(ext_to_in_mapping[&id]);
+            }
+        }
+    }
+});
+
+#[derive(Debug)]
+struct OperationsList(Vec<Operation>);
+
+impl<'a> arbitrary::Arbitrary<'a> for OperationsList {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        // In order to generate a valid list of operations, we must track the tree separately.
+        // To do so, we use `Rc`s and `Weak`s, which is the easiest (but non optimal) way to
+        // maintain a tree.
+
+        struct Node {
+            id: Cell<Option<u32>>, // `None` iff root.
+            parent: Weak<Node>,
+            children: RefCell<Vec<Rc<Node>>>,
+        }
+
+        impl Node {
+            fn gather_children(&self, out: &mut Vec<Rc<Node>>) {
+                let children = self.children.borrow();
+                out.extend(children.iter().cloned());
+                for child in children.iter() {
+                    child.gather_children(out);
+                }
+            }
+
+            fn prune_uncles(self: &Rc<Self>) {
+                if let Some(parent) = self.parent.upgrade() {
+                    let mut parent_children = parent.children.borrow_mut();
+                    parent_children.retain(|c| Rc::ptr_eq(c, self));
+                    parent.prune_uncles();
+                }
+            }
+        }
+
+        let mut operations = Vec::new();
+
+        let mut tree_root = Rc::new(Node {
+            id: Cell::new(None),
+            parent: Weak::new(),
+            children: RefCell::new(Vec::new()),
+        });
+
+        let mut next_node_id = 0;
+
+        u.arbitrary_loop(None, None, |u| {
+            let mut all_nodes = Vec::new();
+            all_nodes.push(tree_root.clone());
+            tree_root.gather_children(&mut all_nodes);
+
+            // Very rarely, we simply clear the tree.
+            if u.ratio(1, 30)? {
+                operations.push(Operation::Clear);
+                tree_root = Rc::new(Node {
+                    id: Cell::new(None),
+                    parent: Weak::new(),
+                    children: RefCell::new(Vec::new()),
+                });
+
+                return Ok(ControlFlow::Continue(()));
+            }
+
+            // 9/10th of the time, insert a new node in the tree.
+            if u.ratio(9, 10)? {
+                let index = u.choose_index(all_nodes.len())?;
+
+                operations.push(Operation::Insert {
+                    parent: all_nodes[index].id.get(),
+                    new_id: next_node_id,
+                });
+                let parent = Rc::downgrade(&all_nodes[index]);
+                all_nodes[index].children.borrow_mut().push(Rc::new(Node {
+                    id: Cell::new(Some(next_node_id)),
+                    parent,
+                    children: RefCell::new(Vec::new()),
+                }));
+                next_node_id += 1;
+
+                return Ok(ControlFlow::Continue(()));
+            }
+
+            // The remaining half of the time, we prune ancestors. Otherwise, we prune uncles.
+            if u.ratio(1, 2)? {
+                let index = u.choose_index(all_nodes.len() - 1)? + 1; // Avoid the tree root
+                operations.push(Operation::PruneAncestors(
+                    all_nodes[index].id.get().unwrap(),
+                ));
+                tree_root = all_nodes[index].clone();
+                all_nodes[index].id.set(None);
+            } else {
+                let index = u.choose_index(all_nodes.len() - 1)? + 1; // Avoid the tree root
+                operations.push(Operation::PruneUncles(all_nodes[index].id.get().unwrap()));
+                all_nodes[index].prune_uncles();
+            }
+
+            Ok(ControlFlow::Continue(()))
+        })?;
+
+        Ok(OperationsList(operations))
+    }
+}


### PR DESCRIPTION
Close https://github.com/paritytech/smoldot/issues/1822

The fork tree has a history of having a lot of bugs that have been fixed over time.

In order to have a reasonably good confidence that there's no panic anymore, this PR adds a fuzzer.
The fuzzer randomly generates operations amongst all the possible mutable functions that the fork tree lets you perform, then applies them.

As of the opening of this PR, it panics because of https://github.com/paritytech/smoldot/pull/2423, but if I manually apply the fix in #2423 then the panics disappear.
