### PR TITLE
Add BestBlockChanged notif in sync and runtime services

### DIFF
--- a/bin/light-base/src/json_rpc_service.rs
+++ b/bin/light-base/src/json_rpc_service.rs
@@ -652,7 +652,8 @@ impl<TPlat: Platform> Background<TPlat> {
                                     .recent_pinned_blocks
                                     .put(hash, block.scale_encoded_header);
                             }
-                            Some(runtime_service::Notification::Finalized { .. }) => {}
+                            Some(runtime_service::Notification::Finalized { .. })
+                            | Some(runtime_service::Notification::BestBlockChanged { .. }) => {}
                             None => break,
                         }
                     }

--- a/bin/light-base/src/json_rpc_service/chain_head.rs
+++ b/bin/light-base/src/json_rpc_service/chain_head.rs
@@ -670,6 +670,26 @@ impl<TPlat: Platform> Background<TPlat> {
                                 break;
                             }
                         }
+                        either::Left(Some(runtime_service::Notification::BestBlockChanged {
+                            hash,
+                        }))
+                        | either::Right(Some(sync_service::Notification::BestBlockChanged {
+                            hash,
+                        })) => {
+                            let _ = me
+                                .requests_subscriptions
+                                .try_push_notification(
+                                    &state_machine_subscription,
+                                    methods::ServerToClient::chainHead_unstable_followEvent {
+                                        subscription: (&subscription_id).into(),
+                                        result: methods::FollowEvent::BestBlockChanged {
+                                            best_block_hash: methods::HashHexString(hash),
+                                        },
+                                    }
+                                    .to_json_call_object_parameters(None),
+                                )
+                                .await;
+                        }
                         either::Left(Some(runtime_service::Notification::Block(block))) => {
                             let hash =
                                 header::hash_from_scale_encoded_header(&block.scale_encoded_header);

--- a/bin/light-base/src/json_rpc_service/state_chain.rs
+++ b/bin/light-base/src/json_rpc_service/state_chain.rs
@@ -468,7 +468,8 @@ impl<TPlat: Platform> Background<TPlat> {
                                 )
                                 .await;
                         }
-                        Some(runtime_service::Notification::Finalized { .. }) => {}
+                        Some(runtime_service::Notification::BestBlockChanged { .. })
+                        | Some(runtime_service::Notification::Finalized { .. }) => {}
                         None => {
                             // TODO: must recreate the channel
                             return;

--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -610,6 +610,15 @@ pub enum Notification {
 
     /// A new block has been added to the list of unfinalized blocks.
     Block(BlockNotification),
+
+    /// The best block has changed to a different one.
+    BestBlockChanged {
+        /// Hash of the new best block.
+        ///
+        /// This can be either the hash of the latest finalized block or the hash of a
+        /// non-finalized block.
+        hash: [u8; 32],
+    },
 }
 
 /// Notification about a new block.
@@ -1276,6 +1285,34 @@ async fn run_background<TPlat: Platform>(
 
                             background.finalize(hash, best_block_hash).await;
                         }
+                        Some(sync_service::Notification::BestBlockChanged { hash }) => {
+                            log::debug!(
+                                target: &log_target,
+                                "Worker <= BestBlockChanged(hash={})",
+                                HashDisplay(&hash)
+                            );
+
+                            let near_head_of_chain = background.sync_service.is_near_head_of_chain_heuristic().await;
+
+                            let mut guarded = background.guarded.lock().await;
+                            let mut guarded = &mut *guarded;
+                            guarded.best_near_head_of_chain = near_head_of_chain;
+
+                            match &mut guarded.tree {
+                                GuardedInner::FinalizedBlockRuntimeKnown {
+                                    tree, ..
+                                } => {
+                                    let idx = tree.input_iter_unordered().find(|block| block.user_data.hash == hash).unwrap().id;
+                                    tree.input_set_best_block(idx);
+                                }
+                                GuardedInner::FinalizedBlockRuntimeUnknown { tree, .. } => {
+                                    let idx = tree.input_iter_unordered().find(|block| block.user_data.hash == hash).unwrap().id;
+                                    tree.input_set_best_block(idx);
+                                }
+                            }
+
+                            background.advance_and_notify_subscribers(guarded);
+                        }
                     };
 
                     // TODO: process any other pending event from blocks_stream before doing that; otherwise we might start download for blocks that we don't care about because they're immediately overwritten by others
@@ -1601,12 +1638,43 @@ impl<TPlat: Platform> Background<TPlat> {
                             }
                         }
                     }
+                    Some(async_tree::OutputUpdate::BestBlockChanged { best_block_index }) => {
+                        let hash = best_block_index
+                            .map_or(&*finalized_block, |idx| tree.block_user_data(idx))
+                            .hash;
+
+                        log::debug!(
+                            target: &self.log_target,
+                            "Worker => OutputBestBlockChanged(hash={})",
+                            HashDisplay(&hash),
+                        );
+
+                        let notif = Notification::BestBlockChanged { hash };
+
+                        let mut to_remove = Vec::new();
+                        for (subscription_id, (sender, _)) in all_blocks_subscriptions.iter_mut() {
+                            if sender.try_send(notif.clone()).is_err() {
+                                to_remove.push(*subscription_id);
+                            }
+                        }
+                        for to_remove in to_remove {
+                            all_blocks_subscriptions.remove(&to_remove);
+                            let pinned_blocks_to_remove = pinned_blocks
+                                .range((to_remove, [0; 32])..=(to_remove, [0xff; 32]))
+                                .map(|((_, h), _)| *h)
+                                .collect::<Vec<_>>();
+                            for block in pinned_blocks_to_remove {
+                                pinned_blocks.remove(&(to_remove, block));
+                            }
+                        }
+                    }
                 },
                 GuardedInner::FinalizedBlockRuntimeUnknown { tree, when_known } => match tree
                     .try_advance_output()
                 {
                     None => break,
-                    Some(async_tree::OutputUpdate::Block(_)) => continue,
+                    Some(async_tree::OutputUpdate::Block(_))
+                    | Some(async_tree::OutputUpdate::BestBlockChanged { .. }) => continue,
                     Some(async_tree::OutputUpdate::Finalized {
                         user_data: new_finalized,
                         former_finalized_async_op_user_data,

--- a/bin/light-base/src/sync_service.rs
+++ b/bin/light-base/src/sync_service.rs
@@ -728,6 +728,15 @@ pub enum Notification {
 
     /// A new block has been added to the list of unfinalized blocks.
     Block(BlockNotification),
+
+    /// The best block has changed to a different one.
+    BestBlockChanged {
+        /// Hash of the new best block.
+        ///
+        /// This can be either the hash of the latest finalized block or the hash of a
+        /// non-finalized block.
+        hash: [u8; 32],
+    },
 }
 
 /// Notification about a new block.

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -410,8 +410,6 @@ pub(super) async fn start_parachain<TPlat: Platform>(
 
                             let node_idx = async_tree.input_iter_unordered().find(|b| *b.user_data == hash).unwrap().id;
                             async_tree.input_set_best_block(node_idx);
-
-                            // TODO: check if this updates the best parablock?
                         }
                     };
                 },

--- a/bin/light-base/src/transactions_service.rs
+++ b/bin/light-base/src/transactions_service.rs
@@ -629,6 +629,9 @@ async fn background_task<TPlat: Platform>(
                                 // download of that block, but it is not worth the effort.
                             }
                         },
+                        Some(runtime_service::Notification::BestBlockChanged { hash }) => {
+                            worker.set_best_block(&log_target, &hash);
+                        },
                         None => continue 'channels_rebuild
                     }
                 },

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Changes in the current best block of a parachain are now taken into account if the new best block had already been reported in the past. ([#2457](https://github.com/paritytech/smoldot/pull/2457))
+
 ## 0.6.21 - 2022-06-30
 
 ### Added

--- a/src/chain/async_tree.rs
+++ b/src/chain/async_tree.rs
@@ -770,6 +770,45 @@ where
         )
     }
 
+    /// Updates the state machine to take into account that the best block of the input has been
+    /// modified.
+    ///
+    /// # Panic
+    ///
+    /// Panics if `new_best_block` isn't a valid node.
+    /// Panics if `new_best_block` isn't equal or a descendant of the input finalized block.
+    ///
+    pub fn input_set_best_block(&mut self, new_best_block: NodeIndex) {
+        // Make sure that `new_best_block` is a descendant of the current input finalized block,
+        // otherwise the state of the tree will be corrupted.
+        // This is checked with an `assert!` rather than a `debug_assert!`, as this constraint
+        // is part of the public API of this method.
+        assert!(self.input_finalized_index.map_or(true, |fin_idx| self
+            .non_finalized_blocks
+            .is_ancestor(fin_idx, new_best_block)));
+
+        // If necessary, update the weight of the block.
+        // TODO: this will panic if the new best block is equal to the output finalized block?
+        match &mut self
+            .non_finalized_blocks
+            .get_mut(new_best_block)
+            .unwrap()
+            .input_best_block_weight
+        {
+            w if *w == self.input_best_block_next_weight - 1 => {}
+            w => {
+                *w = self.input_best_block_next_weight;
+                self.input_best_block_next_weight += 1;
+            }
+        }
+
+        // Minor sanity checks.
+        debug_assert!(self
+            .non_finalized_blocks
+            .iter_unordered()
+            .all(|(_, b)| b.input_best_block_weight < self.input_best_block_next_weight));
+    }
+
     /// Updates the state machine to take into account that the input of blocks has finalized the
     /// given block.
     ///
@@ -1018,6 +1057,58 @@ where
             }));
         }
 
+        // Try to advance the output best block.
+        {
+            let mut best_block_updated = false;
+
+            // Try to advance the output best block to the `Finished` block with the highest
+            // weight.
+            // Weight of the current output best block.
+            let mut current_runtime_service_best_block_weight = match self.best_block_index {
+                None => self.finalized_block_weight,
+                Some(idx) => {
+                    self.non_finalized_blocks
+                        .get(idx)
+                        .unwrap()
+                        .input_best_block_weight
+                }
+            };
+
+            for (node_index, block) in self.non_finalized_blocks.iter_unordered() {
+                // Check uniqueness of weights.
+                debug_assert!(
+                    block.input_best_block_weight != current_runtime_service_best_block_weight
+                        || block.input_best_block_weight == 0
+                        || self.best_block_index == Some(node_index)
+                );
+
+                if block.input_best_block_weight <= current_runtime_service_best_block_weight {
+                    continue;
+                }
+
+                if !matches!(
+                    block.async_op,
+                    AsyncOpState::Finished { reported: true, .. }
+                ) {
+                    continue;
+                }
+
+                // Input best can be updated to the block being iterated.
+                current_runtime_service_best_block_weight = block.input_best_block_weight;
+                self.best_block_index = Some(node_index);
+                best_block_updated = true;
+
+                // Continue looping, as there might be another block with an even
+                // higher weight.
+            }
+
+            if best_block_updated {
+                return Some(OutputUpdate::BestBlockChanged {
+                    best_block_index: self.best_block_index,
+                });
+            }
+        }
+
         // Nothing to do.
         None
     }
@@ -1083,6 +1174,13 @@ pub enum OutputUpdate<'a, TBl, TAsync> {
 
     /// A new block has been added to the list of output unfinalized blocks.
     Block(OutputUpdateBlock<'a, TBl, TAsync>),
+
+    /// The output best block has been modified.
+    BestBlockChanged {
+        /// Index of the best block after the finalization. `None` if the best block is the
+        /// output finalized block.
+        best_block_index: Option<NodeIndex>,
+    },
 }
 
 /// See [`OutputUpdate`].


### PR DESCRIPTION
This PR fixes a hole in the notifications sent by the syncing service and runtime service.

The problem is as follows:
- Let's say that that there's a new best relay chain block R1 containing parachain block P1. We report P1 as the new best parachain block.
- Then there's a new best relay chain block R2 containing parachain block P2. We report P2 as the new best parachain block.
- Then there's a new best relay chain block R3 containing parachain block P1.

Normally, we should report P1 as the new best parachain block.
However, it is at the moment not possible to do so. The only way to report a change in the best chain is either when a new block arrives or when a block gets finalized.
This PR therefore introduces a new event `BestBlockUpdated`, which gets generated specifically in this kind of situation.

In addition to the parachain syncing code, introducing this new event required modifications to several other parts of the code: the JSON-RPC service, the transactions service, the runtime service, and the asynchronous tree.

I took the liberty to rename the `non_finalized_headers` variable in the JSON-RPC service to `headers`, as this variable also contains the current finalized block (which is an important detail) and this name is therefore misleading.

I'm aware of the fact that the `async_tree` is starting to be a bit chaotic, but improving it is a big effort that is out of scope of this PR.
