### PR TITLE
Automatically publish Deno versions from CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,10 +77,12 @@ jobs:
 
   deno-publish:
     runs-on: ubuntu-latest
+    # This action checks if a certain git tag exists. If not, it compiles the JavaScript package,
+    # then commits the compilation artifacts, tags the commit, and pushes the tag.
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0   # Necessary for checking if the tag exists below.
+          fetch-depth: 0   # Necessary below for checking if the tag exists.
       - uses: actions/setup-node@v3.4.1
         with:
           node-version: 14
@@ -94,16 +96,16 @@ jobs:
           toolchain: stable
           profile: minimal
       - uses: Swatinem/rust-cache@v1
-      - id: compute-tag
+      - id: compute-tag  # Compute the tag that we might push.
         run: echo "::set-output name=tag::light-js-deno-v`jq -r .version ./bin/wasm-node/javascript/package.json`"
-      - id: check-tag-exists
+      - id: check-tag-exists  # Check whether the tag already exists.
         run: echo "::set-output name=num-existing::`git tag -l | grep ${{ steps.compute-tag.outputs.tag }} | wc -l`"
       - run: npm install
         working-directory: ./bin/wasm-node/javascript
       - run: npm publish --unsafe-perm --dry-run
         working-directory: ./bin/wasm-node/javascript
       - run: |
-          git add --force ./bin/wasm-node/javascript/dist/mjs  # Bypass the .gitignore
+          git add --force ./bin/wasm-node/javascript/dist/mjs  # --force bypasses the .gitignore
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git commit -m "Deno version publishing"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,6 +79,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0   # Necessary for checking if the tag exists below.
       - uses: actions/setup-node@v3.4.1
         with:
           node-version: 14

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,33 @@ jobs:
           package: ./bin/wasm-node/javascript/package.json
           access: public
 
+  deno-publish:
+    runs-on: ubuntu-latest
+    container:
+      image: rust:1.61
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3.4.1
+        with:
+          node-version: 14
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - run: apt-get update && apt install -y binaryen # For `wasm-opt`
+      - uses: actions-rs/toolchain@v1
+        with:
+          # Ideally we don't want to install any toolchain, but the GH action doesn't support this.
+          toolchain: stable
+          profile: minimal
+      - uses: Swatinem/rust-cache@v1
+      - id: compute-tag
+        run: echo "::set-output name=tag::light-js-deno-v`jq .version ./bin/wasm-node/javascript/package.json`"
+      - run: npm install
+        working-directory: ./bin/wasm-node/javascript
+      - run: npm publish --unsafe-perm --dry-run
+        working-directory: ./bin/wasm-node/javascript
+      - run: git tag light-js-deno-v${{ steps.compute-tag.outputs.tag }}
+
   all-deploy:
     # This dummy job depends on all the mandatory checks. It succeeds if and only if CI is
     # considered successful.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,7 +85,7 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
-      - run: apt-get update && apt install -y binaryen # For `wasm-opt`
+      - run: sudo apt-get update && apt install -y binaryen # For `wasm-opt`
       - uses: actions-rs/toolchain@v1
         with:
           # Ideally we don't want to install any toolchain, but the GH action doesn't support this.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,7 +96,6 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - id: compute-tag
         run: echo "::set-output name=tag::light-js-deno-v`jq -r .version ./bin/wasm-node/javascript/package.json`"
-      - run: npm install
       - id: check-tag-exists
         run: echo "::set-output name=num-existing::`git tag -l | grep ${{ steps.compute-tag.outputs.tag }} | wc -l`"
       - run: npm install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,6 +95,9 @@ jobs:
       - id: compute-tag
         run: echo "::set-output name=tag::light-js-deno-v`jq -r .version ./bin/wasm-node/javascript/package.json`"
       - run: npm install
+      - id: check-tag-exists
+        run: echo "::set-output name=num-existing::`git tag -l | grep ${{ steps.compute-tag.outputs.tag }} | wc -l`"
+      - run: npm install
         working-directory: ./bin/wasm-node/javascript
       - run: npm publish --unsafe-perm --dry-run
         working-directory: ./bin/wasm-node/javascript
@@ -103,8 +106,11 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git commit -m "Deno version publishing"
+      - run: |
           git tag ${{ steps.compute-tag.outputs.tag }}
-          git push origin ${{ steps.compute-tag.outputs.tag }}
+        if: ${{ steps.check-tag-exists.outputs.num-existing == 0 }}
+      - run: git push origin ${{ steps.compute-tag.outputs.tag }}
+        if: ${{ steps.check-tag-exists.outputs.num-existing == 0 && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
   all-deploy:
     # This dummy job depends on all the mandatory checks. It succeeds if and only if CI is

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,7 +93,7 @@ jobs:
           profile: minimal
       - uses: Swatinem/rust-cache@v1
       - id: compute-tag
-        run: echo "::set-output name=tag::light-js-deno-v`jq .version ./bin/wasm-node/javascript/package.json`"
+        run: echo "::set-output name=tag::light-js-deno-v`jq -r .version ./bin/wasm-node/javascript/package.json`"
       - run: npm install
         working-directory: ./bin/wasm-node/javascript
       - run: npm publish --unsafe-perm --dry-run
@@ -103,8 +103,8 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git commit -m "Deno version publishing"
-          git tag light-js-deno-v${{ steps.compute-tag.outputs.tag }}
-          git push origin light-js-deno-v${{ steps.compute-tag.outputs.tag }}
+          git tag ${{ steps.compute-tag.outputs.tag }}
+          git push origin ${{ steps.compute-tag.outputs.tag }}
 
   all-deploy:
     # This dummy job depends on all the mandatory checks. It succeeds if and only if CI is

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,8 +77,6 @@ jobs:
 
   deno-publish:
     runs-on: ubuntu-latest
-    container:
-      image: rust:1.61
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.4.1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,7 +85,7 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
-      - run: sudo apt-get update && apt install -y binaryen # For `wasm-opt`
+      - run: sudo apt-get update && sudo apt install -y binaryen # For `wasm-opt`
       - uses: actions-rs/toolchain@v1
         with:
           # Ideally we don't want to install any toolchain, but the GH action doesn't support this.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,7 +98,13 @@ jobs:
         working-directory: ./bin/wasm-node/javascript
       - run: npm publish --unsafe-perm --dry-run
         working-directory: ./bin/wasm-node/javascript
-      - run: git tag light-js-deno-v${{ steps.compute-tag.outputs.tag }}
+      - run: |
+          git add --force ./bin/wasm-node/javascript/dist/mjs  # Bypass the .gitignore
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -m "Deno version publishing"
+          git tag light-js-deno-v${{ steps.compute-tag.outputs.tag }}
+          git push origin light-js-deno-v${{ steps.compute-tag.outputs.tag }}
 
   all-deploy:
     # This dummy job depends on all the mandatory checks. It succeeds if and only if CI is


### PR DESCRIPTION
~~This PR is a work in progress. I'm pushing commits and seeing how the CI behaves.~~ Done

Close https://github.com/paritytech/smoldot/issues/2427

This new CI action grabs the package version from `package.json`, checks if a `light-js-deno-vX.Y.Z` tag exists. If not, creates a commit with the build artifacts for Deno and tags it.
