### PR TITLE
Fix flaws in the API of peers.rs

### DIFF
--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -1654,7 +1654,7 @@ pub enum ShutdownPeer {
         num_healthy_peer_connections: u32,
     },
 
-    /// Connection was still handshaking and was ingoing.
+    /// Connection was still handshaking and was incoming.
     IngoingHandshake,
 
     /// Connection was still handshaking and was outgoing.

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -466,7 +466,7 @@ where
 
                     // Only produce a `Disconnected` event if connection wasn't handshaking.
                     if was_established {
-                        return Some(Event::Disconnected {
+                        return Some(Event::Shutdown {
                             num_peer_connections,
                             peer_id,
                             user_data,
@@ -1498,7 +1498,7 @@ pub enum Event<TConn> {
     },
 
     /// A connection has stopped.
-    Disconnected {
+    Shutdown {
         /// Identity of the peer on the other side of the connection.
         peer_id: PeerId,
 

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -1231,8 +1231,8 @@ where
     /// A [`Event::Response`] event will later be generated containing the result of the request.
     ///
     /// It is invalid to start a request on a peer before an [`Event::HandshakeFinished`] event
-    /// has been generated, or after a [`Event::Disconnected`] has been generated where
-    /// [`Event::Disconnected::num_peer_connections`] is 0.
+    /// has been generated, or after a [`Event::StartShutdown`] event has been generated where
+    /// [`ShutdownPeer::Established::num_healthy_peer_connections`] is 0.
     ///
     /// Returns a newly-allocated identifier for this request.
     ///

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -455,7 +455,11 @@ where
                         ShutdownPeer::IngoingHandshake
                     };
 
-                    return Some(Event::StartShutdown { peer, reason });
+                    return Some(Event::StartShutdown {
+                        connection_id: id,
+                        peer,
+                        reason,
+                    });
                 }
 
                 collection::Event::Shutdown {
@@ -1539,6 +1543,9 @@ pub enum Event<TConn> {
     },
 
     StartShutdown {
+        /// Identifier of the connection that has started shutting down.
+        connection_id: ConnectionId,
+
         /// State of the connection and identity of the remote.
         peer: ShutdownPeer,
 

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -361,6 +361,7 @@ where
                                 // Note that connections that are shutting down are still counted,
                                 // as we report the disconnected event only at the end of the
                                 // shutdown.
+                                // TODO: reconsider
                                 self.inner.connection_state(*connection_id).established
                             })
                             .count();
@@ -439,6 +440,7 @@ where
                                         // Note that connections that are shutting down are still counted,
                                         // as we report the disconnected event only at the end of the
                                         // shutdown.
+                                        // TODO: reconsider
                                         self.inner.connection_state(*connection_id).established
                                     })
                                     .count();
@@ -493,6 +495,7 @@ where
                                 // Note that connections that are shutting down are still counted,
                                 // as we report the disconnected event only at the end of the
                                 // shutdown.
+                                // TODO: reconsider
                                 self.inner.connection_state(*connection_id).established
                             })
                             .count();

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -1071,7 +1071,7 @@ where
                     // When `num_peer_connections` != 1 we don't care about this event.
                 }
 
-                peers::Event::Disconnected {
+                peers::Event::Shutdown {
                     peer_id,
                     num_peer_connections,
                     user_data: address,
@@ -1107,7 +1107,7 @@ where
                         chain_indices,
                     });
                 }
-                peers::Event::Disconnected {
+                peers::Event::Shutdown {
                     peer_id,
                     user_data: address,
                     ..

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -1072,8 +1072,11 @@ where
                 }
 
                 peers::Event::Shutdown {
-                    peer_id,
-                    num_peer_connections,
+                    peer:
+                        peers::ShutdownPeer::Established {
+                            peer_id,
+                            num_peer_connections,
+                        },
                     user_data: address,
                 } if num_peer_connections == 0 => {
                     // TODO: O(n)
@@ -1108,7 +1111,7 @@ where
                     });
                 }
                 peers::Event::Shutdown {
-                    peer_id,
+                    peer: peers::ShutdownPeer::Established { peer_id, .. },
                     user_data: address,
                     ..
                 } => {
@@ -1120,6 +1123,9 @@ where
                             entry.get_mut().set_disconnected(&address);
                         }
                     }
+                }
+                peers::Event::Shutdown { .. } => {
+                    // TODO:
                 }
 
                 // Insubstantial error for diagnostic purposes.

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -1062,7 +1062,7 @@ where
             match inner_event {
                 peers::Event::HandshakeFinished {
                     peer_id,
-                    num_peer_connections,
+                    num_healthy_peer_connections: num_peer_connections,
                     ..
                 } if num_peer_connections.get() == 1 => {
                     break Some(Event::Connected(peer_id));
@@ -1079,7 +1079,7 @@ where
                     peer:
                         peers::ShutdownPeer::Established {
                             peer_id,
-                            num_peer_connections,
+                            num_healthy_peer_connections: num_peer_connections,
                         },
                     user_data: address,
                 } if num_peer_connections == 0 => {

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -1071,6 +1071,10 @@ where
                     // When `num_peer_connections` != 1 we don't care about this event.
                 }
 
+                peers::Event::StartShutdown { .. } => {
+                    // TODO:
+                }
+
                 peers::Event::Shutdown {
                     peer:
                         peers::ShutdownPeer::Established {


### PR DESCRIPTION
Close https://github.com/paritytech/smoldot/issues/2370

This PR removes weirdnesses in the implementation of `peers.rs` by improving its API. There is now a `StartShutdown` event similar to `collection.rs`, after which it is invalid to start requests. After this event has been generated, all open substreams will be closed.

See https://github.com/paritytech/smoldot/pull/2369 for more context.

I _think_ I've preserved the same behavior in `service.rs` as before this PR, but I'm not completely sure of that. One exception is that we now properly clean up k-buckets when a connection was still handshaking is shut down.
I will improve `service.rs` as a follow-up to this PR.
