### PR TITLE
Adjust JS API to support multi-stream connections

### DIFF
--- a/bin/wasm-node/javascript/src/index-browser.ts
+++ b/bin/wasm-node/javascript/src/index-browser.ts
@@ -111,11 +111,11 @@ function trustedBase64Decode(base64: string): Uint8Array {
       connection.binaryType = 'arraybuffer';
 
       connection.onopen = () => {
-          config.onOpen();
+          config.onOpen({ type: 'single-stream' });
       };
       connection.onclose = (event) => {
           const message = "Error code " + event.code + (!!event.reason ? (": " + event.reason) : "");
-          config.onClose(message);
+          config.onConnectionClose(message);
       };
       connection.onmessage = (msg) => {
           config.onMessage(new Uint8Array(msg.data as ArrayBuffer));
@@ -136,6 +136,8 @@ function trustedBase64Decode(base64: string): Uint8Array {
 
     send: (data: Uint8Array): void => {
         connection.send(data);
-    }
+    },
+
+    openOutSubstream: () => { throw new Error('Wrong connection type') }
   };
 }

--- a/bin/wasm-node/javascript/src/index-nodejs.ts
+++ b/bin/wasm-node/javascript/src/index-nodejs.ts
@@ -103,11 +103,11 @@ function connect(config: ConnectionConfig, forbidTcp: boolean, forbidWs: boolean
         connection.socket.binaryType = 'arraybuffer';
 
         connection.socket.onopen = () => {
-            config.onOpen();
+            config.onOpen({ type: 'single-stream' });
         };
         connection.socket.onclose = (event) => {
             const message = "Error code " + event.code + (!!event.reason ? (": " + event.reason) : "");
-            config.onClose(message);
+            config.onConnectionClose(message);
         };
         connection.socket.onmessage = (msg) => {
             config.onMessage(new Uint8Array(msg.data as ArrayBuffer));
@@ -129,14 +129,14 @@ function connect(config: ConnectionConfig, forbidTcp: boolean, forbidWs: boolean
 
         connection.socket.on('connect', () => {
             if (socket.destroyed) return;
-            config.onOpen();
+            config.onOpen({ type: 'single-stream' });
         });
         connection.socket.on('close', (hasError) => {
             if (socket.destroyed) return;
             // NodeJS doesn't provide a reason why the closing happened, but only
             // whether it was caused by an error.
             const message = hasError ? "Error" : "Closed gracefully";
-            config.onClose(message);
+            config.onConnectionClose(message);
         });
         connection.socket.on('error', () => { });
         connection.socket.on('data', (message) => {
@@ -173,7 +173,9 @@ function connect(config: ConnectionConfig, forbidTcp: boolean, forbidWs: boolean
                 // TCP
                 connection.socket.write(data);
             }
-        }
+        },
+
+        openOutSubstream: () => { throw new Error('Wrong connection type') }
     };
 }
 

--- a/bin/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
+++ b/bin/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
@@ -356,7 +356,11 @@ export default function (config: Config): { imports: WebAssembly.ModuleImports, 
                     onStreamOpened: (streamId: number, direction: 'inbound' | 'outbound') => {
                         if (killedTracked.killed) return;
                         try {
-                            instance.exports.connection_stream_opened(connectionId, streamId, direction === 'outbound');
+                            instance.exports.connection_stream_opened(
+                                connectionId,
+                                streamId,
+                                direction === 'outbound' ? 1 : 0
+                            );
                         } catch(_error) {}
                     },
                     onStreamClose: (streamId: number) => {


### PR DESCRIPTION
cc https://github.com/paritytech/smoldot/issues/1712

Adjusts the JS code that binds the `index-*` files to the Wasm VM that runs smoldot.
It now supports multi-stream connections.
