### PR TITLE
Tweak whether enableCurrentTask is enabled

### DIFF
--- a/bin/wasm-node/javascript/src/client.ts
+++ b/bin/wasm-node/javascript/src/client.ts
@@ -566,7 +566,10 @@ export function start(options?: ClientOptions): Client {
     // Maximum level of log entries sent by the client.
     // 0 = Logging disabled, 1 = Error, 2 = Warn, 3 = Info, 4 = Debug, 5 = Trace
     maxLogLevel: options.maxLogLevel || 3,
-    enableCurrentTask: true, // TODO: make this configurable? `true` slows things down but makes it easily debuggable
+    // `enableCurrentTask` adds a small performance hit, but adds some additional information to
+    // crash reports. Whether this should be enabled is very opiniated and not that important. At
+    // the moment, we enable it all the time, except if the user has logging disabled altogether.
+    enableCurrentTask: options.maxLogLevel ? options.maxLogLevel >= 1 : true,
     cpuRateLimit: options.cpuRateLimit || 1.0,
     forbidTcp: options.forbidTcp || false,
     forbidWs: options.forbidWs || false,


### PR DESCRIPTION
As explained in the comment, `enableCurrentTask` adds a small overhead but provides additional useful information in crash reports. This PR enables it iff logging is enabled.