### PR TITLE
Pass `type: "module"` to `new Worker()`

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- `new Worker` is now called with the `{ type: "module" }` option. Despite not being supported by NodeJS or Firefox, indicating this option is technically more correct and is necessary in order for smoldot to run with Deno.
 - When a database and a chain specification checkpoint are both provided to `addChain`, the block in the database is used only if it has a higher block number than the block in the chain specification checkpoint. This makes it possible to bypass issues where smoldot is incapable of syncing over a certain block by updating the chain specification, without having to manually clear existing databases. ([#2401](https://github.com/paritytech/smoldot/pull/2401))
 
 ### Fixed

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- `new Worker` is now called with the `{ type: "module" }` option. Despite not being supported by NodeJS or Firefox, indicating this option is technically more correct and is necessary in order for smoldot to run with Deno.
+- `new Worker` is now called with the `{ type: "module" }` option. Despite not being supported by NodeJS or Firefox, indicating this option is technically more correct and is necessary in order for smoldot to run with Deno. ([#2426](https://github.com/paritytech/smoldot/pull/2426))
 - When a database and a chain specification checkpoint are both provided to `addChain`, the block in the database is used only if it has a higher block number than the block in the chain specification checkpoint. This makes it possible to bypass issues where smoldot is incapable of syncing over a certain block by updating the chain specification, without having to manually clear existing databases. ([#2401](https://github.com/paritytech/smoldot/pull/2401))
 
 ### Fixed

--- a/bin/wasm-node/javascript/README.md
+++ b/bin/wasm-node/javascript/README.md
@@ -77,7 +77,7 @@ The code in this package uses a web worker (in browsers) or a worker thread (on 
 line of JavaScript that creates the worker is of the following form:
 
 ``` js
-new Worker(new URL('./worker.js', import.meta.url));
+new Worker(new URL('./worker.js', import.meta.url), { type: "module" });
 ```
 
 This format is compatible [with Webpack 5](https://webpack.js.org/guides/web-workers/), meaning

--- a/bin/wasm-node/javascript/src/worker/spawn-browser-overwrite.js
+++ b/bin/wasm-node/javascript/src/worker/spawn-browser-overwrite.js
@@ -31,9 +31,9 @@ export default function () {
     // modules in the worker code. It is thus also the role of this bundler to tweak or remove
     // the value of this `type` property to indicate to the browser that modules aren't in use.
     //
-    // It is unclear whether bundlers actually do this. Whether bundlers actually do this or not,
-    // it is nonetheless more correct to indicate `type: "module"` and doing so doesn't have any
-    // drawback.
+    // WebPack in particular does this, but it is unclear whether *all* bundlers do it.
+    // Whether bundlers actually do this or not, it is nonetheless more correct to indicate
+    // `type: "module"` and doing so doesn't have any drawback.
     const worker = new Worker(new URL('./worker.js', import.meta.url), { name: "smoldot", type: "module" });
     return worker;
 }

--- a/bin/wasm-node/javascript/src/worker/spawn-browser-overwrite.js
+++ b/bin/wasm-node/javascript/src/worker/spawn-browser-overwrite.js
@@ -24,6 +24,16 @@ export default function () {
     // Because this line is precisely recognized by bundlers, we extract it to a separate
     // JavaScript file.
     // See also the README.md for more context.
-    const worker = new Worker(new URL('./worker.js', import.meta.url), { name: "smoldot" });
+
+    // Note that, at the time of writing, Firefox doesn't support the `type: "module"` option.
+    // Because browsers don't fully support modules yet, this code is expected to be run through
+    // a bundler (e.g. WebPack) before being given to a browser, which will remove all usage of
+    // modules in the worker code. It is thus also the role of this bundler to tweak or remove
+    // the value of this `type` property to indicate to the browser that modules aren't in use.
+    //
+    // It is unclear whether bundlers actually do this. Whether bundlers actually do this or not,
+    // it is nonetheless more correct to indicate `type: "module"` and doing so doesn't have any
+    // drawback.
+    const worker = new Worker(new URL('./worker.js', import.meta.url), { name: "smoldot", type: "module" });
     return worker;
 }

--- a/bin/wasm-node/javascript/src/worker/spawn.js
+++ b/bin/wasm-node/javascript/src/worker/spawn.js
@@ -23,6 +23,10 @@ export default function () {
     // Because this line is precisely recognized by bundlers, we extract it to a separate
     // JavaScript file.
     // See also the README.md for more context.
-    const worker = new Worker(new URL('./worker.js', import.meta.url));
+
+    // Note that at the time of writing of this comment, NodeJS doesn't support the
+    // `type: "module"` option, as modules "just work". But we put it anyway because Deno throws
+    // an exception if this option isn't present.
+    const worker = new Worker(new URL('./worker.js', import.meta.url), { type: "module" });
     return worker;
 }


### PR DESCRIPTION
Deno throws an exception if we call `new Worker` without `type: "module"`.

See the comments for more information.

cc @harrysolovay 