### PR TITLE
Fix `state_getKeys` and `state_getKeysPaged` almost always erroneously returning an empty result

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix `state_getKeys` and `state_getKeysPaged` almost always erroneously returning an empty result.
+
 ## 0.6.22 - 2022-07-11
 
 ## Changed


### PR DESCRIPTION
The `next` variable, which contains the list of queries to perform at the next iteration, can be empty either because we're done or because no progress could be made.
Since we iterate forever until progress can be made, there's always a point where no progress can be made anymore.

Unfortunately, we were checking `next.is_empty()` too early and assuming that it means that we're done.

This PR fixes the logic to check if any progress has been made before assuming success.
