### PR TITLE
Fix #2591

### DIFF
--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -211,7 +211,7 @@ pub(super) async fn start_parachain<TPlat: Platform>(
                         debug_assert!(new_parahead.is_some());
 
                         // If this is the first time (in this loop) a finalized parahead is known,
-                        // any `SuscribeAll` message that has been answered beforehand was
+                        // any `SubscribeAll` message that has been answered beforehand was
                         // answered in a dummy way with a potentially obsolete finalized header.
                         // For this reason, we reset all subscriptions to force all subscribers to
                         // re-subscribe.

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -205,6 +205,11 @@ pub(super) async fn start_parachain<TPlat: Platform>(
                         ..
                     } if *new_parahead != former_parahead => {
                         debug_assert!(new_parahead.is_some());
+
+                        if former_parahead.is_none() {
+                            all_subscriptions.clear();
+                        }
+
                         let hash =
                             header::hash_from_scale_encoded_header(new_parahead.as_ref().unwrap());
 

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -489,6 +489,7 @@ pub(super) async fn start_parachain<TPlat: Platform>(
                             // same thing as whether its relay chain is at the head of the chain.
                             // Note that there is no ordering guarantee of any kind w.r.t.
                             // block subscriptions notifications.
+                            // TODO: that's not exactly true, we might not have fetched any parahead yet
                             let val = relay_chain_sync.is_near_head_of_chain_heuristic().await;
                             let _ = send_back.send(val);
                         },

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -203,26 +203,27 @@ pub(super) async fn start_parachain<TPlat: Platform>(
             while let Some(update) = async_tree.try_advance_output() {
                 match update {
                     async_tree::OutputUpdate::Finalized {
-                        async_op_user_data: new_parahead,
-                        former_finalized_async_op_user_data: former_parahead,
+                        async_op_user_data: new_finalized_parahead,
+                        former_finalized_async_op_user_data: former_finalized_parahead,
                         pruned_blocks,
                         ..
-                    } if *new_parahead != former_parahead => {
-                        debug_assert!(new_parahead.is_some());
+                    } if *new_finalized_parahead != former_finalized_parahead => {
+                        debug_assert!(new_finalized_parahead.is_some());
 
                         // If this is the first time (in this loop) a finalized parahead is known,
                         // any `SubscribeAll` message that has been answered beforehand was
                         // answered in a dummy way with a potentially obsolete finalized header.
                         // For this reason, we reset all subscriptions to force all subscribers to
                         // re-subscribe.
-                        if former_parahead.is_none() {
+                        if former_finalized_parahead.is_none() {
                             all_subscriptions.clear();
                         }
 
-                        let hash =
-                            header::hash_from_scale_encoded_header(new_parahead.as_ref().unwrap());
+                        let hash = header::hash_from_scale_encoded_header(
+                            new_finalized_parahead.as_ref().unwrap(),
+                        );
 
-                        obsolete_finalized_parahead = new_parahead.clone().unwrap();
+                        obsolete_finalized_parahead = new_finalized_parahead.clone().unwrap();
 
                         if let Ok(header) =
                             header::decode(&obsolete_finalized_parahead, block_number_bytes)

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -515,6 +515,8 @@ pub(super) async fn start_parachain<TPlat: Platform>(
                             let _ = send_back.send(val);
                         },
                         ToBackground::SubscribeAll { send_back, buffer_size, .. } => {
+                            let (tx, new_blocks) = mpsc::channel(buffer_size.saturating_sub(1));
+
                             // There are two possibilities here: either we know of any recent
                             // finalized parahead, or we don't. In case where we don't know of
                             // any finalized parahead yet, we report a single obsolete finalized
@@ -522,8 +524,6 @@ pub(super) async fn start_parachain<TPlat: Platform>(
                             // module makes sure that no other block is reported to subscriptions
                             // as long as this is the case, and that subscriptions are reset once
                             // the first known finalized parahead is known.
-                            let (tx, new_blocks) = mpsc::channel(buffer_size.saturating_sub(1));
-
                             if let Some(finalized_parahead) = async_tree.finalized_async_user_data() {
                                 // Finalized parahead is known.
                                 let _ = send_back.send(super::SubscribeAll {

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -521,14 +521,21 @@ pub(super) async fn start_parachain<TPlat: Platform>(
 
                     match foreground_message {
                         ToBackground::IsNearHeadOfChainHeuristic { send_back } => {
-                            // Since there is a mapping between relay chain blocks and parachain
-                            // blocks, whether a parachain is at the head of the chain is the
-                            // same thing as whether its relay chain is at the head of the chain.
-                            // Note that there is no ordering guarantee of any kind w.r.t.
-                            // block subscriptions notifications.
-                            // TODO: that's not exactly true, we might not have fetched any parahead yet
-                            let val = relay_chain_sync.is_near_head_of_chain_heuristic().await;
-                            let _ = send_back.send(val);
+                            if async_tree.finalized_async_user_data().is_some() {
+                                // Since there is a mapping between relay chain blocks and
+                                // parachain blocks, whether a parachain is at the head of the
+                                // chain is the same thing as whether its relay chain is at the
+                                // head of the chain.
+                                // Note that there is no ordering guarantee of any kind w.r.t.
+                                // block subscriptions notifications.
+                                let val = relay_chain_sync.is_near_head_of_chain_heuristic().await;
+                                let _ = send_back.send(val);
+                            } else {
+                                // If no finalized parahead is known yet, we might be very close
+                                // to the head but also maybe very very far away. We lean on the
+                                // cautious side and always return `false`.
+                                let _ = send_back.send(false);
+                            }
                         },
                         ToBackground::SubscribeAll { send_back, buffer_size, .. } => {
                             let (tx, new_blocks) = mpsc::channel(buffer_size.saturating_sub(1));

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixed
 
-- Fix sometimes erroneously reporting a very old `parent_hash` (usually the genesis block hash) in `chainHead_unstable_follow` when following a parachain.
-- After smoldot has downloaded the runtime of an old parachain block, it would sometimes erroneously consider that this runtime hasn't changed since then. This would lead to issues such as `state_getRuntimeVersion` and `state_subscribeRuntimeVersion` returning information about an old runtime, or `state_getMetadata` or `state_call` using an old runtime.
+- Fix sometimes erroneously reporting a very old `parent_hash` (usually the genesis block hash) in `chainHead_unstable_follow` when following a parachain. ([#2602](https://github.com/paritytech/smoldot/pull/2602))
+- After smoldot has downloaded the runtime of an old parachain block, it would sometimes erroneously consider that this runtime hasn't changed since then. This would lead to issues such as `state_getRuntimeVersion` and `state_subscribeRuntimeVersion` returning information about an old runtime, or `state_getMetadata` or `state_call` using an old runtime. ([#2602](https://github.com/paritytech/smoldot/pull/2602))
 
 ## 0.6.28 - 2022-08-08
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix sometimes erroneously reporting a very old `parent_hash` (usually the genesis block hash) in `chainHead_unstable_follow` when following a parachain.
+- After smoldot has downloaded the runtime of an old parachain block, it would sometimes erroneously consider that this runtime hasn't changed since then. This would lead to issues such as `state_getRuntimeVersion` and `state_subscribeRuntimeVersion` returning information about an old runtime, or `state_getMetadata` or `state_call` using an old runtime.
+
 ## 0.6.28 - 2022-08-08
 
 ### Changed


### PR DESCRIPTION
Fix https://github.com/paritytech/smoldot/issues/2591

This PR fixes the internal logic of `parachain.rs` and, importantly, clarifies it.

The code was doing some very wrong things with the `finalized_parahead` variable. This variable might be equal to a very old block (typically the genesis block), yet the code would use it as a fallback in various situations.

This would lead to the `SyncService` reporting that the parent of a recent block was equal to the genesis block (in theory could have been another block than genesis, but in practice the genesis block). As a consequence, the `RuntimeService` would download the runtime of the genesis block and think that the recent block was using the same, since it is a child and didn't indicate that a runtime upgrade occurred.

https://github.com/paritytech/smoldot/issues/2591 was fixed by adding a simple `if` block that clears all active subscriptions once a finalized parahead is known, and two other `if` blocks that prevent notifications from being emitted before the finalized parahead is known. This makes me think that this logic got accidentally removed in a refactoring.
