### PR TITLE
Report RuntimeCompilation to the top-most level

### DIFF
--- a/bin/full-node/src/run/consensus_service.rs
+++ b/bin/full-node/src/run/consensus_service.rs
@@ -1093,6 +1093,9 @@ impl SyncBackground {
                                     .map(|(k, _)| k);
                                 verify = req.inject_keys_ordered(keys);
                             }
+                            all::BlockVerification::RuntimeCompilation(rt) => {
+                                verify = rt.build();
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This is the continuation of something that I've started to do but haven't finished.

We now report the need to compile a runtime up to the highest level, so that the consensus service can measure how long it takes to compile a runtime.
