### PR TITLE
Add names to runtime service subscriptions

### DIFF
--- a/bin/light-base/src/json_rpc_service.rs
+++ b/bin/light-base/src/json_rpc_service.rs
@@ -602,7 +602,11 @@ impl<TPlat: Platform> Background<TPlat> {
                     // malicious.
                     let mut subscribe_all = me
                         .runtime_service
-                        .subscribe_all(32, NonZeroUsize::new(usize::max_value()).unwrap())
+                        .subscribe_all(
+                            "json-rpc-blocks-cache",
+                            32,
+                            NonZeroUsize::new(usize::max_value()).unwrap(),
+                        )
                         .await;
 
                     cache.subscription_id = Some(subscribe_all.new_blocks.id());

--- a/bin/light-base/src/json_rpc_service/chain_head.rs
+++ b/bin/light-base/src/json_rpc_service/chain_head.rs
@@ -380,7 +380,7 @@ impl<TPlat: Platform> Background<TPlat> {
         let (mut subscribe_all, runtime_subscribe_all) = if runtime_updates {
             let subscribe_all = self
                 .runtime_service
-                .subscribe_all(32, NonZeroUsize::new(32).unwrap())
+                .subscribe_all("chainHead_follow", 32, NonZeroUsize::new(32).unwrap())
                 .await;
             let id = subscribe_all.new_blocks.id();
             (either::Left(subscribe_all), Some(id))

--- a/bin/light-base/src/json_rpc_service/getters.rs
+++ b/bin/light-base/src/json_rpc_service/getters.rs
@@ -38,7 +38,7 @@ impl<TPlat: Platform> Background<TPlat> {
             header::hash_from_scale_encoded_header(
                 &self
                     .runtime_service
-                    .subscribe_all(16, NonZeroUsize::new(24).unwrap())
+                    .subscribe_all("chain_getFinalizedHead", 16, NonZeroUsize::new(24).unwrap())
                     .await
                     .finalized_block_scale_encoded_header,
             ),

--- a/bin/light-base/src/json_rpc_service/state_chain.rs
+++ b/bin/light-base/src/json_rpc_service/state_chain.rs
@@ -417,7 +417,11 @@ impl<TPlat: Platform> Background<TPlat> {
                         // malicious.
                         let subscribe_all = me
                             .runtime_service
-                            .subscribe_all(64, NonZeroUsize::new(usize::max_value()).unwrap())
+                            .subscribe_all(
+                                "chain_subscribeAllHeads",
+                                64,
+                                NonZeroUsize::new(usize::max_value()).unwrap(),
+                            )
                             .await;
 
                         // The existing finalized and already-known blocks aren't reported to the

--- a/bin/light-base/src/json_rpc_service/state_chain/sub_utils.rs
+++ b/bin/light-base/src/json_rpc_service/state_chain/sub_utils.rs
@@ -44,7 +44,7 @@ pub async fn subscribe_runtime_version<TPlat: Platform>(
 ) {
     let mut master_stream = stream::unfold(runtime_service.clone(), |runtime_service| async move {
         let subscribe_all = runtime_service
-            .subscribe_all(16, NonZeroUsize::new(24).unwrap())
+            .subscribe_all("subscribe-runtime-version", 16, NonZeroUsize::new(24).unwrap())
             .await;
 
         // Map of runtimes by hash. Contains all non-finalized blocks, plus the current finalized
@@ -227,7 +227,7 @@ pub async fn subscribe_finalized<TPlat: Platform>(
 ) -> (Vec<u8>, stream::BoxStream<'static, Vec<u8>>) {
     let mut master_stream = stream::unfold(runtime_service.clone(), |runtime_service| async move {
         let subscribe_all = runtime_service
-            .subscribe_all(16, NonZeroUsize::new(32).unwrap())
+            .subscribe_all("subscribe-finalized", 16, NonZeroUsize::new(32).unwrap())
             .await;
 
         // Map of block headers by hash. Contains all non-finalized blocks headers.
@@ -310,7 +310,7 @@ pub async fn subscribe_best<TPlat: Platform>(
 ) -> (Vec<u8>, stream::BoxStream<'static, Vec<u8>>) {
     let mut master_stream = stream::unfold(runtime_service.clone(), |runtime_service| async move {
         let subscribe_all = runtime_service
-            .subscribe_all(16, NonZeroUsize::new(32).unwrap())
+            .subscribe_all("subscribe-best", 16, NonZeroUsize::new(32).unwrap())
             .await;
 
         // Map of block headers by hash. Contains all non-finalized blocks headers, plus the

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -81,7 +81,11 @@ pub(super) async fn start_parachain<TPlat: Platform>(
         // The maximum number of pinned block is ignored, as this maximum is a way to avoid
         // malicious behaviors. This code is by definition not considered malicious.
         let mut relay_chain_subscribe_all = relay_chain_sync
-            .subscribe_all(32, NonZeroUsize::new(usize::max_value()).unwrap())
+            .subscribe_all(
+                "parachain-sync",
+                32,
+                NonZeroUsize::new(usize::max_value()).unwrap(),
+            )
             .await;
         log::debug!(
             target: &log_target,

--- a/bin/light-base/src/transactions_service.rs
+++ b/bin/light-base/src/transactions_service.rs
@@ -338,7 +338,11 @@ async fn background_task<TPlat: Platform>(
         // malicious behaviors. This code is by definition not considered malicious.
         let mut subscribe_all = worker
             .runtime_service
-            .subscribe_all(32, NonZeroUsize::new(usize::max_value()).unwrap())
+            .subscribe_all(
+                "transactions-service",
+                32,
+                NonZeroUsize::new(usize::max_value()).unwrap(),
+            )
             .await;
         let initial_finalized_block_hash = header::hash_from_scale_encoded_header(
             &subscribe_all.finalized_block_scale_encoded_header,


### PR DESCRIPTION
Adds a name parameter when subscribing to the runtime service.

These names have been useful in the past in order to debug things locally, but I've never actually left them in the source code.
I think it makes sense to leave them.

Should make debugging https://github.com/paritytech/smoldot/issues/2617 easier the next time it happens
