### PR TITLE
Clarify message concerning unsupported bad blocks

### DIFF
--- a/bin/light-base/src/lib.rs
+++ b/bin/light-base/src/lib.rs
@@ -782,8 +782,8 @@ impl<TChain, TPlat: Platform> Client<TChain, TPlat> {
                         if has_bad_blocks {
                             log::warn!(
                                 target: "smoldot",
-                                "Chain {} has bad blocks in its chain specification. Bad blocks \
-                                are not implemented in the light client.", log_name
+                                "Chain specification of {} contains a list of bad blocks. Bad \
+                                blocks are not implemented in the light client.", log_name
                             );
                         }
 


### PR DESCRIPTION
At the moment, it sounds like the chain specification contains a list of blocks, and some of these blocks are bad, implying that the chain specification has a problem.

This PR clarifies the meaning.