### PR TITLE
Adjust when log message about block request error is printed

### DIFF
--- a/bin/light-base/src/network_service.rs
+++ b/bin/light-base/src/network_service.rs
@@ -444,7 +444,10 @@ impl<TPlat: Platform> NetworkService<TPlat> {
 
         if !log::log_enabled!(log::Level::Debug) {
             match &result {
-                Ok(_) | Err(service::BlocksRequestError::Request(_)) => {}
+                Ok(_)
+                | Err(service::BlocksRequestError::EmptyResponse)
+                | Err(service::BlocksRequestError::NotVerifiable) => {}
+                Err(service::BlocksRequestError::Request(err)) if !err.is_protocol_error() => {}
                 Err(err) => {
                     log::warn!(
                         target: "network",

--- a/src/libp2p/collection.rs
+++ b/src/libp2p/collection.rs
@@ -1771,6 +1771,17 @@ pub enum RequestError {
     Substream(established::RequestError),
 }
 
+impl RequestError {
+    /// Returns `true` if the error is caused by a faulty behavior by the remote. Returns `false`
+    /// if the error can happen in normal situations.
+    pub fn is_protocol_error(&self) -> bool {
+        match self {
+            RequestError::ConnectionShutdown => false,
+            RequestError::Substream(err) => err.is_protocol_error(),
+        }
+    }
+}
+
 #[derive(Debug, derive_more::Display, Clone)]
 pub enum NotificationsOutErr {
     /// Opening has been interrupted because the connection as a whole is being shut down.

--- a/src/libp2p/connection/established/substream.rs
+++ b/src/libp2p/connection/established/substream.rs
@@ -1585,6 +1585,21 @@ pub enum RequestError {
     ResponseLebError(leb128::FramedError),
 }
 
+impl RequestError {
+    /// Returns `true` if the error is caused by a faulty behavior by the remote. Returns `false`
+    /// if the error can happen in normal situations.
+    pub fn is_protocol_error(&self) -> bool {
+        match self {
+            RequestError::Timeout => false, // Remote is likely overloaded.
+            RequestError::ProtocolNotAvailable => true,
+            RequestError::SubstreamClosed => false,
+            RequestError::SubstreamReset => true,
+            RequestError::NegotiationError(_) => true,
+            RequestError::ResponseLebError(_) => true,
+        }
+    }
+}
+
 /// Error potentially returned by [`Substream::respond_in_request`].
 #[derive(Debug, derive_more::Display)]
 pub enum RespondInRequestError {


### PR DESCRIPTION
At the moment, if a blocks request fails we print a warning log message saying that the peer is likely incompatible.

We do this even when it doesn't make sense (such as `EmptyResponse`, which simply indicates that the remote doesn't know the requested block), and we don't print it in some situations where it should make sense (for example protocol not supported).

This PR tweaks the condition under which we print the log message.
