### PR TITLE
Remove unused fallback protocol names system

### DIFF
--- a/src/libp2p/collection.rs
+++ b/src/libp2p/collection.rs
@@ -105,12 +105,6 @@ pub struct NotificationProtocolConfig {
     /// Name of the protocol negotiated on the wire.
     pub protocol_name: String,
 
-    /// Optional alternative names for this protocol. Can represent different versions.
-    ///
-    /// Negotiated in order in which they are passed.
-    // TODO: presently unused
-    pub fallback_protocol_names: Vec<String>,
-
     /// Maximum size, in bytes, of the handshake that can be received.
     pub max_handshake_size: usize,
 
@@ -1676,7 +1670,6 @@ pub enum Event<TConn> {
     /// If `Ok`, it is now possible to send notifications on this substream.
     /// If `Err`, the substream no longer exists and the [`SubstreamId`] becomes invalid.
     NotificationsOutResult {
-        // TODO: what if fallback?
         substream_id: SubstreamId,
         /// If `Ok`, contains the handshake sent back by the remote. Its interpretation is out of
         /// scope of this module.

--- a/src/libp2p/collection/multi_stream.rs
+++ b/src/libp2p/collection/multi_stream.rs
@@ -95,18 +95,10 @@ where
                 established: established::MultiStream::new(established::Config {
                     notifications_protocols: notification_protocols
                         .iter()
-                        .flat_map(|net| {
-                            let max_handshake_size = net.config.max_handshake_size;
-                            let max_notification_size = net.config.max_notification_size;
-                            iter::once(&net.config.protocol_name)
-                                .chain(net.config.fallback_protocol_names.iter())
-                                .map(move |name| {
-                                    established::ConfigNotifications {
-                                        name: name.clone(), // TODO: cloning :-/
-                                        max_handshake_size,
-                                        max_notification_size,
-                                    }
-                                })
+                        .map(|net| established::ConfigNotifications {
+                            name: net.config.protocol_name.clone(), // TODO: clone :-/
+                            max_handshake_size: net.config.max_handshake_size,
+                            max_notification_size: net.config.max_notification_size,
                         })
                         .collect(),
                     request_protocols: request_response_protocols.to_vec(), // TODO: overhead

--- a/src/libp2p/collection/single_stream.rs
+++ b/src/libp2p/collection/single_stream.rs
@@ -680,19 +680,10 @@ where
                                 established: connection.into_connection(established::Config {
                                     notifications_protocols: notification_protocols
                                         .iter()
-                                        .flat_map(|net| {
-                                            let max_handshake_size = net.config.max_handshake_size;
-                                            let max_notification_size =
-                                                net.config.max_notification_size;
-                                            iter::once(&net.config.protocol_name)
-                                                .chain(net.config.fallback_protocol_names.iter())
-                                                .map(move |name| {
-                                                    established::ConfigNotifications {
-                                                        name: name.clone(), // TODO: cloning :-/
-                                                        max_handshake_size,
-                                                        max_notification_size,
-                                                    }
-                                                })
+                                        .map(|net| established::ConfigNotifications {
+                                            name: net.config.protocol_name.clone(), // TODO: clone :-/
+                                            max_handshake_size: net.config.max_handshake_size,
+                                            max_notification_size: net.config.max_notification_size,
                                         })
                                         .collect(),
                                     request_protocols: request_response_protocols.to_vec(), // TODO: overhead

--- a/src/libp2p/collection/single_stream.rs
+++ b/src/libp2p/collection/single_stream.rs
@@ -29,7 +29,7 @@ use super::{
 
 use alloc::{collections::VecDeque, string::ToString as _, sync::Arc};
 use core::{
-    iter, mem,
+    mem,
     ops::{Add, Sub},
     time::Duration,
 };

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -256,13 +256,11 @@ where
             .flat_map(|chain| {
                 iter::once(peers::NotificationProtocolConfig {
                     protocol_name: format!("/{}/block-announces/1", chain.protocol_id),
-                    fallback_protocol_names: Vec::new(),
                     max_handshake_size: 1024 * 1024, // TODO: arbitrary
                     max_notification_size: 1024 * 1024,
                 })
                 .chain(iter::once(peers::NotificationProtocolConfig {
                     protocol_name: format!("/{}/transactions/1", chain.protocol_id),
-                    fallback_protocol_names: Vec::new(),
                     max_handshake_size: 4,
                     max_notification_size: 16 * 1024 * 1024,
                 }))
@@ -273,7 +271,6 @@ where
                     // comprehensible.
                     iter::once(peers::NotificationProtocolConfig {
                         protocol_name: "/paritytech/grandpa/1".to_string(),
-                        fallback_protocol_names: Vec::new(),
                         max_handshake_size: 4,
                         max_notification_size: 1024 * 1024,
                     })


### PR DESCRIPTION
Ages ago, I added a dummy field called `fallback_protocol_names` that lets you specify a list of alternative protocol names that would be negotiated if the main one isn't supported by the remote.

Substrate has a similar feature, and it's very useful in order to do protocol upgrades. (e.g. https://github.com/paritytech/smoldot/pull/2116)

Unfortunately this has never been implemented.
Instead of leaving this dummy feature here, this PR just removes it. It can always be added back properly in the future.
