### PR TITLE
Also parse `runtime_apis` custom section

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -215,7 +215,7 @@ impl<'a> CoreVersionRef<'a> {
         out.extend(self.spec_version.to_le_bytes());
         out.extend(self.impl_version.to_le_bytes());
 
-        out.extend(crate::util::encode_scale_compact_usize(self.apis.clone().len()).as_ref());
+        out.extend(crate::util::encode_scale_compact_usize(self.apis.clone().count()).as_ref());
         for api in self.apis.clone() {
             out.extend(api.name_hash);
             out.extend(api.version.to_le_bytes());
@@ -304,8 +304,6 @@ impl<'a> Iterator for CoreVersionApisRefIter<'a> {
         }
     }
 }
-
-impl<'a> ExactSizeIterator for CoreVersionApisRefIter<'a> {}
 
 impl<'a> PartialEq for CoreVersionApisRefIter<'a> {
     fn eq(&self, other: &Self) -> bool {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -198,6 +198,13 @@ pub struct CoreVersionRef<'a> {
     pub state_version: Option<u8>,
 }
 
+impl<'a> CoreVersionRef<'a> {
+    /// Returns the SCALE encoding of this data structure.
+    pub fn scale_encoding_vec(&self) -> Vec<u8> {
+        todo!()
+    }
+}
+
 /// Iterator to a list of APIs. See [`CoreVersionRef::apis`].
 #[derive(Clone)]
 pub struct CoreVersionApisRefIter<'a> {

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -56,13 +56,16 @@
 //!
 //! ## Runtime version
 //!
-//! Wasm files can contain so-called custom sections. A runtime can contain a custom section whose
-//! name is `"runtime_version"`, in which case it must contain a so-called runtime version.
+//! Wasm files can contain so-called custom sections. A runtime can contain two custom sections
+//! whose names are `"runtime_version"` and `"runtime_apis"`, in which case they must contain a
+//! so-called runtime version.
 //!
 //! The runtime version contains important field that identifies a runtime.
 //!
-//! If no `"runtime_version"` custom section can be found, the `Core_version` entry point is used
-//! to obtain the runtime version.
+//! If no `"runtime_version"` and `"runtime_apis"` custom sections can be found, the
+//! `Core_version` entry point is used as a fallback in order to obtain the runtime version. This
+//! fallback mechanism is maintained for backwards compatibility purposes, but is considered
+//! deprecated.
 //!
 //! ## Memory allocations
 //!

--- a/src/executor/host/embedded_runtime_version.rs
+++ b/src/executor/host/embedded_runtime_version.rs
@@ -50,7 +50,7 @@ pub fn find_embedded_runtime_version(
     )))
 }
 
-/// Error returned by [`find_encoded_embedded_runtime_version`].
+/// Error returned by [`find_embedded_runtime_version`].
 #[derive(Debug, derive_more::Display, Clone)]
 pub enum FindEmbeddedRuntimeVersionError {
     /// Error while finding the custom section.
@@ -90,7 +90,7 @@ pub fn find_encoded_embedded_runtime_version_apis(
     Ok((runtime_version, runtime_apis))
 }
 
-/// Error returned by [`find_encoded_embedded_runtime_version`].
+/// Error returned by [`find_encoded_embedded_runtime_version_apis`].
 #[derive(Debug, derive_more::Display, Clone)]
 pub enum FindEncodedEmbeddedRuntimeVersionApisError {
     /// Failed to parse Wasm binary.

--- a/src/executor/host/embedded_runtime_version.rs
+++ b/src/executor/host/embedded_runtime_version.rs
@@ -39,10 +39,11 @@ pub fn find_embedded_runtime_version(
         Err(()) => return Err(FindEmbeddedRuntimeVersionError::RuntimeVersionDecode),
     };
 
-    decoded_runtime_version.apis = match CoreVersionApisRefIter::from_slice(runtime_apis_content) {
-        Ok(d) => d,
-        Err(()) => return Err(FindEmbeddedRuntimeVersionError::RuntimeApisDecode),
-    };
+    decoded_runtime_version.apis =
+        match CoreVersionApisRefIter::from_slice_no_length(runtime_apis_content) {
+            Ok(d) => d,
+            Err(()) => return Err(FindEmbeddedRuntimeVersionError::RuntimeApisDecode),
+        };
 
     Ok(Some(CoreVersion(
         decoded_runtime_version.scale_encoding_vec(),


### PR DESCRIPTION
Fix https://github.com/paritytech/smoldot/issues/1107

This is an amendment to https://github.com/paritytech/smoldot/pull/2556

After asking on Element why the `apis` field was empty when obtaining the runtime version from the custom section, it has been pointed out that for some reason they're in a separate section named `runtime_apis`.

The APIs decoded from the `runtime_apis` section must then be inserted into the struct that was decoded from the `runtime_version` section.
It's very weird, and the person I talked to (@pepyakin) seems to agree that this is weird.
