### PR TITLE
Add support for digest item other type

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -980,7 +980,7 @@ pub enum DigestItemRef<'a> {
         opaque: &'a [u8],
     },
 
-    /// Some other thing. Unsupported and experimental.
+    /// Some other thing. Always ignored.
     Other(&'a [u8]),
 
     /// Runtime of the chain has been updated in this block. This can include the runtime code or

--- a/src/header.rs
+++ b/src/header.rs
@@ -1192,7 +1192,7 @@ pub enum DigestItem {
     /// the heap pages.
     RuntimeEnvironmentUpdated,
 
-    /// Some other thing. Unsupported and experimental.
+    /// Some other thing. Always ignored.
     Other(Vec<u8>),
 }
 


### PR DESCRIPTION
The DigestItem type in substrate has a other type:

```rust
pub enum DigestItemRef<'a> {
        ///...
	/// Any 'non-system' digest item, opaque to the native code.
	Other(&'a [u8]),
	///...
}
```

This will be used for some chain based on substrate, and if use this digestitem, the smoldot will failed to sync blocks from it.

This PR fix this problem by add this type to DigestItem.