### PR TITLE
Remove banned_blocks stub in all_forks

### DIFF
--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -2639,7 +2639,6 @@ impl<TRq> Shared<TRq> {
             max_requests_per_block: self.max_requests_per_block,
             allow_unknown_consensus_engines: self.allow_unknown_consensus_engines,
             full: false,
-            banned_blocks: iter::empty(), // TODO: not implemented, should be passed by config after the optimistic sync supports banned blocks too
         });
 
         debug_assert!(self


### PR DESCRIPTION
The `all_forks` syncing supports banned blocks, but we always pass an empty list at the moment.
I think that banned blocks should be implemented from the sync service instead.
