### PR TITLE
Replace `websocket` dependency with `ws`

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -9,6 +9,10 @@
 - The GRANDPA warp sync implementation has been considerably refactored. It is possible that unintended changes in behaviour have accidentally been introduced. ([#2578](https://github.com/paritytech/smoldot/pull/2578))
 - A warning is now printed if the `badBlocks` field in a chain specification is not empty. Bad blocks are not supported by the smoldot light client. ([#2585](https://github.com/paritytech/smoldot/pull/2585))
 
+### Fix
+
+- Fix WebSockets not working in the CommonJS bindings for NodeJS due to a problematic import. ([#2589](https://github.com/paritytech/smoldot/pull/2589)).
+
 ## 0.6.27 - 2022-07-29
 
 ### Changed

--- a/bin/wasm-node/javascript/demo/demo.mjs
+++ b/bin/wasm-node/javascript/demo/demo.mjs
@@ -18,8 +18,7 @@
 // This file launches a WebSocket server that exposes JSON-RPC functions.
 
 import * as smoldot from '../dist/mjs/index-nodejs.js';
-import { default as websocket } from 'websocket';
-import * as http from 'node:http';
+import { WebSocketServer } from 'ws';
 import * as process from 'node:process';
 import * as fs from 'node:fs';
 
@@ -86,36 +85,29 @@ client
     });
 
 // Start the WebSocket server listening on port 9944.
-let server = http.createServer(function (_request, response) {
-    response.writeHead(404);
-    response.end();
-});
-server.listen(9944, function () {
-    console.log('JSON-RPC server now listening on port 9944');
-    console.log('Please visit one of:');
-    for (const chainId in chainSpecsById) {
-        console.log('- ' + chainId + ': https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944%2F' + chainId);
-    }
-    console.log('');
-});
-let wsServer = new websocket.server({
-    httpServer: server,
-    autoAcceptConnections: false,
+let wsServer = new WebSocketServer({
+    port: 9944
 });
 
-wsServer.on('request', function (request) {
+console.log('JSON-RPC server now listening on port 9944');
+console.log('Please visit one of:');
+for (const chainId in chainSpecsById) {
+    console.log('- ' + chainId + ': https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944%2F' + chainId);
+}
+console.log('');
+
+wsServer.on('connection', function (connection, request) {
     // Received a new incoming WebSocket connection.
 
     // Note that we don't care too much about sanitizing input as this is just a demo.
-    const chainCfg = chainSpecsById[request.resource.substring(1)];
+    const chainCfg = chainSpecsById[request.url.substring(1)];
 
     if (!chainCfg) {
-        request.reject(404);
+        connection.close();
         return;
     }
 
-    const connection = request.accept(request.requestedProtocols[0], request.origin);
-    console.log('(demo) New JSON-RPC client connected: ' + request.remoteAddress + '.');
+    console.log('(demo) New JSON-RPC client connected: ' + request.socket.remoteAddress + '.');
 
     // Start loading the chain.
     let chain = (async () => {
@@ -130,7 +122,7 @@ wsServer.on('request', function (request) {
             const para = await client.addChain({
                 chainSpec: chainCfg.chainSpec,
                 jsonRpcCallback: (resp) => {
-                    connection.sendUTF(resp);
+                    connection.send(resp);
                 },
                 potentialRelayChains: [relay]
             });
@@ -141,7 +133,7 @@ wsServer.on('request', function (request) {
                 relay: await client.addChain({
                     chainSpec: chainCfg.chainSpec,
                     jsonRpcCallback: (resp) => {
-                        connection.sendUTF(resp);
+                        connection.send(resp);
                     },
                 })
             };
@@ -152,14 +144,15 @@ wsServer.on('request', function (request) {
     });
 
     // Receiving a message from the connection. This is a JSON-RPC request.
-    connection.on('message', function (message) {
-        if (message.type === 'utf8') {
+    connection.on('message', function (data, isBinary) {
+        if (!isBinary) {
+            const message = data.toString('utf8');
             chain
                 .then(chain => {
                     if (chain.para)
-                        chain.para.sendJsonRpc(message.utf8Data);
+                        chain.para.sendJsonRpc(message);
                     else
-                        chain.relay.sendJsonRpc(message.utf8Data);
+                        chain.relay.sendJsonRpc(message);
                 })
                 .catch((error) => {
                     console.error("(demo) Error during JSON-RPC request: " + error);
@@ -172,7 +165,7 @@ wsServer.on('request', function (request) {
 
     // When the connection closes, remove the chains that have been added.
     connection.on('close', function (reasonCode, description) {
-        console.log("(demo) JSON-RPC client " + connection.remoteAddress + ' disconnected.');
+        console.log("(demo) JSON-RPC client " + request.socket.remoteAddress + ' disconnected.');
         chain.then(chain => {
             chain.relay.remove();
             if (chain.para)

--- a/bin/wasm-node/javascript/package-lock.json
+++ b/bin/wasm-node/javascript/package-lock.json
@@ -10,12 +10,12 @@
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "pako": "^2.0.4",
-        "websocket": "^1.0.32"
+        "ws": "^8.8.1"
       },
       "devDependencies": {
         "@types/node": "^18.0.0",
         "@types/pako": "^2.0.0",
-        "@types/websocket": "^1.0.4",
+        "@types/ws": "^8.5.3",
         "ava": "^4.0.0",
         "dtslint": "^4.0.6",
         "rimraf": "^3.0.2",
@@ -128,10 +128,10 @@
       "integrity": "sha512-FwAQwMRbkhx0J6YELkwIpciVzCcgEqXEbIrIn3a2P5d3kGEHQ3wVhlN3YdVepYP+bZzCYO6OjmD4o9TGOZ40rA==",
       "dev": true
     },
-    "node_modules/@types/websocket": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.5.tgz",
-      "integrity": "sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==",
+    "node_modules/@types/ws": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -820,6 +820,8 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.2.tgz",
       "integrity": "sha512-AtnG3W6M8B2n4xDQ5R+70EXvOpnXsFYg/AK2yTZd+HQ/oxAdz+GI+DvjmhBw3L0ole+LJ0ngqY4JMbDzkfNzhA==",
       "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.2.0"
       }
@@ -1310,15 +1312,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dependencies": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
-    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -1341,14 +1334,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
       }
     },
     "node_modules/decamelize": {
@@ -1555,35 +1540,6 @@
         "once": "^1.4.0"
       }
     },
-    "node_modules/es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dependencies": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
-    "node_modules/es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "node_modules/es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dependencies": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -1623,19 +1579,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-      "dependencies": {
-        "type": "^2.0.0"
-      }
-    },
-    "node_modules/ext/node_modules/type": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-      "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -2190,7 +2133,8 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "node_modules/is-unicode-supported": {
       "version": "1.2.0",
@@ -2501,20 +2445,12 @@
         "mkdirp": "bin/cmd.js"
       }
     },
-    "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "node_modules/next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
-    },
     "node_modules/node-gyp-build": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
       "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
+      "optional": true,
+      "peer": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -3607,11 +3543,6 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
-    "node_modules/type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-    },
     "node_modules/type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -3629,14 +3560,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
-    },
-    "node_modules/typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "dependencies": {
-        "is-typedarray": "^1.0.0"
-      }
     },
     "node_modules/typescript": {
       "version": "4.7.4",
@@ -3674,6 +3597,8 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.3.tgz",
       "integrity": "sha512-jtJM6fpGv8C1SoH4PtG22pGto6x+Y8uPprW0tw3//gGFhDDTiuksgradgFN6yRayDP4SyZZa6ZMGHLIa17+M8A==",
       "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.2.0"
       }
@@ -3724,22 +3649,6 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/websocket": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
-      "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
-      "dependencies": {
-        "bufferutil": "^4.0.1",
-        "debug": "^2.2.0",
-        "es5-ext": "^0.10.50",
-        "typedarray-to-buffer": "^3.1.5",
-        "utf-8-validate": "^5.0.2",
-        "yaeti": "^0.0.6"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/well-known-symbols": {
@@ -3844,19 +3753,31 @@
         "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
+    "node_modules/ws": {
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/y18n": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
-    },
-    "node_modules/yaeti": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
-      "engines": {
-        "node": ">=0.10.32"
-      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -4053,10 +3974,10 @@
       "integrity": "sha512-FwAQwMRbkhx0J6YELkwIpciVzCcgEqXEbIrIn3a2P5d3kGEHQ3wVhlN3YdVepYP+bZzCYO6OjmD4o9TGOZ40rA==",
       "dev": true
     },
-    "@types/websocket": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.5.tgz",
-      "integrity": "sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==",
+    "@types/ws": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -4594,6 +4515,8 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.2.tgz",
       "integrity": "sha512-AtnG3W6M8B2n4xDQ5R+70EXvOpnXsFYg/AK2yTZd+HQ/oxAdz+GI+DvjmhBw3L0ole+LJ0ngqY4JMbDzkfNzhA==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "node-gyp-build": "^4.2.0"
       }
@@ -4975,15 +4898,6 @@
         "array-find-index": "^1.0.1"
       }
     },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -5000,14 +4914,6 @@
       "dev": true,
       "requires": {
         "time-zone": "^1.0.0"
-      }
-    },
-    "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "requires": {
-        "ms": "2.0.0"
       }
     },
     "decamelize": {
@@ -5164,35 +5070,6 @@
         "once": "^1.4.0"
       }
     },
-    "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -5216,21 +5093,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
-    },
-    "ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-      "requires": {
-        "type": "^2.0.0"
-      },
-      "dependencies": {
-        "type": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
-        }
-      }
     },
     "extend": {
       "version": "3.0.2",
@@ -5670,7 +5532,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-unicode-supported": {
       "version": "1.2.0",
@@ -5908,20 +5771,12 @@
         "minimist": "^1.2.5"
       }
     },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
-    },
     "node-gyp-build": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
+      "optional": true,
+      "peer": true
     },
     "nofilter": {
       "version": "3.1.0",
@@ -6743,11 +6598,6 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
-    "type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-    },
     "type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -6759,14 +6609,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
-    },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
     },
     "typescript": {
       "version": "4.7.4",
@@ -6793,6 +6635,8 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.3.tgz",
       "integrity": "sha512-jtJM6fpGv8C1SoH4PtG22pGto6x+Y8uPprW0tw3//gGFhDDTiuksgradgFN6yRayDP4SyZZa6ZMGHLIa17+M8A==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "node-gyp-build": "^4.2.0"
       }
@@ -6837,19 +6681,6 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
-      }
-    },
-    "websocket": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
-      "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
-      "requires": {
-        "bufferutil": "^4.0.1",
-        "debug": "^2.2.0",
-        "es5-ext": "^0.10.50",
-        "typedarray-to-buffer": "^3.1.5",
-        "utf-8-validate": "^5.0.2",
-        "yaeti": "^0.0.6"
       }
     },
     "well-known-symbols": {
@@ -6935,16 +6766,17 @@
         "signal-exit": "^3.0.7"
       }
     },
+    "ws": {
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+      "requires": {}
+    },
     "y18n": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
-    },
-    "yaeti": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yallist": {
       "version": "4.0.0",

--- a/bin/wasm-node/javascript/package.json
+++ b/bin/wasm-node/javascript/package.json
@@ -35,12 +35,12 @@
   },
   "dependencies": {
     "pako": "^2.0.4",
-    "websocket": "^1.0.32"
+    "ws": "^8.8.1"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",
     "@types/pako": "^2.0.0",
-    "@types/websocket": "^1.0.4",
+    "@types/ws": "^8.5.3",
     "ava": "^4.0.0",
     "dtslint": "^4.0.6",
     "rimraf": "^3.0.2",

--- a/bin/wasm-node/javascript/src/index-browser.ts
+++ b/bin/wasm-node/javascript/src/index-browser.ts
@@ -19,7 +19,7 @@
 
 import { Client, ClientOptions, start as innerStart } from './client.js'
 import { Connection, ConnectionError, ConnectionConfig } from './instance/instance.js';
-import pako from 'pako';
+import { inflate } from 'pako';
 
 export {
   AddChainError,
@@ -46,7 +46,7 @@ export function start(options?: ClientOptions): Client {
 
   return innerStart(options, {
     base64DecodeAndZlibInflate: (input) => {
-        return Promise.resolve(pako.inflate(trustedBase64Decode(input)))
+        return Promise.resolve(inflate(trustedBase64Decode(input)))
     },
     performanceNow: () => {
       return performance.now()

--- a/bin/wasm-node/javascript/src/index-nodejs.ts
+++ b/bin/wasm-node/javascript/src/index-nodejs.ts
@@ -15,11 +15,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// Note: if you modify these imports, please test both the ModuleJS and CommonJS generated
+// bindings. JavaScript being JavaScript, some libraries (such as `websocket`) have issues working
+// with both at the same time.
+
 import { Client, ClientOptions, start as innerStart } from './client.js'
 import { Connection, ConnectionError, ConnectionConfig } from './instance/instance.js';
 
-import Websocket from 'websocket';
-import pako from 'pako';
+import { WebSocket } from 'ws';
+import { inflate } from 'pako';
 
 import { hrtime } from 'node:process';
 import { createConnection as nodeCreateConnection } from 'node:net';
@@ -51,7 +55,7 @@ export function start(options?: ClientOptions): Client {
 
   return innerStart(options || {}, {
     base64DecodeAndZlibInflate: (input) => {
-        return Promise.resolve(pako.inflate(Buffer.from(input, 'base64')))
+        return Promise.resolve(inflate(Buffer.from(input, 'base64')))
     },
     performanceNow: () => {
       const time = hrtime();
@@ -98,7 +102,7 @@ function connect(config: ConnectionConfig, forbidTcp: boolean, forbidWs: boolean
 
         connection = {
             ty: 'websocket',
-            socket: new Websocket.w3cwebsocket(url)
+            socket: new WebSocket(url)
         };
         connection.socket.binaryType = 'arraybuffer';
 
@@ -186,5 +190,5 @@ interface TcpWrapped {
 
 interface WebSocketWrapped {
     ty: 'websocket',
-    socket: Websocket.w3cwebsocket,
+    socket: WebSocket,
 }

--- a/bin/wasm-node/javascript/tsconfig.json
+++ b/bin/wasm-node/javascript/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "compilerOptions": {
         "declaration": true,
-        "allowJs": true,
-        "allowSyntheticDefaultImports": true,
         "strict": true,
         "allowUnreachableCode": false,
         "allowUnusedLabels": false,


### PR DESCRIPTION
Fix #2588 

The `websocket` package on NPM is just kind of fucked up, and it is impossible to make it work on both ModuleJS and CommonJS. This PR switches to `ws`, which works fine.
This was previously not possible because we were using the `websocket` library in the browser as well. This is no longer the case.

The biggest effort was updating the demo.

Additionally, I've made some tweaks to the `tsconfig.json` to disable some magic features. I removed them as a first attempt at understanding the issue. They turned out to be unrelated, but they're better left disabled anyway.
