### PR TITLE
Fix missing entry in v0.6.29 changelog

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Fix sometimes erroneously reporting a very old `parent_hash` (usually the genesis block hash) in `chainHead_unstable_follow` when following a parachain. ([#2602](https://github.com/paritytech/smoldot/pull/2602))
 - After smoldot has downloaded the runtime of an old parachain block, it would sometimes erroneously consider that this runtime hasn't changed since then. This would lead to issues such as `state_getRuntimeVersion` and `state_subscribeRuntimeVersion` returning information about an old runtime, or `state_getMetadata` or `state_call` using an old runtime. ([#2602](https://github.com/paritytech/smoldot/pull/2602))
+- Fix WebSocket errors leading to the program stopping while running in NodeJS. ([#2604](https://github.com/paritytech/smoldot/pull/2604))
 
 ## 0.6.28 - 2022-08-08
 


### PR DESCRIPTION
I forgot to add a changelog entry to https://github.com/paritytech/smoldot/pull/2604