### PR TITLE
Remove faulty debug_assert

### DIFF
--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -352,12 +352,7 @@ where
                                 (actual_peer_index, usize::min_value())
                                     ..=(actual_peer_index, usize::max_value()),
                             )
-                            .filter(|(_, v)| {
-                                // Since this check happens only at the first connection, all
-                                // substreams are necessarily closed.
-                                debug_assert!(matches!(v.open, NotificationsOutOpenState::Closed));
-                                v.desired
-                            })
+                            .filter(|(_, v)| v.desired)
                             .map(|((_, index), _)| *index)
                             .collect::<Vec<_>>();
 


### PR DESCRIPTION
Fix https://github.com/paritytech/smoldot/issues/2619

Because we now include also connections that are shutting down, it is possible that a connection that is shutting down still has its notifications substream open. This `debug_assert!` is thus not accurate.