### PR TITLE
Don't always invalidate cache of runtime after finality proof

### DIFF
--- a/bin/light-base/src/sync_service/standalone.rs
+++ b/bin/light-base/src/sync_service/standalone.rs
@@ -787,7 +787,14 @@ impl<TPlat: Platform> Task<TPlat> {
                             self.network_up_to_date_best = false;
                         }
                         self.network_up_to_date_finalized = false;
-                        self.known_finalized_runtime = None; // TODO: only do if there was no RuntimeUpdated log item
+                        // Invalidate the cache of the runtime of the finalized blocks if any
+                        // of the finalized blocks indicates that a runtime update happened.
+                        if finalized_blocks
+                            .iter()
+                            .any(|b| b.header.digest.has_runtime_environment_updated())
+                        {
+                            self.known_finalized_runtime = None;
+                        }
                         self.dispatch_all_subscribers(Notification::Finalized {
                             hash: self.sync.finalized_block_header().hash(),
                             best_block_hash: self.sync.best_block_hash(),


### PR DESCRIPTION
The sync service needs to download the runtime of the chain in order to do a warp sync. After the warp sync is finished, the runtime that we used is stored in a cache. The value in this cache is later grabbed when the runtime service initializes.

Right now we clear the content of this cache if the finalized block changes. This PR modifies this to clear the cache only if one of the finalized blocks indicates that a runtime update happened.

In practice, this change most likely doesn't do anything. The runtime service initializes (and the value in cache is grabbed) as soon as it is notified of the warp sync being finished. The chances that a finality proof is received and verified in-between are extremely low. But still, this PR does it more correctly.
