### PR TITLE
Use block_number_bytes when decoding justifications

### DIFF
--- a/bin/fuzz/fuzz_targets/grandpa-justification-parse.rs
+++ b/bin/fuzz/fuzz_targets/grandpa-justification-parse.rs
@@ -17,6 +17,9 @@
 
 #![no_main]
 
-libfuzzer_sys::fuzz_target!(|data: &[u8]| {
-    let _ = smoldot::finality::justification::decode::decode_grandpa(data);
+libfuzzer_sys::fuzz_target!(|params: (&[u8], u8)| {
+    let _ = smoldot::finality::justification::decode::decode_grandpa(
+        params.0,
+        usize::from(params.1) + 1,
+    );
 });

--- a/bin/fuzz/fuzz_targets/protocol-grandpa-warp-sync-response-decode.rs
+++ b/bin/fuzz/fuzz_targets/protocol-grandpa-warp-sync-response-decode.rs
@@ -17,6 +17,9 @@
 
 #![no_main]
 
-libfuzzer_sys::fuzz_target!(|data: &[u8]| {
-    let _ = smoldot::network::protocol::decode_grandpa_warp_sync_response(data);
+libfuzzer_sys::fuzz_target!(|params: (&[u8], u8)| {
+    let _ = smoldot::network::protocol::decode_grandpa_warp_sync_response(
+        params.0,
+        usize::from(params.1) + 1,
+    );
 });

--- a/src/chain/blocks_tree/finality.rs
+++ b/src/chain/blocks_tree/finality.rs
@@ -309,8 +309,11 @@ impl<T> NonFinalizedTreeInner<T> {
         match (&self.finality, &consensus_engine_id) {
             (Finality::Grandpa { .. }, b"FRNK") => {
                 // Turn justification into a strongly-typed struct.
-                let decoded = justification::decode::decode_grandpa(scale_encoded_justification)
-                    .map_err(JustificationVerifyError::InvalidJustification)?;
+                let decoded = justification::decode::decode_grandpa(
+                    scale_encoded_justification,
+                    self.block_number_bytes,
+                )
+                .map_err(JustificationVerifyError::InvalidJustification)?;
 
                 // Delegate the first step to the other function.
                 let (block_index, authorities_set_id, authorities_list) = self
@@ -319,6 +322,7 @@ impl<T> NonFinalizedTreeInner<T> {
 
                 justification::verify::verify(justification::verify::Config {
                     justification: decoded,
+                    block_number_bytes: self.block_number_bytes,
                     authorities_set_id,
                     authorities_list,
                 })

--- a/src/finality/justification/decode.rs
+++ b/src/finality/justification/decode.rs
@@ -21,10 +21,14 @@ use alloc::vec::Vec;
 use core::fmt;
 
 /// Attempt to decode the given SCALE-encoded justification.
-pub fn decode_grandpa(scale_encoded: &[u8]) -> Result<GrandpaJustificationRef, Error> {
-    match nom::combinator::complete(nom::combinator::all_consuming(grandpa_justification))(
-        scale_encoded,
-    ) {
+pub fn decode_grandpa(
+    scale_encoded: &[u8],
+    block_number_bytes: usize,
+) -> Result<GrandpaJustificationRef, Error> {
+    match nom::combinator::complete(nom::combinator::all_consuming(grandpa_justification(
+        block_number_bytes,
+    )))(scale_encoded)
+    {
         Ok((_, justification)) => Ok(justification),
         Err(nom::Err::Error(err) | nom::Err::Failure(err)) => Err(Error(err.code)),
         Err(_) => unreachable!(),
@@ -37,8 +41,9 @@ pub fn decode_grandpa(scale_encoded: &[u8]) -> Result<GrandpaJustificationRef, E
 /// the remainder.
 pub fn decode_partial_grandpa(
     scale_encoded: &[u8],
+    block_number_bytes: usize,
 ) -> Result<(GrandpaJustificationRef, &[u8]), Error> {
-    match nom::combinator::complete(grandpa_justification)(scale_encoded) {
+    match nom::combinator::complete(grandpa_justification(block_number_bytes))(scale_encoded) {
         Ok((remainder, justification)) => Ok((justification, remainder)),
         Err(nom::Err::Error(err) | nom::Err::Failure(err)) => Err(Error(err.code)),
         Err(_) => unreachable!(),
@@ -53,7 +58,7 @@ const PRECOMMIT_ENCODED_LEN: usize = 32 + 4 + 64 + 32;
 pub struct GrandpaJustificationRef<'a> {
     pub round: u64,
     pub target_hash: &'a [u8; 32],
-    pub target_number: u32,
+    pub target_number: u64,
     pub precommits: PrecommitsRef<'a>,
     pub votes_ancestries: VotesAncestriesIter<'a>,
 }
@@ -64,7 +69,7 @@ pub struct GrandpaJustificationRef<'a> {
 pub struct GrandpaJustification {
     pub round: u64,
     pub target_hash: [u8; 32],
-    pub target_number: u32,
+    pub target_number: u64,
     pub precommits: Vec<Precommit>,
     // TODO: pub votes_ancestries: Vec<Header>,
 }
@@ -108,19 +113,26 @@ impl<'a> fmt::Debug for PrecommitsRef<'a> {
 
 #[derive(Copy, Clone)]
 enum PrecommitsRefInner<'a> {
-    Undecoded(&'a [u8]),
+    Undecoded {
+        data: &'a [u8],
+        block_number_bytes: usize,
+    },
     Decoded(&'a [Precommit]),
 }
 
 impl<'a> PrecommitsRef<'a> {
     pub fn iter(&self) -> impl ExactSizeIterator<Item = PrecommitRef<'a>> + 'a {
         match self.inner {
-            PrecommitsRefInner::Undecoded(slice) => {
-                debug_assert_eq!(slice.len() % PRECOMMIT_ENCODED_LEN, 0);
+            PrecommitsRefInner::Undecoded {
+                data,
+                block_number_bytes,
+            } => {
+                debug_assert_eq!(data.len() % PRECOMMIT_ENCODED_LEN, 0);
                 PrecommitsRefIter {
                     inner: PrecommitsRefIterInner::Undecoded {
-                        remaining_len: slice.len() / PRECOMMIT_ENCODED_LEN,
-                        pointer: slice,
+                        block_number_bytes,
+                        remaining_len: data.len() / PRECOMMIT_ENCODED_LEN,
+                        pointer: data,
                     },
                 }
             }
@@ -138,6 +150,7 @@ pub struct PrecommitsRefIter<'a> {
 enum PrecommitsRefIterInner<'a> {
     Decoded(core::slice::Iter<'a, Precommit>),
     Undecoded {
+        block_number_bytes: usize,
         remaining_len: usize,
         pointer: &'a [u8],
     },
@@ -150,6 +163,7 @@ impl<'a> Iterator for PrecommitsRefIter<'a> {
         match &mut self.inner {
             PrecommitsRefIterInner::Decoded(iter) => iter.next().map(Into::into),
             PrecommitsRefIterInner::Undecoded {
+                block_number_bytes,
                 pointer,
                 remaining_len,
             } => {
@@ -157,7 +171,7 @@ impl<'a> Iterator for PrecommitsRefIter<'a> {
                     return None;
                 }
 
-                let (new_pointer, precommit) = precommit(pointer).unwrap();
+                let (new_pointer, precommit) = precommit(*block_number_bytes)(pointer).unwrap();
                 *pointer = new_pointer;
                 *remaining_len -= 1;
 
@@ -183,7 +197,7 @@ pub struct PrecommitRef<'a> {
     /// Hash of the block concerned by the pre-commit.
     pub target_hash: &'a [u8; 32],
     /// Height of the block concerned by the pre-commit.
-    pub target_number: u32,
+    pub target_number: u64,
 
     /// Ed25519 signature made with [`PrecommitRef::authority_public_key`].
     // TODO: document what is being signed
@@ -198,8 +212,11 @@ impl<'a> PrecommitRef<'a> {
     /// Decodes a SCALE-encoded precommit.
     ///
     /// Returns the rest of the data alongside with the decoded struct.
-    pub fn decode_partial(scale_encoded: &[u8]) -> Result<(PrecommitRef, &[u8]), Error> {
-        match precommit(scale_encoded) {
+    pub fn decode_partial(
+        scale_encoded: &[u8],
+        block_number_bytes: usize,
+    ) -> Result<(PrecommitRef, &[u8]), Error> {
+        match precommit(block_number_bytes)(scale_encoded) {
             Ok((remainder, precommit)) => Ok((precommit, remainder)),
             Err(nom::Err::Error(err) | nom::Err::Failure(err)) => Err(Error(err.code)),
             Err(_) => unreachable!(),
@@ -212,7 +229,7 @@ pub struct Precommit {
     /// Hash of the block concerned by the pre-commit.
     pub target_hash: [u8; 32],
     /// Height of the block concerned by the pre-commit.
-    pub target_number: u32,
+    pub target_number: u64,
 
     /// Ed25519 signature made with [`PrecommitRef::authority_public_key`].
     // TODO: document what is being signed
@@ -283,15 +300,17 @@ impl<'a> ExactSizeIterator for VotesAncestriesIter<'a> {}
 pub struct Error(nom::error::ErrorKind);
 
 /// `Nom` combinator that parses a justification.
-fn grandpa_justification(bytes: &[u8]) -> nom::IResult<&[u8], GrandpaJustificationRef> {
+fn grandpa_justification<'a>(
+    block_number_bytes: usize,
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], GrandpaJustificationRef> {
     nom::error::context(
         "grandpa_justification",
         nom::combinator::map(
             nom::sequence::tuple((
                 nom::number::complete::le_u64,
                 nom::bytes::complete::take(32u32),
-                nom::number::complete::le_u32,
-                precommits,
+                crate::util::nom_varsize_number_decode_u64(block_number_bytes),
+                precommits(block_number_bytes),
                 votes_ancestries,
             )),
             |(round, target_hash, target_number, precommits, votes_ancestries)| {
@@ -304,35 +323,42 @@ fn grandpa_justification(bytes: &[u8]) -> nom::IResult<&[u8], GrandpaJustificati
                 }
             },
         ),
-    )(bytes)
+    )
 }
 
 /// `Nom` combinator that parses a list of precommits.
-fn precommits(bytes: &[u8]) -> nom::IResult<&[u8], PrecommitsRef> {
+fn precommits<'a>(
+    block_number_bytes: usize,
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], PrecommitsRef> {
     nom::combinator::map(
-        nom::combinator::flat_map(crate::util::nom_scale_compact_usize, |num_elems| {
+        nom::combinator::flat_map(crate::util::nom_scale_compact_usize, move |num_elems| {
             nom::combinator::recognize(nom::multi::fold_many_m_n(
                 num_elems,
                 num_elems,
-                precommit,
+                precommit(block_number_bytes),
                 || {},
                 |(), _| (),
             ))
         }),
-        |inner| PrecommitsRef {
-            inner: PrecommitsRefInner::Undecoded(inner),
+        move |data| PrecommitsRef {
+            inner: PrecommitsRefInner::Undecoded {
+                data,
+                block_number_bytes,
+            },
         },
-    )(bytes)
+    )
 }
 
 /// `Nom` combinator that parses a single precommit.
-fn precommit(bytes: &[u8]) -> nom::IResult<&[u8], PrecommitRef> {
+fn precommit<'a>(
+    block_number_bytes: usize,
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], PrecommitRef> {
     nom::error::context(
         "precommit",
         nom::combinator::map(
             nom::sequence::tuple((
                 nom::bytes::complete::take(32u32),
-                nom::number::complete::le_u32,
+                crate::util::nom_varsize_number_decode_u64(block_number_bytes),
                 nom::bytes::complete::take(64u32),
                 nom::bytes::complete::take(32u32),
             )),
@@ -343,7 +369,7 @@ fn precommit(bytes: &[u8]) -> nom::IResult<&[u8], PrecommitRef> {
                 authority_public_key: TryFrom::try_from(authority_public_key).unwrap(),
             },
         ),
-    )(bytes)
+    )
 }
 
 /// `Nom` combinator that parses a list of headers.
@@ -379,45 +405,50 @@ fn votes_ancestries(bytes: &[u8]) -> nom::IResult<&[u8], VotesAncestriesIter> {
 mod tests {
     #[test]
     fn decode() {
-        super::decode_grandpa(&[
-            7, 181, 6, 0, 0, 0, 0, 0, 41, 241, 171, 236, 144, 172, 25, 157, 240, 109, 238, 59, 160,
-            115, 76, 8, 195, 253, 109, 240, 108, 170, 63, 120, 149, 47, 143, 149, 22, 64, 88, 210,
-            0, 158, 4, 0, 20, 41, 241, 171, 236, 144, 172, 25, 157, 240, 109, 238, 59, 160, 115,
-            76, 8, 195, 253, 109, 240, 108, 170, 63, 120, 149, 47, 143, 149, 22, 64, 88, 210, 0,
-            158, 4, 0, 13, 247, 129, 120, 204, 170, 120, 173, 41, 241, 213, 234, 121, 111, 20, 38,
-            193, 94, 99, 139, 57, 30, 71, 209, 236, 222, 165, 123, 70, 139, 71, 65, 36, 142, 39,
-            13, 94, 240, 44, 174, 150, 85, 149, 223, 166, 82, 210, 103, 40, 129, 102, 26, 212, 116,
-            231, 209, 163, 107, 49, 82, 229, 197, 82, 8, 28, 21, 28, 17, 203, 114, 51, 77, 38, 215,
-            7, 105, 227, 175, 123, 191, 243, 128, 26, 78, 45, 202, 43, 9, 183, 204, 224, 175, 141,
-            216, 19, 7, 41, 241, 171, 236, 144, 172, 25, 157, 240, 109, 238, 59, 160, 115, 76, 8,
-            195, 253, 109, 240, 108, 170, 63, 120, 149, 47, 143, 149, 22, 64, 88, 210, 0, 158, 4,
-            0, 62, 37, 145, 44, 21, 192, 120, 229, 236, 113, 122, 56, 193, 247, 45, 210, 184, 12,
-            62, 220, 253, 147, 70, 133, 85, 18, 90, 167, 201, 118, 23, 107, 184, 187, 3, 104, 170,
-            132, 17, 18, 89, 77, 156, 145, 242, 8, 185, 88, 74, 87, 21, 52, 247, 101, 57, 154, 163,
-            5, 130, 20, 15, 230, 8, 3, 104, 13, 39, 130, 19, 249, 8, 101, 138, 73, 161, 2, 90, 127,
-            70, 108, 25, 126, 143, 182, 250, 187, 94, 98, 34, 10, 123, 215, 95, 134, 12, 171, 41,
-            241, 171, 236, 144, 172, 25, 157, 240, 109, 238, 59, 160, 115, 76, 8, 195, 253, 109,
-            240, 108, 170, 63, 120, 149, 47, 143, 149, 22, 64, 88, 210, 0, 158, 4, 0, 125, 172, 79,
-            71, 1, 38, 137, 128, 232, 95, 70, 104, 217, 95, 7, 58, 28, 114, 182, 216, 171, 56, 231,
-            218, 199, 244, 220, 122, 6, 225, 5, 175, 172, 47, 198, 61, 84, 42, 75, 66, 62, 90, 243,
-            18, 58, 36, 108, 235, 132, 103, 136, 38, 164, 164, 237, 164, 41, 225, 152, 157, 146,
-            237, 24, 11, 142, 89, 54, 135, 0, 234, 137, 226, 191, 137, 34, 204, 158, 75, 134, 214,
-            101, 29, 28, 104, 154, 13, 87, 129, 63, 151, 104, 219, 170, 222, 207, 113, 41, 241,
-            171, 236, 144, 172, 25, 157, 240, 109, 238, 59, 160, 115, 76, 8, 195, 253, 109, 240,
-            108, 170, 63, 120, 149, 47, 143, 149, 22, 64, 88, 210, 0, 158, 4, 0, 68, 192, 211, 142,
-            239, 33, 55, 222, 165, 127, 203, 155, 217, 170, 61, 95, 206, 74, 74, 19, 123, 60, 67,
-            142, 80, 18, 175, 40, 136, 156, 151, 224, 191, 157, 91, 187, 39, 185, 249, 212, 158,
-            73, 197, 90, 54, 222, 13, 76, 181, 134, 69, 3, 165, 248, 94, 196, 68, 186, 80, 218, 87,
-            162, 17, 11, 222, 166, 244, 167, 39, 211, 178, 57, 146, 117, 214, 238, 136, 23, 136,
-            31, 16, 89, 116, 113, 220, 29, 39, 241, 68, 41, 90, 214, 251, 147, 60, 122, 41, 241,
-            171, 236, 144, 172, 25, 157, 240, 109, 238, 59, 160, 115, 76, 8, 195, 253, 109, 240,
-            108, 170, 63, 120, 149, 47, 143, 149, 22, 64, 88, 210, 0, 158, 4, 0, 58, 187, 123, 135,
-            2, 157, 81, 197, 40, 200, 218, 52, 253, 193, 119, 104, 190, 246, 221, 225, 175, 195,
-            177, 218, 209, 175, 83, 119, 98, 175, 196, 48, 67, 76, 59, 223, 13, 202, 48, 1, 10, 99,
-            200, 201, 123, 29, 89, 131, 120, 70, 162, 235, 11, 191, 96, 57, 83, 51, 217, 199, 35,
-            50, 174, 2, 247, 45, 175, 46, 86, 14, 79, 15, 34, 251, 92, 187, 4, 173, 29, 127, 238,
-            133, 10, 171, 35, 143, 208, 20, 193, 120, 118, 158, 126, 58, 155, 132, 0,
-        ])
+        super::decode_grandpa(
+            &[
+                7, 181, 6, 0, 0, 0, 0, 0, 41, 241, 171, 236, 144, 172, 25, 157, 240, 109, 238, 59,
+                160, 115, 76, 8, 195, 253, 109, 240, 108, 170, 63, 120, 149, 47, 143, 149, 22, 64,
+                88, 210, 0, 158, 4, 0, 20, 41, 241, 171, 236, 144, 172, 25, 157, 240, 109, 238, 59,
+                160, 115, 76, 8, 195, 253, 109, 240, 108, 170, 63, 120, 149, 47, 143, 149, 22, 64,
+                88, 210, 0, 158, 4, 0, 13, 247, 129, 120, 204, 170, 120, 173, 41, 241, 213, 234,
+                121, 111, 20, 38, 193, 94, 99, 139, 57, 30, 71, 209, 236, 222, 165, 123, 70, 139,
+                71, 65, 36, 142, 39, 13, 94, 240, 44, 174, 150, 85, 149, 223, 166, 82, 210, 103,
+                40, 129, 102, 26, 212, 116, 231, 209, 163, 107, 49, 82, 229, 197, 82, 8, 28, 21,
+                28, 17, 203, 114, 51, 77, 38, 215, 7, 105, 227, 175, 123, 191, 243, 128, 26, 78,
+                45, 202, 43, 9, 183, 204, 224, 175, 141, 216, 19, 7, 41, 241, 171, 236, 144, 172,
+                25, 157, 240, 109, 238, 59, 160, 115, 76, 8, 195, 253, 109, 240, 108, 170, 63, 120,
+                149, 47, 143, 149, 22, 64, 88, 210, 0, 158, 4, 0, 62, 37, 145, 44, 21, 192, 120,
+                229, 236, 113, 122, 56, 193, 247, 45, 210, 184, 12, 62, 220, 253, 147, 70, 133, 85,
+                18, 90, 167, 201, 118, 23, 107, 184, 187, 3, 104, 170, 132, 17, 18, 89, 77, 156,
+                145, 242, 8, 185, 88, 74, 87, 21, 52, 247, 101, 57, 154, 163, 5, 130, 20, 15, 230,
+                8, 3, 104, 13, 39, 130, 19, 249, 8, 101, 138, 73, 161, 2, 90, 127, 70, 108, 25,
+                126, 143, 182, 250, 187, 94, 98, 34, 10, 123, 215, 95, 134, 12, 171, 41, 241, 171,
+                236, 144, 172, 25, 157, 240, 109, 238, 59, 160, 115, 76, 8, 195, 253, 109, 240,
+                108, 170, 63, 120, 149, 47, 143, 149, 22, 64, 88, 210, 0, 158, 4, 0, 125, 172, 79,
+                71, 1, 38, 137, 128, 232, 95, 70, 104, 217, 95, 7, 58, 28, 114, 182, 216, 171, 56,
+                231, 218, 199, 244, 220, 122, 6, 225, 5, 175, 172, 47, 198, 61, 84, 42, 75, 66, 62,
+                90, 243, 18, 58, 36, 108, 235, 132, 103, 136, 38, 164, 164, 237, 164, 41, 225, 152,
+                157, 146, 237, 24, 11, 142, 89, 54, 135, 0, 234, 137, 226, 191, 137, 34, 204, 158,
+                75, 134, 214, 101, 29, 28, 104, 154, 13, 87, 129, 63, 151, 104, 219, 170, 222, 207,
+                113, 41, 241, 171, 236, 144, 172, 25, 157, 240, 109, 238, 59, 160, 115, 76, 8, 195,
+                253, 109, 240, 108, 170, 63, 120, 149, 47, 143, 149, 22, 64, 88, 210, 0, 158, 4, 0,
+                68, 192, 211, 142, 239, 33, 55, 222, 165, 127, 203, 155, 217, 170, 61, 95, 206, 74,
+                74, 19, 123, 60, 67, 142, 80, 18, 175, 40, 136, 156, 151, 224, 191, 157, 91, 187,
+                39, 185, 249, 212, 158, 73, 197, 90, 54, 222, 13, 76, 181, 134, 69, 3, 165, 248,
+                94, 196, 68, 186, 80, 218, 87, 162, 17, 11, 222, 166, 244, 167, 39, 211, 178, 57,
+                146, 117, 214, 238, 136, 23, 136, 31, 16, 89, 116, 113, 220, 29, 39, 241, 68, 41,
+                90, 214, 251, 147, 60, 122, 41, 241, 171, 236, 144, 172, 25, 157, 240, 109, 238,
+                59, 160, 115, 76, 8, 195, 253, 109, 240, 108, 170, 63, 120, 149, 47, 143, 149, 22,
+                64, 88, 210, 0, 158, 4, 0, 58, 187, 123, 135, 2, 157, 81, 197, 40, 200, 218, 52,
+                253, 193, 119, 104, 190, 246, 221, 225, 175, 195, 177, 218, 209, 175, 83, 119, 98,
+                175, 196, 48, 67, 76, 59, 223, 13, 202, 48, 1, 10, 99, 200, 201, 123, 29, 89, 131,
+                120, 70, 162, 235, 11, 191, 96, 57, 83, 51, 217, 199, 35, 50, 174, 2, 247, 45, 175,
+                46, 86, 14, 79, 15, 34, 251, 92, 187, 4, 173, 29, 127, 238, 133, 10, 171, 35, 143,
+                208, 20, 193, 120, 118, 158, 126, 58, 155, 132, 0,
+            ],
+            4,
+        )
         .unwrap();
     }
 }

--- a/src/network/protocol/grandpa.rs
+++ b/src/network/protocol/grandpa.rs
@@ -370,16 +370,19 @@ fn catch_up<'a>(
                 nom::combinator::flat_map(crate::util::nom_scale_compact_usize, move |num_elems| {
                     nom::multi::many_m_n(num_elems, num_elems, prevote(block_number_bytes))
                 }),
-                nom::combinator::flat_map(crate::util::nom_scale_compact_usize, |num_elems| {
-                    nom::multi::many_m_n(num_elems, num_elems, |s| {
-                        crate::finality::justification::decode::PrecommitRef::decode_partial(s)
-                            .map(|(a, b)| (b, a))
-                            .map_err(|_| {
-                                nom::Err::Failure(nom::error::make_error(
-                                    s,
-                                    nom::error::ErrorKind::Verify,
-                                ))
-                            })
+                nom::combinator::flat_map(crate::util::nom_scale_compact_usize, move |num_elems| {
+                    nom::multi::many_m_n(num_elems, num_elems, move |s| {
+                        crate::finality::justification::decode::PrecommitRef::decode_partial(
+                            s,
+                            block_number_bytes,
+                        )
+                        .map(|(a, b)| (b, a))
+                        .map_err(|_| {
+                            nom::Err::Failure(nom::error::make_error(
+                                s,
+                                nom::error::ErrorKind::Verify,
+                            ))
+                        })
                     })
                 }),
                 nom::bytes::complete::take(32u32),

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -1320,8 +1320,10 @@ where
                         let response = response
                             .map_err(GrandpaWarpSyncRequestError::Request)
                             .and_then(|payload| {
-                                protocol::decode_grandpa_warp_sync_response(&payload)
-                                    .map_err(GrandpaWarpSyncRequestError::Decode)
+                                protocol::decode_grandpa_warp_sync_response(
+                                    &payload, 4, // TODO: no
+                                )
+                                .map_err(GrandpaWarpSyncRequestError::Decode)
                             });
 
                         break Some(Event::GrandpaWarpSyncRequestResult {

--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -149,6 +149,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
             } else {
                 match warp_sync::warp_sync(warp_sync::Config {
                     start_chain_information: config.chain_information,
+                    block_number_bytes: config.block_number_bytes,
                     sources_capacity: config.sources_capacity,
                 }) {
                     Ok(inner) => AllSyncInner::GrandpaWarpSync { inner },


### PR DESCRIPTION
Fourth point of https://github.com/paritytech/smoldot/issues/2478

Properly parses justifications depending on the number of bytes in the block number.