### PR TITLE
Rename base64DecodeAndZlibInflate -> trustedBase64DecodeAndZlibInflate

### DIFF
--- a/bin/wasm-node/javascript/src/index-browser.ts
+++ b/bin/wasm-node/javascript/src/index-browser.ts
@@ -45,7 +45,7 @@ export function start(options?: ClientOptions): Client {
   options = options || {}
 
   return innerStart(options, {
-    base64DecodeAndZlibInflate: (input) => {
+    trustedBase64DecodeAndZlibInflate: (input) => {
         return Promise.resolve(inflate(trustedBase64Decode(input)))
     },
     performanceNow: () => {

--- a/bin/wasm-node/javascript/src/index-deno.ts
+++ b/bin/wasm-node/javascript/src/index-deno.ts
@@ -42,7 +42,7 @@ export function start(options?: ClientOptions): Client {
     options = options || {};
 
     return innerStart(options || {}, {
-        base64DecodeAndZlibInflate: async (input) => {
+        trustedBase64DecodeAndZlibInflate: async (input) => {
             const buffer = trustedBase64Decode(input);
 
             // This code has been copy-pasted from the official streams draft specification.

--- a/bin/wasm-node/javascript/src/index-nodejs.ts
+++ b/bin/wasm-node/javascript/src/index-nodejs.ts
@@ -54,7 +54,7 @@ export function start(options?: ClientOptions): Client {
   options = options || {};
 
   return innerStart(options || {}, {
-    base64DecodeAndZlibInflate: (input) => {
+    trustedBase64DecodeAndZlibInflate: (input) => {
         return Promise.resolve(inflate(Buffer.from(input, 'base64')))
     },
     performanceNow: () => {

--- a/bin/wasm-node/javascript/src/instance/raw-instance.ts
+++ b/bin/wasm-node/javascript/src/instance/raw-instance.ts
@@ -58,7 +58,7 @@ export interface PlatformBindings {
      * This function is asynchronous because implementations might use the compression streams
      * Web API, which for whatever reason is asynchronous.
      */
-    base64DecodeAndZlibInflate: (input: string) => Promise<Uint8Array>,
+    trustedBase64DecodeAndZlibInflate: (input: string) => Promise<Uint8Array>,
 
     /**
      * Returns the number of milliseconds since an arbitrary epoch.
@@ -84,7 +84,7 @@ export async function startInstance(config: Config, platformBindings: PlatformBi
     // different file.
     // This is suboptimal compared to using `instantiateStreaming`, but it is the most
     // cross-platform cross-bundler approach.
-    const wasmBytecode = await platformBindings.base64DecodeAndZlibInflate(wasmBase64)
+    const wasmBytecode = await platformBindings.trustedBase64DecodeAndZlibInflate(wasmBase64)
 
     let killAll: () => void;
 


### PR DESCRIPTION
This function name is now a bit long, but I think it's important to convey that input is trusted.