### PR TITLE
Run the trie structure test more

### DIFF
--- a/src/trie/trie_structure/tests.rs
+++ b/src/trie/trie_structure/tests.rs
@@ -331,8 +331,8 @@ fn fuzzing() {
         Uniform::new_inclusive(min, max).sample(&mut rand::thread_rng())
     }
 
-    // We run the test a couple times because of randomness.
-    for _ in 0..16 {
+    // We run the test multiple times because of randomness.
+    for _ in 0..256 {
         // Generate a set of keys that will find themselves in the tries in the end.
         let final_storage: HashSet<Vec<Nibble>> = {
             let mut list = vec![Vec::new()];


### PR DESCRIPTION
After https://github.com/paritytech/smoldot/pull/2550, I looked around and saw this test. We only run it 16 times, and my machine takes 1ms to run all 16 times. So I increased the number of times, as it seems like a good idea.