### PR TITLE
Show error if request is too large

### DIFF
--- a/bin/wasm-node/javascript/src/client.ts
+++ b/bin/wasm-node/javascript/src/client.ts
@@ -428,8 +428,10 @@ export function start(options?: ClientOptions): Client {
             throw new AlreadyDestroyedError();
           if (!options.jsonRpcCallback)
             throw new JsonRpcDisabledError();
-          if (request.length >= 8 * 1024 * 1024)
-            return;
+          if (request.length >= 64 * 1024 * 1024) {
+            console.error("Client.sendJsonRpc ignored a JSON-RPC request because it was too large (" + request.length + " bytes)");
+            return
+          };
           instance.request(request, chainId);
         },
         databaseContent: (maxUtf8BytesSize) => {

--- a/bin/wasm-node/javascript/test/misc.js
+++ b/bin/wasm-node/javascript/test/misc.js
@@ -29,7 +29,7 @@ test('too large json-rpc requests rejected', async t => {
   // Generate a very long string. We start with a length of 1 and double for every iteration.
   // Thus the final length of the string is `2^i` where `i` is the number of iterations.
   let veryLongString = 'a';
-  for (let i = 0; i < 24; ++i) {
+  for (let i = 0; i < 27; ++i) {
     veryLongString += veryLongString;
   }
 


### PR DESCRIPTION
The idea behind this limit is to avoid crashing the client by sending a very large request that leads to out of memory.

Choosing a precise limit is a bit tricky, because there are for example some legitimate very large transactions.

This PR increases that limit and prints a warning.
