### PR TITLE
Fix #2618

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix circular dependency between JavaScript modules. ([#2614](https://github.com/paritytech/smoldot/pull/2614))
+- Fix panic when a handshake timeout or protocol error happens on a connection at the same time as the local node tries to shut it down.
 
 ## 0.6.29 - 2022-08-09
 


### PR DESCRIPTION
Fix https://github.com/paritytech/smoldot/issues/2618

It turns out that when a handshake timeout or protocol error happens, we set the connection's state to `ShutdownWaitingAck { was_api_reset: false }`.

`was_api_reset: false` indicates that the shutdown wasn't initiated through the public API.

Unfortunately, other parts of the code interpret `was_api_reset: false` as meaning "was initiated through the coordinator", as it assumes that a shutdown is only ever initiated either through the public API or through the coordinator.

This omits the third way to start a shutdown: when a handshake timeout or protocol error happens.
