### PR TITLE
No longer panic in the old subscription JSON-RPC functions if block can't be decoded

### DIFF
--- a/bin/light-base/src/json_rpc_service/state_chain.rs
+++ b/bin/light-base/src/json_rpc_service/state_chain.rs
@@ -440,16 +440,29 @@ impl<TPlat: Platform> Background<TPlat> {
                                 ))
                                 .await;
 
+                            let header = match methods::Header::from_scale_encoded_header(
+                                &block.scale_encoded_header,
+                            ) {
+                                Ok(h) => h,
+                                Err(error) => {
+                                    log::warn!(
+                                        target: &me.log_target,
+                                        "`chain_subscribeAllHeads` subscription has skipped \
+                                        block due to undecodable header. Hash: {}. Error: {}",
+                                        HashDisplay(&header::hash_from_scale_encoded_header(&block.scale_encoded_header)),
+                                        error,
+                                    );
+                                    continue;
+                                }
+                            };
+
                             let _ = me
                                 .requests_subscriptions
                                 .try_push_notification(
                                     &state_machine_subscription,
                                     methods::ServerToClient::chain_newHead {
                                         subscription: (&subscription_id).into(),
-                                        result: methods::Header::from_scale_encoded_header(
-                                            &block.scale_encoded_header,
-                                        )
-                                        .unwrap(),
+                                        result: header,
                                     }
                                     .to_json_call_object_parameters(None),
                                 )
@@ -457,7 +470,7 @@ impl<TPlat: Platform> Background<TPlat> {
                         }
                         Some(runtime_service::Notification::Finalized { .. }) => {}
                         None => {
-                            // TODO: ?!
+                            // TODO: must recreate the channel
                             return;
                         }
                     }
@@ -538,28 +551,34 @@ impl<TPlat: Platform> Background<TPlat> {
             let me = self.clone();
             async move {
                 loop {
-                    match blocks_list.next().await {
-                        Some(block) => {
-                            let header =
-                                methods::Header::from_scale_encoded_header(&block).unwrap();
+                    // Stream returned by `subscribe_finalized` is always unlimited.
+                    let header = blocks_list.next().await.unwrap();
 
-                            me.requests_subscriptions
-                                .set_queued_notification(
-                                    &state_machine_subscription,
-                                    0,
-                                    methods::ServerToClient::chain_finalizedHead {
-                                        subscription: (&subscription_id).into(),
-                                        result: header,
-                                    }
-                                    .to_json_call_object_parameters(None),
-                                )
-                                .await;
+                    let header = match methods::Header::from_scale_encoded_header(&header) {
+                        Ok(h) => h,
+                        Err(error) => {
+                            log::warn!(
+                                target: &me.log_target,
+                                "`chain_subscribeFinalizedHeads` subscription has skipped block \
+                                due to undecodable header. Hash: {}. Error: {}",
+                                HashDisplay(&header::hash_from_scale_encoded_header(&header)),
+                                error,
+                            );
+                            continue;
                         }
-                        None => {
-                            // TODO: ?!
-                            return;
-                        }
-                    }
+                    };
+
+                    me.requests_subscriptions
+                        .set_queued_notification(
+                            &state_machine_subscription,
+                            0,
+                            methods::ServerToClient::chain_finalizedHead {
+                                subscription: (&subscription_id).into(),
+                                result: header,
+                            }
+                            .to_json_call_object_parameters(None),
+                        )
+                        .await;
                 }
             }
         };

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Block headers with a digest item of type `Other` no longer fail to parse. ([#2425](https://github.com/paritytech/smoldot/pull/2425))
 
+### Fixed
+
+- The `chain_subscribeAllHeads`, `chain_subscribeNewHeads`, and `chain_subscribeFinalizedHeads` JSON-RPC functions no longer panic if connected to a chain whose headers are in a format that can't be decoded. Instead, no notification is sent and a warning is printed. ([#2442](https://github.com/paritytech/smoldot/pull/2442))
+
 ## 0.6.20 - 2022-06-23
 
 ### Changed


### PR DESCRIPTION
In the case of a relay chain, we simply cannot sync if the block headers are in a format that can't be decoded.
However, in the case of a parachain, it is actually possible to follow the chain without decoding headers.
In that situation, the JSON-RPC functions shouldn't panic.