### PR TITLE
Silence NoPeers discovery errors

### DIFF
--- a/bin/light-base/src/network_service.rs
+++ b/bin/light-base/src/network_service.rs
@@ -1153,12 +1153,23 @@ async fn update_round<TPlat: Platform>(
                             guarded.network.discover(&TPlat::now(), chain_index, nodes);
                         }
                         Err(error) => {
-                            log::warn!(
+                            log::debug!(
                                 target: "connections",
-                                "Problem during discovery on {}: {}",
-                                &shared.log_chain_names[chain_index],
+                                "Discovery => {:?}",
                                 error
                             );
+
+                            // No error is printed if the error is about the fact that we have
+                            // 0 peers, as this tends to happen quite frequently at initialization
+                            // and there is nothing that can be done against this error anyway.
+                            if !matches!(error, service::DiscoveryError::NoPeer) {
+                                log::warn!(
+                                    target: "connections",
+                                    "Problem during discovery on {}: {}",
+                                    &shared.log_chain_names[chain_index],
+                                    error
+                                );
+                            }
                         }
                     }
                 }

--- a/bin/light-base/src/network_service.rs
+++ b/bin/light-base/src/network_service.rs
@@ -1162,13 +1162,21 @@ async fn update_round<TPlat: Platform>(
                             // No error is printed if the error is about the fact that we have
                             // 0 peers, as this tends to happen quite frequently at initialization
                             // and there is nothing that can be done against this error anyway.
-                            if !matches!(error, service::DiscoveryError::NoPeer) {
-                                log::warn!(
-                                    target: "connections",
-                                    "Problem during discovery on {}: {}",
-                                    &shared.log_chain_names[chain_index],
-                                    error
-                                );
+                            // No error is printed either if the request fails due to a benign
+                            // networking error such as an unresponsive peer.
+                            match error {
+                                service::DiscoveryError::NoPeer => {}
+                                service::DiscoveryError::FindNode(
+                                    service::KademliaFindNodeError::RequestFailed(err),
+                                ) if !err.is_protocol_error() => {}
+                                _ => {
+                                    log::warn!(
+                                        target: "connections",
+                                        "Problem during discovery on {}: {}",
+                                        &shared.log_chain_names[chain_index],
+                                        error
+                                    );
+                                }
                             }
                         }
                     }

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Changed
+
+- No warning is generated anymore if the discovery process doesn't work due to having 0 peers.
+
 ### Fixed
 
 - Changes in the current best block of a parachain are now taken into account if the new best block had already been reported in the past. ([#2457](https://github.com/paritytech/smoldot/pull/2457))

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Changed
 
-- No warning is generated anymore if the discovery process doesn't work due to having 0 peers. ([#2476](https://github.com/paritytech/smoldot/pull/2476))
+- No warning is generated anymore if the discovery process doesn't work due to having 0 peers, or failed due to a benign networking issue. ([#2476](https://github.com/paritytech/smoldot/pull/2476))
 
 ### Fixed
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Changed
 
-- No warning is generated anymore if the discovery process doesn't work due to having 0 peers.
+- No warning is generated anymore if the discovery process doesn't work due to having 0 peers. ([#2476](https://github.com/paritytech/smoldot/pull/2476))
 
 ### Fixed
 


### PR DESCRIPTION
People keep mentioning this warning about no peers, but there's actually nothing that can be done anyway, and thus no point in printing the warning.