### PR TITLE
Simplify handling of monotonic_clock_ms

### DIFF
--- a/bin/wasm-node/javascript/src/compat/index-browser-overwrite.js
+++ b/bin/wasm-node/javascript/src/compat/index-browser-overwrite.js
@@ -17,10 +17,6 @@
 
 // Overrides `index.js` when in a browser.
 
-export function performanceNow() {
-    return performance.now()
-}
-
 export function isTcpAvailable() {
     return false;
 }

--- a/bin/wasm-node/javascript/src/compat/index.d.ts
+++ b/bin/wasm-node/javascript/src/compat/index.d.ts
@@ -22,8 +22,6 @@ import type { Socket as TcpSocket, NetConnectOpts } from 'node:net';
 
 export type WasmModuleImports = WebAssembly.ModuleImports;
 
-export function performanceNow(): number;
-
 export function isTcpAvailable(): boolean;
 
 export function createConnection(options: NetConnectOpts, connectionListener?: () => void): TcpSocket;

--- a/bin/wasm-node/javascript/src/compat/index.js
+++ b/bin/wasm-node/javascript/src/compat/index.js
@@ -19,14 +19,8 @@
 //
 // A rule in the `package.json` overrides it with `index-browser-override.js` when in a browser.
 
-import { hrtime } from 'node:process';
 import { createConnection as nodeCreateConnection } from 'node:net';
 import { randomFillSync } from 'node:crypto';
-
-export function performanceNow() {
-    const time = hrtime();
-    return ((time[0] * 1e3) + (time[1] / 1e6));
-}
 
 export function isTcpAvailable() {
     return true;

--- a/bin/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
+++ b/bin/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
@@ -130,7 +130,9 @@ export default function (config: Config): { imports: compat.WasmModuleImports, k
         unix_time_ms: () => Date.now(),
 
         // Must return the value of a monotonic clock in milliseconds.
-        monotonic_clock_ms: () => compat.performanceNow(),
+        monotonic_clock_ms: () => {
+            return globalThis.performance.now()
+        },
 
         // Must call `timer_finished` after the given number of milliseconds has elapsed.
         start_timer: (id: number, ms: number) => {


### PR DESCRIPTION
It turns out that `performance.now()` works since NodeJS v8.5 (so, ages ago): https://nodejs.org/api/perf_hooks.html#performancenow

It's unclear since when NodeJS supports `globalThis`, but there seems to be hints that it was working in NodeJS v10 already, which is far away enough.
