### PR TITLE
Rename Peers::Connected -> HandshakeFinished and add field

### DIFF
--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -1489,7 +1489,7 @@ pub enum Event<TConn> {
 
         /// Identity of the peer that was expected to be reached.
         ///
-        /// Always `Some` for outgoing connections and always `None` for ingoing connections.
+        /// Always `Some` for outgoing connections and always `None` for incoming connections.
         expected_peer_id: Option<PeerId>,
 
         /// Number of other established connections with the same peer, including the one that

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -811,8 +811,8 @@ where
     /// [`PeerId`] will no longer be part of the return value of
     /// [`Peers::unfulfilled_desired_peers`].
     ///
-    /// No [`Event::Connected`] will be generated. Calling this function implicitly acts as if
-    /// this event was generated.
+    /// No [`Event::HandshakeFinished`] will be generated. Calling this function implicitly acts
+    /// as if this event had been implicitly generated.
     pub fn add_multi_stream_outgoing_connection<TSubId>(
         &mut self,
         now: TNow,
@@ -1219,8 +1219,8 @@ where
     ///
     /// A [`Event::Response`] event will later be generated containing the result of the request.
     ///
-    /// It is invalid to start a request on a peer before an [`Event::Connected`] has been
-    /// generated, or after a [`Event::Disconnected`] has been generated where
+    /// It is invalid to start a request on a peer before an [`Event::HandshakeFinished`] event
+    /// has been generated, or after a [`Event::Disconnected`] has been generated where
     /// [`Event::Disconnected::num_peer_connections`] is 0.
     ///
     /// Returns a newly-allocated identifier for this request.

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -1060,14 +1060,14 @@ where
             };
 
             match inner_event {
-                peers::Event::Connected {
+                peers::Event::HandshakeFinished {
                     peer_id,
                     num_peer_connections,
                     ..
                 } if num_peer_connections.get() == 1 => {
                     break Some(Event::Connected(peer_id));
                 }
-                peers::Event::Connected { .. } => {
+                peers::Event::HandshakeFinished { .. } => {
                     // When `num_peer_connections` != 1 we don't care about this event.
                 }
 


### PR DESCRIPTION
Ongoing clean up work of the networking.

This PR renames `Connected` to `HandshakeFinished`. `Connected` was supposed to mean "there now exists a new connection with the given peer". But in practice we will need to precisely track connections, so this is the wrong approach.

Additionally, I've added a `expected_peer_id` field. Ultimately this will be reported to the outermost API layer.
