### PR TITLE
Fix base64 decoding function

### DIFF
--- a/bin/wasm-node/javascript/src/index-browser.ts
+++ b/bin/wasm-node/javascript/src/index-browser.ts
@@ -45,8 +45,8 @@ export function start(options?: ClientOptions): Client {
   options = options || {}
 
   return innerStart(options, {
-    zlibInflate: (buffer) => {
-        return pako.inflate(buffer)
+    base64DecodeAndZlibInflate: (input) => {
+        return pako.inflate(trustedBase64Decode(input))
     },
     performanceNow: () => {
       return performance.now()
@@ -61,6 +61,23 @@ export function start(options?: ClientOptions): Client {
       return connect(config, options?.forbidWs || false, options?.forbidNonLocalWs || false, options?.forbidWss || false)
     }
   })
+}
+
+/**
+ * Decodes a base64 string.
+ *
+ * The input is assumed to be correct.
+ */
+function trustedBase64Decode(base64: string): Uint8Array {
+    // This code is a bit sketchy due to the fact that we decode into a string, but it seems to
+    // work.
+    const binaryString = atob(base64);
+    const size = binaryString.length;
+    const bytes = new Uint8Array(size);
+    for (let i = 0; i < size; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+    }
+    return bytes;
 }
 
 /**

--- a/bin/wasm-node/javascript/src/index-nodejs.ts
+++ b/bin/wasm-node/javascript/src/index-nodejs.ts
@@ -50,8 +50,8 @@ export function start(options?: ClientOptions): Client {
   options = options || {};
 
   return innerStart(options || {}, {
-    zlibInflate: (buffer) => {
-        return pako.inflate(buffer)
+    base64DecodeAndZlibInflate: (input) => {
+        return pako.inflate(Buffer.from(input, 'base64'))
     },
     performanceNow: () => {
       const time = hrtime();

--- a/bin/wasm-node/javascript/src/instance/buffer.ts
+++ b/bin/wasm-node/javascript/src/instance/buffer.ts
@@ -60,42 +60,13 @@ function checkRange(buffer: Uint8Array, offset: number, length: number) {
  * The input is assumed to be correct.
  */
 export function trustedBase64Decode(base64: string): Uint8Array {
-    // This implementation was mostly copy-pasted (with some adjustments)
-    // from <https://developer.mozilla.org/en-US/docs/Glossary/Base64>. As indicated in the
-    // about section (<https://developer.mozilla.org/en-US/docs/MDN/About>), this code is in the
-    // public domain.
-
-    function b64ToUint6(nChr: number) {
-        return nChr > 64 && nChr < 91 ?
-            nChr - 65
-            : nChr > 96 && nChr < 123 ?
-                nChr - 71
-                : nChr > 47 && nChr < 58 ?
-                    nChr + 4
-                    : nChr === 43 ?
-                        62
-                        : nChr === 47 ?
-                            63
-                            :
-                            0;
-    
+    // This code is a bit sketchy due to the fact that we decode into a string, but it seems to
+    // work.
+    const binaryString = atob(base64);
+    const size = binaryString.length;
+    const bytes = new Uint8Array(size);
+    for (let i = 0; i < size; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
     }
-
-    const nInLen = base64.length
-    const nOutLen = nInLen * 3 + 1 >> 2
-    const taBytes = new Uint8Array(nOutLen);
-
-    for (var nMod3, nMod4, nUint24 = 0, nOutIdx = 0, nInIdx = 0; nInIdx < nInLen; nInIdx++) {
-        nMod4 = nInIdx & 3;
-        nUint24 |= b64ToUint6(base64.charCodeAt(nInIdx)) << 6 * (3 - nMod4);
-        if (nMod4 === 3 || nInLen - nInIdx === 1) {
-            for (nMod3 = 0; nMod3 < 3 && nOutIdx < nOutLen; nMod3++, nOutIdx++) {
-                taBytes[nOutIdx] = nUint24 >>> (16 >>> nMod3 & 24) & 255;
-            }
-            nUint24 = 0;
-
-        }
-    }
-
-    return taBytes;
+    return bytes;
 }

--- a/bin/wasm-node/javascript/src/instance/buffer.ts
+++ b/bin/wasm-node/javascript/src/instance/buffer.ts
@@ -53,20 +53,3 @@ function checkRange(buffer: Uint8Array, offset: number, length: number) {
     if (offset + length > buffer.length)
         throw new RangeError()
 }
-
-/**
- * Decodes a base64 string.
- *
- * The input is assumed to be correct.
- */
-export function trustedBase64Decode(base64: string): Uint8Array {
-    // This code is a bit sketchy due to the fact that we decode into a string, but it seems to
-    // work.
-    const binaryString = atob(base64);
-    const size = binaryString.length;
-    const bytes = new Uint8Array(size);
-    for (let i = 0; i < size; i++) {
-        bytes[i] = binaryString.charCodeAt(i);
-    }
-    return bytes;
-}

--- a/bin/wasm-node/javascript/src/instance/raw-instance.ts
+++ b/bin/wasm-node/javascript/src/instance/raw-instance.ts
@@ -15,8 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import * as buffer from './buffer.js';
-
 import { ConnectionConfig, Connection, Config as SmoldotBindingsConfig, default as smoldotLightBindingsBuilder } from './bindings-smoldot-light.js';
 import { Config as WasiConfig, default as wasiBindingsBuilder } from './bindings-wasi.js';
 
@@ -51,9 +49,13 @@ export interface Config {
  */
 export interface PlatformBindings {
     /**
-     * Decompresses the given buffer using the inflate algorithm with zlib header.
+     * Base64-decode the given buffer then decompress its content using the inflate algorithm
+     * with zlib header.
+     *
+     * The input is considered trusted. In other words, the implementation doesn't have to
+     * resist malicious input.
      */
-    zlibInflate: (buffer: Uint8Array) => Uint8Array,
+    base64DecodeAndZlibInflate: (input: string) => Uint8Array,
 
     /**
      * Returns the number of milliseconds since an arbitrary epoch.
@@ -79,7 +81,7 @@ export async function startInstance(config: Config, platformBindings: PlatformBi
     // different file.
     // This is suboptimal compared to using `instantiateStreaming`, but it is the most
     // cross-platform cross-bundler approach.
-    const wasmBytecode = platformBindings.zlibInflate(buffer.trustedBase64Decode(wasmBase64))
+    const wasmBytecode = platformBindings.base64DecodeAndZlibInflate(wasmBase64)
 
     let killAll: () => void;
 


### PR DESCRIPTION
It turns out that the cause of https://github.com/paritytech/smoldot/issues/2523 was a bug in the base64 decoding code.
This PR replaces this code with something that seems to work.
