### PR TITLE
Backport runtime spec embedded in Wasm module

### DIFF
--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -918,9 +918,6 @@ pub enum RuntimeError {
     /// Error while compiling the runtime.
     #[display(fmt = "{}", _0)]
     Build(executor::host::NewErr),
-    /// Error when determining the runtime specification.
-    #[display(fmt = "Error determining runtime version: {}", _0)]
-    CoreVersion(executor::CoreVersionError),
 }
 
 struct Guarded<TPlat: Platform> {

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -178,19 +178,10 @@ impl ChainSpec {
             (finality, vm_prototype)
         };
 
-        let (state_version, vm_prototype) = {
-            match executor::core_version(vm_prototype) {
-                (Ok(runtime_spec), vm_prototype) => {
-                    let state_version = match runtime_spec.decode().state_version {
-                        Some(0) | None => trie::TrieEntryVersion::V0,
-                        Some(1) => trie::TrieEntryVersion::V1,
-                        Some(_) => return Err(FromGenesisStorageError::UnknownStateVersion),
-                    };
-
-                    (state_version, vm_prototype)
-                }
-                (Err(err), _) => return Err(FromGenesisStorageError::CoreVersionLoad(err)),
-            }
+        let state_version = match vm_prototype.runtime_version().decode().state_version {
+            Some(0) | None => trie::TrieEntryVersion::V0,
+            Some(1) => trie::TrieEntryVersion::V1,
+            Some(_) => return Err(FromGenesisStorageError::UnknownStateVersion),
         };
 
         let chain_info = ChainInformation {
@@ -544,9 +535,6 @@ pub enum FromGenesisStorageError {
     /// Error when retrieving the Babe algorithm configuration.
     #[display(fmt = "Error when retrieving the Babe configuration: {}", _0)]
     BabeConfigLoad(babe_genesis_config::FromVmPrototypeError),
-    /// Failed to retrieve the core version of the runtime.
-    #[display(fmt = "Failed to retrieve the core version of the runtime: {}", _0)]
-    CoreVersionLoad(executor::CoreVersionError),
     /// State version in runtime specification is not supported.
     UnknownStateVersion,
     /// Multiple consensus algorithms have been detected.

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -80,6 +80,7 @@ pub enum InvalidHeapPagesError {
 /// the output.
 ///
 /// All host functions are forbidden.
+// TODO: this function is probably not needed
 pub fn core_version(
     vm_proto: host::HostVmPrototype,
 ) -> (Result<CoreVersion, CoreVersionError>, host::HostVmPrototype) {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -74,6 +74,8 @@ pub enum InvalidHeapPagesError {
     TooLarge,
 }
 
+// TODO: consider moving all the core-version-related code in host
+
 /// Runs the `Core_version` function using the given virtual machine prototype, and returns
 /// the output.
 ///

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -196,7 +196,7 @@ use core::{fmt, hash::Hasher as _, iter, str};
 use sha2::Digest as _;
 use tiny_keccak::Hasher as _;
 
-pub mod embedded_runtime_spec;
+pub mod embedded_runtime_version;
 
 pub use vm::HeapPages;
 pub use zstd::Error as ModuleFormatError;
@@ -272,7 +272,7 @@ impl HostVmPrototype {
         // TODO: configurable maximum allowed size? a uniform value is important for consensus
         let module = zstd::zstd_decode_if_necessary(config.module.as_ref(), 50 * 1024 * 1024)
             .map_err(NewErr::BadFormat)?;
-        let runtime_version = embedded_runtime_spec::find_embedded_runtime_spec(&module)
+        let runtime_version = embedded_runtime_version::find_embedded_runtime_version(&module)
             .ok()
             .flatten(); // TODO: return error instead of using `ok()`? unclear
         let module = vm::Module::new(module, config.exec_hint).map_err(vm::NewErr::ModuleError)?;

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -185,7 +185,7 @@
 //! }
 //! ```
 
-use super::{allocator, vm};
+use super::{allocator, vm, CoreVersion};
 use crate::{trie, util};
 
 use alloc::{borrow::ToOwned as _, format, string::String, vec, vec::Vec};
@@ -337,6 +337,11 @@ impl HostVmPrototype {
     /// Returns the number of heap pages that were passed to [`HostVmPrototype::new`].
     pub fn heap_pages(&self) -> HeapPages {
         self.heap_pages
+    }
+
+    /// Returns the runtime version found in the module.
+    pub fn runtime_version(&self) -> &CoreVersion {
+        todo!()
     }
 
     /// Starts the VM, calling the function passed as parameter.

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -54,12 +54,15 @@
 //! If the code starts with the magic bytes `[82, 188, 83, 118, 70, 219, 142, 5]`, then it is
 //! assumed that the rest of the data is a zstandard-compressed WebAssembly module.
 //!
-//! ## Runtime specification in custom section
+//! ## Runtime version
 //!
 //! Wasm files can contain so-called custom sections. A runtime can contain a custom section whose
-//! name is `"runtime_version"`, in which case it must contain a runtime specification.
+//! name is `"runtime_version"`, in which case it must contain a so-called runtime version.
 //!
-//! See the parent module for more information about runtime specifications.
+//! The runtime version contains important field that identifies a runtime.
+//!
+//! If no `"runtime_version"` custom section can be found, the `Core_version` entry point is used
+//! to obtain the runtime version.
 //!
 //! ## Memory allocations
 //!

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -420,10 +420,6 @@ impl HostVmPrototype {
         function_to_call: &str,
         data: impl Iterator<Item = impl AsRef<[u8]>> + Clone,
     ) -> Result<ReadyToRun, (StartErr, Self)> {
-        // This debug assertion is unrelated to running the VM, but we perform it in order to
-        // potentially detect internal issues ahead of time.
-        debug_assert!(self.runtime_version.is_some());
-
         let mut data_len_u32: u32 = 0;
         for data in data.clone() {
             let len = match u32::try_from(data.as_ref().len()) {

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -186,6 +186,8 @@ use core::{fmt, hash::Hasher as _, iter, str};
 use sha2::Digest as _;
 use tiny_keccak::Hasher as _;
 
+pub mod embedded_runtime_spec;
+
 pub use vm::HeapPages;
 pub use zstd::Error as ModuleFormatError;
 
@@ -255,6 +257,7 @@ impl HostVmPrototype {
         // TODO: configurable maximum allowed size? a uniform value is important for consensus
         let module = zstd::zstd_decode_if_necessary(config.module.as_ref(), 50 * 1024 * 1024)
             .map_err(NewErr::BadFormat)?;
+        // TODO: let ctnt = embedded_runtime_spec::find_embedded_runtime_spec(&module)
         let module = vm::Module::new(module, config.exec_hint).map_err(vm::NewErr::ModuleError)?;
         Self::from_module(module, config.heap_pages, config.allow_unresolved_imports)
     }

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -54,6 +54,13 @@
 //! If the code starts with the magic bytes `[82, 188, 83, 118, 70, 219, 142, 5]`, then it is
 //! assumed that the rest of the data is a zstandard-compressed WebAssembly module.
 //!
+//! ## Runtime specification in custom section
+//!
+//! Wasm files can contain so-called custom sections. A runtime can contain a custom section whose
+//! name is `"runtime_version"`, in which case it must contain a runtime specification.
+//!
+//! See the parent module for more information about runtime specifications.
+//!
 //! ## Memory allocations
 //!
 //! One of the instructions available in WebAssembly code is

--- a/src/executor/host/embedded_runtime_spec.rs
+++ b/src/executor/host/embedded_runtime_spec.rs
@@ -1,0 +1,144 @@
+// Smoldot
+// Copyright (C) 2019-2022  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Wasm runtimes can optionally contain a custom section (as defined in the official WebAssembly
+//! core specification).
+//!
+//! This module is dedicated to finding this section.
+
+// TODO: there is a small quirk in that the `apis` field is always empty when the runtime spec is in a custom version; deal with this by either removing all references to the `apis` field, or thoroughly documenting that quirk
+
+use super::super::CoreVersionRef;
+
+/// Tries to find the custom section containing the runtime specification and decodes it.
+pub fn find_embedded_runtime_spec(
+    binary_wasm_module: &[u8],
+) -> Result<Option<CoreVersionRef>, FindEmbeddedRuntimeSpecError> {
+    let section_content = match find_encoded_embedded_runtime_spec(binary_wasm_module) {
+        Ok(Some(c)) => c,
+        Ok(None) => return Ok(None),
+        Err(err) => return Err(FindEmbeddedRuntimeSpecError::FindSection(err)),
+    };
+
+    match super::super::decode(section_content) {
+        Ok(spec) => Ok(Some(spec)),
+        Err(()) => Err(FindEmbeddedRuntimeSpecError::Decode),
+    }
+}
+
+/// Error returned by [`find_encoded_embedded_runtime_spec`].
+#[derive(Debug, derive_more::Display, Clone)]
+pub enum FindEmbeddedRuntimeSpecError {
+    /// Error while finding the custom section.
+    #[display(fmt = "{}", _0)]
+    FindSection(FindEncodedEmbeddedRuntimeSpecError),
+    /// Error while decoding the runtime specification.
+    Decode,
+}
+
+/// Tries to find the custom section containing the runtime specification.
+///
+/// This function does not attempt to decode the content of the custom section.
+pub fn find_encoded_embedded_runtime_spec(
+    binary_wasm_module: &[u8],
+) -> Result<Option<&[u8]>, FindEncodedEmbeddedRuntimeSpecError> {
+    // A Wasm binary file contains two magic numbers followed with a list of sections.
+    match nom::combinator::all_consuming(nom::combinator::complete(wasm_module_with_custom(
+        b"runtime_version",
+    )))(binary_wasm_module)
+    {
+        Ok((_, content)) => Ok(content),
+        Err(_) => Err(FindEncodedEmbeddedRuntimeSpecError::FailedToParse),
+    }
+}
+
+/// Error returned by [`find_encoded_embedded_runtime_spec`].
+#[derive(Debug, derive_more::Display, Clone)]
+pub enum FindEncodedEmbeddedRuntimeSpecError {
+    /// Failed to parse Wasm binary.
+    FailedToParse,
+}
+
+/// Parses a Wasm module, and returns the content of the first custom section with the given name,
+/// if any is found.
+///
+/// If multiple custom sections exist with that name, all but the first are ignored.
+fn wasm_module_with_custom<'a>(
+    desired_section_name: &'a [u8],
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], Option<&'a [u8]>> {
+    nom::sequence::preceded(
+        nom::sequence::tuple((
+            nom::bytes::complete::tag(b"\0asm"),
+            nom::bytes::complete::tag(&[0x1, 0x0, 0x0, 0x0]),
+        )),
+        nom::multi::fold_many0(
+            section,
+            || None,
+            move |prev_found, maybe_found| {
+                let (found_name, found_content) = match maybe_found {
+                    Some(f) => f,
+                    None => return prev_found,
+                };
+
+                if prev_found.is_some() {
+                    return prev_found;
+                }
+
+                if found_name == desired_section_name {
+                    Some(found_content)
+                } else {
+                    None
+                }
+            },
+        ),
+    )
+}
+
+/// Parses a Wasm section. If it is a custom section, returns its name and content.
+fn section<'a>(bytes: &'a [u8]) -> nom::IResult<&'a [u8], Option<(&'a [u8], &'a [u8])>> {
+    nom::branch::alt((
+        nom::combinator::map(
+            nom::combinator::map_parser(
+                nom::sequence::preceded(
+                    nom::bytes::complete::tag(&[0]),
+                    nom::multi::length_data(nom::combinator::map_opt(
+                        crate::util::leb128::nom_leb128_u64,
+                        |n| u32::try_from(n).ok(),
+                    )),
+                ),
+                nom::sequence::tuple((
+                    nom::multi::length_data(nom::combinator::map_opt(
+                        crate::util::leb128::nom_leb128_u64,
+                        |n| u32::try_from(n).ok(),
+                    )),
+                    nom::combinator::rest,
+                )),
+            ),
+            |(name, content)| Some((name, content)),
+        ),
+        nom::combinator::map(
+            nom::sequence::tuple((
+                nom::number::complete::u8,
+                nom::multi::length_data(nom::combinator::map_opt(
+                    crate::util::leb128::nom_leb128_u64,
+                    |n| u32::try_from(n).ok(),
+                )),
+            )),
+            |_| None,
+        ),
+    ))(bytes)
+}

--- a/src/executor/host/embedded_runtime_spec.rs
+++ b/src/executor/host/embedded_runtime_spec.rs
@@ -22,12 +22,12 @@
 
 // TODO: there is a small quirk in that the `apis` field is always empty when the runtime spec is in a custom version; deal with this by either removing all references to the `apis` field, or thoroughly documenting that quirk
 
-use super::super::CoreVersionRef;
+use super::super::CoreVersion;
 
-/// Tries to find the custom section containing the runtime specification and decodes it.
+/// Tries to find the custom section containing the runtime specification and checks its validity.
 pub fn find_embedded_runtime_spec(
     binary_wasm_module: &[u8],
-) -> Result<Option<CoreVersionRef>, FindEmbeddedRuntimeSpecError> {
+) -> Result<Option<CoreVersion>, FindEmbeddedRuntimeSpecError> {
     let section_content = match find_encoded_embedded_runtime_spec(binary_wasm_module) {
         Ok(Some(c)) => c,
         Ok(None) => return Ok(None),
@@ -35,7 +35,7 @@ pub fn find_embedded_runtime_spec(
     };
 
     match super::super::decode(section_content) {
-        Ok(spec) => Ok(Some(spec)),
+        Ok(_) => Ok(Some(CoreVersion(section_content.to_vec()))),
         Err(()) => Err(FindEmbeddedRuntimeSpecError::Decode),
     }
 }

--- a/src/executor/host/embedded_runtime_version.rs
+++ b/src/executor/host/embedded_runtime_version.rs
@@ -24,51 +24,51 @@
 
 use super::super::CoreVersion;
 
-/// Tries to find the custom section containing the runtime specification and checks its validity.
-pub fn find_embedded_runtime_spec(
+/// Tries to find the custom section containing the runtime version and checks its validity.
+pub fn find_embedded_runtime_version(
     binary_wasm_module: &[u8],
-) -> Result<Option<CoreVersion>, FindEmbeddedRuntimeSpecError> {
-    let section_content = match find_encoded_embedded_runtime_spec(binary_wasm_module) {
+) -> Result<Option<CoreVersion>, FindEmbeddedRuntimeVersionError> {
+    let section_content = match find_encoded_embedded_runtime_version(binary_wasm_module) {
         Ok(Some(c)) => c,
         Ok(None) => return Ok(None),
-        Err(err) => return Err(FindEmbeddedRuntimeSpecError::FindSection(err)),
+        Err(err) => return Err(FindEmbeddedRuntimeVersionError::FindSection(err)),
     };
 
     match super::super::decode(section_content) {
         Ok(_) => Ok(Some(CoreVersion(section_content.to_vec()))),
-        Err(()) => Err(FindEmbeddedRuntimeSpecError::Decode),
+        Err(()) => Err(FindEmbeddedRuntimeVersionError::Decode),
     }
 }
 
-/// Error returned by [`find_encoded_embedded_runtime_spec`].
+/// Error returned by [`find_encoded_embedded_runtime_version`].
 #[derive(Debug, derive_more::Display, Clone)]
-pub enum FindEmbeddedRuntimeSpecError {
+pub enum FindEmbeddedRuntimeVersionError {
     /// Error while finding the custom section.
     #[display(fmt = "{}", _0)]
-    FindSection(FindEncodedEmbeddedRuntimeSpecError),
-    /// Error while decoding the runtime specification.
+    FindSection(FindEncodedEmbeddedRuntimeVersionError),
+    /// Error while decoding the runtime version.
     Decode,
 }
 
-/// Tries to find the custom section containing the runtime specification.
+/// Tries to find the custom section containing the runtime version.
 ///
 /// This function does not attempt to decode the content of the custom section.
-pub fn find_encoded_embedded_runtime_spec(
+pub fn find_encoded_embedded_runtime_version(
     binary_wasm_module: &[u8],
-) -> Result<Option<&[u8]>, FindEncodedEmbeddedRuntimeSpecError> {
+) -> Result<Option<&[u8]>, FindEncodedEmbeddedRuntimeVersionError> {
     // A Wasm binary file contains two magic numbers followed with a list of sections.
     match nom::combinator::all_consuming(nom::combinator::complete(wasm_module_with_custom(
         b"runtime_version",
     )))(binary_wasm_module)
     {
         Ok((_, content)) => Ok(content),
-        Err(_) => Err(FindEncodedEmbeddedRuntimeSpecError::FailedToParse),
+        Err(_) => Err(FindEncodedEmbeddedRuntimeVersionError::FailedToParse),
     }
 }
 
-/// Error returned by [`find_encoded_embedded_runtime_spec`].
+/// Error returned by [`find_encoded_embedded_runtime_version`].
 #[derive(Debug, derive_more::Display, Clone)]
-pub enum FindEncodedEmbeddedRuntimeSpecError {
+pub enum FindEncodedEmbeddedRuntimeVersionError {
     /// Failed to parse Wasm binary.
     FailedToParse,
 }

--- a/src/executor/read_only_runtime_host.rs
+++ b/src/executor/read_only_runtime_host.rs
@@ -315,14 +315,7 @@ impl Inner {
                         }
                     };
 
-                    match super::core_version(vm_prototype) {
-                        (Ok(version), _) => {
-                            self.vm = req.resume(Ok(version.as_ref()));
-                        }
-                        (Err(_), _) => {
-                            self.vm = req.resume(Err(()));
-                        }
-                    }
+                    self.vm = req.resume(Ok(vm_prototype.runtime_version().as_ref()));
                 }
 
                 host::HostVm::ExternalStorageRoot(req) => {

--- a/src/executor/runtime_host.rs
+++ b/src/executor/runtime_host.rs
@@ -679,14 +679,7 @@ impl Inner {
                         }
                     };
 
-                    match super::core_version(vm_prototype) {
-                        (Ok(version), _) => {
-                            self.vm = req.resume(Ok(version.as_ref()));
-                        }
-                        (Err(_), _) => {
-                            self.vm = req.resume(Err(()));
-                        }
-                    }
+                    self.vm = req.resume(Ok(vm_prototype.runtime_version().as_ref()));
                 }
 
                 host::HostVm::StartStorageTransaction(tx) => {

--- a/src/transactions/validate.rs
+++ b/src/transactions/validate.rs
@@ -281,7 +281,7 @@ pub fn validate_transaction(
 ) -> Query {
     // The parameters of the function, and whether to call `Core_initialize_block` beforehand,
     // depend on the API version.
-    // TODO: should the runtime spec be cached into the `HostVmPrototype`?
+    // TODO: we can't use the runtime spec cached in the HostVmPrototype, as its `apis` field is empty; requires clarification from the Substrate team
     let (api_version, virtual_machine) = match executor::core_version(config.runtime) {
         (Ok(runtime_spec), runtime) => {
             let expected = blake2_rfc::blake2b::blake2b(8, &[], b"TaggedTransactionQueue");


### PR DESCRIPTION
Fix https://github.com/paritytech/smoldot/issues/1107

Rather than execute an expensive runtime call, it is possible to get this information from a custom Wasm section.

The objective of this PR isn't really the speed boost brought by reading the Wasm module, but the fact that we now have a `runtime_version() -> &CoreVersion` method on `HostVmPrototype`.
In other words, there is now a low-cost guaranteed way of knowing the version of a runtime.

This makes various other changes that require knowing the runtime version easier.
