### PR TITLE
Refactor platform.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2313,7 +2313,9 @@ name = "smoldot-light-wasm"
 version = "0.6.20"
 dependencies = [
  "event-listener",
+ "fnv",
  "futures",
+ "hashbrown 0.12.1",
  "lazy_static",
  "log",
  "pin-project",

--- a/bin/light-base/src/lib.rs
+++ b/bin/light-base/src/lib.rs
@@ -46,6 +46,7 @@ mod transactions_service;
 mod util;
 
 pub use json_rpc_service::HandleRpcError;
+pub use peer_id::PeerId;
 
 /// See [`Client::add_chain`].
 #[derive(Debug, Clone)]
@@ -199,7 +200,7 @@ pub enum PlatformConnection<TStream, TConnection> {
     SingleStream(TStream),
     /// The connection is made of multiple substreams. The encryption and multiplexing are handled
     /// externally.
-    MultiStream(TConnection, peer_id::PeerId),
+    MultiStream(TConnection, PeerId),
 }
 
 /// Direction in which a substream has been opened. See [`Platform::next_substream`].

--- a/bin/wasm-node/javascript/src/worker/bindings-smoldot-light.ts
+++ b/bin/wasm-node/javascript/src/worker/bindings-smoldot-light.ts
@@ -203,6 +203,12 @@ export default function (config: Config): compat.WasmModuleImports {
             // should never be called.
         },
 
+        // Closes a substream on a multi-stream connection
+        connection_stream_close: (_connectionId: number, _streamId: number) => {
+            // Given that multi-stream connections are never opened at the moment, this function
+            // should never be called.
+        },
+
         // Must queue the data found in the WebAssembly memory at the given pointer. It is assumed
         // that this function is called only when the connection is in an open state.
         stream_send: (connectionId: number, _streamId: number, ptr: number, len: number) => {

--- a/bin/wasm-node/rust/Cargo.toml
+++ b/bin/wasm-node/rust/Cargo.toml
@@ -13,7 +13,9 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 event-listener = { version = "2.5.2" }
+fnv = { version = "1.0.7", default-features = false }
 futures = "0.3.21"
+hashbrown = { version = "0.12.1", default-features = false }
 lazy_static = "1.4.0"
 log = { version = "0.4.17", features = ["std"] }
 pin-project = "1.0.8"

--- a/bin/wasm-node/rust/src/bindings.rs
+++ b/bin/wasm-node/rust/src/bindings.rs
@@ -217,7 +217,14 @@ extern "C" {
     ///
     /// This function will only be called for multi-stream connections. The connection must
     /// currently be in the `Open` state. See the documentation of [`connection_new`] for details.
-    pub fn connection_stream_open(id: u32);
+    pub fn connection_stream_open(connection_id: u32);
+
+    /// Closes an existing substream of a multi-stream connection. The substream must currently
+    /// be in the `Open` state.
+    ///
+    /// This function will only be called for multi-stream connections. The connection must
+    /// currently be in the `Open` state. See the documentation of [`connection_new`] for details.
+    pub fn connection_stream_close(connection_id: u32, stream_id: u32);
 
     /// Queues data on the given stream. The data is found in the memory of the WebAssembly
     /// virtual machine, at the given pointer. The data must be sent as a binary frame.

--- a/bin/wasm-node/rust/src/platform.rs
+++ b/bin/wasm-node/rust/src/platform.rs
@@ -460,7 +460,8 @@ enum ConnectionInner {
         /// Peer id we're connected to.
         peer_id: smoldot_light_base::PeerId,
         /// List of substreams that the host (i.e. JavaScript side) has reported have been opened,
-        /// but that haven't been reported through [`Platform::next_substream`] yet.
+        /// but that haven't been reported through [`smoldot_light_base::Platform::next_substream`]
+        /// yet.
         opened_substreams_to_pick_up: VecDeque<(u32, PlatformSubstreamDirection)>,
         /// Number of objects (connections and streams) in the [`Platform`] API that reference
         /// this connection. If it switches from 1 to 0, the connection must be removed.

--- a/bin/wasm-node/rust/src/platform.rs
+++ b/bin/wasm-node/rust/src/platform.rs
@@ -459,8 +459,8 @@ enum ConnectionInner {
     MultiStream {
         /// Peer id we're connected to.
         peer_id: smoldot_light_base::PeerId,
-        /// List of substreams that the host (i.e. JS side) has reported have been opened, but
-        /// that haven't been reported through [`Platform::next_substream`] yet.
+        /// List of substreams that the host (i.e. JavaScript side) has reported have been opened,
+        /// but that haven't been reported through [`Platform::next_substream`] yet.
         opened_substreams_to_pick_up: VecDeque<(u32, PlatformSubstreamDirection)>,
         /// Number of objects (connections and streams) in the [`Platform`] API that reference
         /// this connection. If it switches from 1 to 0, the connection must be removed.

--- a/bin/wasm-node/rust/src/platform.rs
+++ b/bin/wasm-node/rust/src/platform.rs
@@ -600,7 +600,7 @@ pub(crate) fn connection_stream_opened(connection_id: u32, stream_id: u32, outbo
         );
 
         if _prev_value.is_some() {
-            panic!() // StreamId has been reused.
+            panic!("same stream_id used multiple times in connection_stream_opened")
         }
 
         opened_substreams_to_pick_up.push_back((


### PR DESCRIPTION
As promised, this PR refactors `platform.rs`.

Before this PR, we were allocating objects on the heap then turning the heap pointer into a `u32`. When the JS would call methods, we would convert the `u32` back into a heap pointer. This is a bit risky.

This PR completely removes this and tracks the networking state in two maps, one of connections and one of streams.

It also implements multi-stream connections, and adds a function that was missing in the bindings: `connection_stream_close`.
