### PR TITLE
Make sure connected addresses are inserted when discovering

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fix panic that occured when connecting to a peer, then discovering it through the background discovery process, then disconnecting from it. ([#2616](https://github.com/paritytech/smoldot/pull/2616))
 - Fix circular dependency between JavaScript modules. ([#2614](https://github.com/paritytech/smoldot/pull/2614))
 
 ## 0.6.29 - 2022-08-09

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -886,6 +886,9 @@ where
                                     {
                                         let state = self.inner.connection_state(connection_id);
                                         debug_assert!(state.established);
+                                        // Because we mark addresses as disconnected when the
+                                        // shutdown process starts, we ignore shutting down
+                                        // connections.
                                         if state.shutting_down {
                                             continue;
                                         }
@@ -899,6 +902,9 @@ where
                                     {
                                         let state = self.inner.connection_state(connection_id);
                                         debug_assert!(!state.established);
+                                        // Because we mark addresses as disconnected when the
+                                        // shutdown process starts, we ignore shutting down
+                                        // connections.
                                         if state.shutting_down {
                                             continue;
                                         }

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -847,6 +847,7 @@ where
                 kademlia::kbuckets::Entry::LocalKey => return, // TODO: return some diagnostic?
                 kademlia::kbuckets::Entry::Vacant(entry) => {
                     match entry.insert((), now, kademlia::kbuckets::PeerState::Disconnected) {
+                        Err(kademlia::kbuckets::InsertError::Full) => return, // TODO: return some diagnostic?
                         Ok((_, removed_entry)) => {
                             // `removed_entry` is the peer that was removed the k-buckets as the
                             // result of the new insertion. Purge it from `self.kbuckets_peers`
@@ -873,16 +874,46 @@ where
                                         NonZeroUsize::new(e.num_references.get() + 1).unwrap();
                                     e
                                 }
-                                // TODO: is it possible that we're already connected to this peer? since we call set_disconnected() when we disconnect, we would geta panic
-                                hashbrown::hash_map::Entry::Vacant(e) => e.insert(KBucketsPeer {
-                                    num_references: NonZeroUsize::new(1).unwrap(),
-                                    addresses: addresses::Addresses::with_capacity(
+                                hashbrown::hash_map::Entry::Vacant(e) => {
+                                    // The peer was not in the k-buckets, but it is possible that
+                                    // we already have existing connections to it.
+                                    let mut addresses = addresses::Addresses::with_capacity(
                                         self.max_addresses_per_peer.get(),
-                                    ),
-                                }),
+                                    );
+
+                                    for connection_id in
+                                        self.inner.established_peer_connections(&e.key())
+                                    {
+                                        let state = self.inner.connection_state(connection_id);
+                                        debug_assert!(state.established);
+                                        if state.shutting_down {
+                                            continue;
+                                        }
+                                        addresses
+                                            .insert_discovered(self.inner[connection_id].clone());
+                                        addresses.set_connected(&self.inner[connection_id]);
+                                    }
+
+                                    for connection_id in
+                                        self.inner.handshaking_peer_connections(&e.key())
+                                    {
+                                        let state = self.inner.connection_state(connection_id);
+                                        debug_assert!(!state.established);
+                                        if state.shutting_down {
+                                            continue;
+                                        }
+                                        addresses
+                                            .insert_discovered(self.inner[connection_id].clone());
+                                        addresses.set_pending(&self.inner[connection_id]);
+                                    }
+
+                                    e.insert(KBucketsPeer {
+                                        num_references: NonZeroUsize::new(1).unwrap(),
+                                        addresses,
+                                    })
+                                }
                             }
                         }
-                        Err(kademlia::kbuckets::InsertError::Full) => return, // TODO: return some diagnostic?
                     }
                 }
                 kademlia::kbuckets::Entry::Occupied(_) => {

--- a/src/network/service/addresses.rs
+++ b/src/network/service/addresses.rs
@@ -93,6 +93,19 @@ impl Addresses {
         }
     }
 
+    /// If the given address is in the list, sets its state to "pending".
+    ///
+    /// # Panic
+    ///
+    /// Panics if the state of this address was already pending.
+    ///
+    pub(super) fn set_pending(&mut self, addr: &multiaddr::Multiaddr) {
+        if let Some(index) = self.list.iter().position(|(a, _)| a == addr) {
+            assert!(!matches!(self.list[index].1, State::PendingConnect));
+            self.list[index].1 = State::PendingConnect;
+        }
+    }
+
     /// If the given address is in the list, sets its state to "disconnected".
     ///
     /// # Panic


### PR DESCRIPTION
Fix https://github.com/paritytech/smoldot/issues/2568

This PR makes sure that, when we discover a peer that we're already connected to, we insert the addresses we're connected to or connecting to.
