### PR TITLE
Implement outgoing WebSocket connections in the full node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,6 +2354,7 @@ dependencies = [
  "mick-jaeger",
  "rand",
  "smoldot",
+ "soketto",
  "terminal_size",
  "tracing",
  "tracing-subscriber",

--- a/bin/full-node/Cargo.toml
+++ b/bin/full-node/Cargo.toml
@@ -31,6 +31,7 @@ hex = { version = "0.4.3", default-features = false }
 mick-jaeger = "0.1.8"
 rand = "0.8.5"
 smoldot = { version = "0.2.0", path = "../..", default-features = false, features = ["database-sqlite", "std"] }
+soketto = "0.7.1"
 terminal_size = "0.2.1"
 tracing = { version = "0.1.36", features = ["attributes"] }
 tracing-subscriber = { version = "0.2.25", default-features = false, features = ["ansi", "chrono", "env-filter", "json", "fmt", "parking_lot", "smallvec"] }

--- a/bin/full-node/src/run/network_service.rs
+++ b/bin/full-node/src/run/network_service.rs
@@ -1211,7 +1211,7 @@ async fn opening_connection_task(
     )
 )]
 async fn established_connection_task(
-    socket: async_std::net::TcpStream,
+    socket: impl AsyncRead + AsyncWrite + Unpin,
     inner: Arc<Inner>,
     connection_id: service::ConnectionId,
     mut connection_task: service::SingleStreamConnectionTask<Instant>,

--- a/bin/full-node/src/run/network_service.rs
+++ b/bin/full-node/src/run/network_service.rs
@@ -377,6 +377,7 @@ impl NetworkService {
                         }
                     }
                 } else {
+                    // TODO: support WebSocket server
                     return Err(InitError::BadListenMultiaddr(listen_address));
                 }
             };

--- a/bin/full-node/src/run/network_service.rs
+++ b/bin/full-node/src/run/network_service.rs
@@ -1429,27 +1429,25 @@ fn multiaddr_to_socket(
     };
 
     Ok(async move {
-        match addr {
-            either::Left(socket_addr) => {
-                let tcp_socket = async_std::net::TcpStream::connect(socket_addr).await;
-
-                if let Ok(tcp_socket) = &tcp_socket {
-                    // The Nagle algorithm, implemented in the kernel, consists in buffering the
-                    // data to be sent out and waiting a bit before actually sending it out, in
-                    // order to potentially merge multiple writes in a row into one packet. In
-                    // the implementation below, it is guaranteed that the buffer in `WithBuffers`
-                    // is filled with as much data as possible before the operating system gets
-                    // involved. As such, we disable the Nagle algorithm, in order to avoid adding
-                    // an artificial delay to all sends.
-                    let _ = tcp_socket.set_nodelay(true);
-                }
-
-                tcp_socket
-            }
+        let tcp_socket = match addr {
+            either::Left(socket_addr) => async_std::net::TcpStream::connect(socket_addr).await,
             either::Right((dns, port)) => {
                 async_std::net::TcpStream::connect((&dns[..], port)).await
             }
+        };
+
+        if let Ok(tcp_socket) = &tcp_socket {
+            // The Nagle algorithm, implemented in the kernel, consists in buffering the
+            // data to be sent out and waiting a bit before actually sending it out, in
+            // order to potentially merge multiple writes in a row into one packet. In
+            // the implementation below, it is guaranteed that the buffer in `WithBuffers`
+            // is filled with as much data as possible before the operating system gets
+            // involved. As such, we disable the Nagle algorithm, in order to avoid adding
+            // an artificial delay to all sends.
+            let _ = tcp_socket.set_nodelay(true);
         }
+
+        tcp_socket
     })
 }
 

--- a/bin/full-node/src/run/network_service/websocket.rs
+++ b/bin/full-node/src/run/network_service/websocket.rs
@@ -1,0 +1,355 @@
+// Smoldot
+// Copyright (C) 2019-2022  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use futures::prelude::*;
+
+use core::{
+    cmp, mem,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use std::io;
+
+/// Negotiates the WebSocket protocol (including the HTTP-like request) on the given socket, and
+/// returns an object that translates reads and writes into WebSocket binary frames.
+pub async fn websocket_handshake(
+    tcp_socket: impl AsyncRead + AsyncWrite + Send + Unpin + 'static,
+) -> Result<impl AsyncRead + AsyncWrite + Send + Unpin + 'static, io::Error> {
+    // TODO: what is the host?
+    let mut client = soketto::handshake::Client::new(tcp_socket, "...", "/");
+
+    let (sender, receiver) = match client.handshake().await {
+        Ok(soketto::handshake::ServerResponse::Accepted { .. }) => client.into_builder().finish(),
+        Ok(soketto::handshake::ServerResponse::Redirect { .. }) => {
+            // TODO: implement?
+            return Err(io::Error::new(
+                io::ErrorKind::ConnectionRefused,
+                "Redirections not implemented",
+            ));
+        }
+        Ok(soketto::handshake::ServerResponse::Rejected { status_code }) => {
+            return Err(io::Error::new(
+                io::ErrorKind::ConnectionRefused,
+                format!("Status code {}", status_code),
+            ))
+        }
+        Err(err) => return Err(io::Error::new(io::ErrorKind::Other, err)),
+    };
+
+    Ok(Connection {
+        sender: Write::Idle(sender),
+        receiver: Read::Idle(receiver, Vec::with_capacity(1024), 0),
+    })
+}
+
+struct Connection<T> {
+    sender: Write<T>,
+    receiver: Read<T>,
+}
+
+enum Read<T> {
+    Idle(soketto::connection::Receiver<T>, Vec<u8>, usize),
+    Error(soketto::connection::Error),
+    InProgress(
+        Pin<
+            Box<
+                dyn Future<
+                        Output = Result<
+                            (soketto::connection::Receiver<T>, Vec<u8>),
+                            soketto::connection::Error,
+                        >,
+                    > + Send,
+            >,
+        >,
+    ),
+    Poisoned,
+}
+
+enum Write<T> {
+    Idle(soketto::connection::Sender<T>),
+    Writing(
+        Pin<
+            Box<
+                dyn Future<
+                        Output = Result<soketto::connection::Sender<T>, soketto::connection::Error>,
+                    > + Send,
+            >,
+        >,
+    ),
+    Flushing(
+        Pin<
+            Box<
+                dyn Future<
+                        Output = Result<soketto::connection::Sender<T>, soketto::connection::Error>,
+                    > + Send,
+            >,
+        >,
+    ),
+    Closing(Pin<Box<dyn Future<Output = Result<(), soketto::connection::Error>> + Send>>),
+    Closed,
+    Error(soketto::connection::Error),
+    Poisoned,
+}
+
+impl<T: AsyncRead + AsyncWrite + Send + Unpin + 'static> AsyncRead for Connection<T> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        out_buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        assert_ne!(out_buf.len(), 0);
+
+        loop {
+            match mem::replace(&mut self.receiver, Read::Poisoned) {
+                Read::Idle(socket, pending, pending_pos) if pending_pos < pending.len() => {
+                    let to_copy = cmp::min(out_buf.len(), pending.len() - pending_pos);
+                    debug_assert_ne!(to_copy, 0);
+                    out_buf[..to_copy].copy_from_slice(&pending[pending_pos..][..to_copy]);
+                    self.receiver = Read::Idle(socket, pending, pending_pos + to_copy);
+                    return Poll::Ready(Ok(to_copy));
+                }
+                Read::Idle(mut socket, mut buffer, _) => {
+                    buffer.clear();
+                    self.receiver = Read::InProgress(Box::pin(async move {
+                        socket.receive_data(&mut buffer).await?;
+                        Ok((socket, buffer))
+                    }));
+                }
+                Read::InProgress(mut future) => match Pin::new(&mut future).poll(cx) {
+                    Poll::Pending => {
+                        self.receiver = Read::InProgress(future);
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(Ok((socket, buffer))) => {
+                        self.receiver = Read::Idle(socket, buffer, 0);
+                    }
+                    Poll::Ready(Err(err)) => {
+                        self.receiver = Read::Error(err);
+                    }
+                },
+                Read::Error(err) => {
+                    let out_err = convert_err(&err);
+                    self.receiver = Read::Error(err);
+                    return Poll::Ready(Err(out_err));
+                }
+                Read::Poisoned => unreachable!(),
+            }
+        }
+    }
+}
+
+impl<T: AsyncRead + AsyncWrite + Send + Unpin + 'static> AsyncWrite for Connection<T> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        loop {
+            match mem::replace(&mut self.sender, Write::Poisoned) {
+                Write::Idle(mut socket) => {
+                    let len = buf.len();
+                    let buf = buf.to_vec();
+                    self.sender = Write::Writing(Box::pin(async move {
+                        socket.send_binary_mut(buf).await?;
+                        Ok(socket)
+                    }));
+                    return Poll::Ready(Ok(len));
+                }
+                Write::Flushing(mut future) => match Pin::new(&mut future).poll(cx) {
+                    Poll::Pending => {
+                        self.sender = Write::Flushing(future);
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(Ok(socket)) => {
+                        self.sender = Write::Idle(socket);
+                    }
+                    Poll::Ready(Err(err)) => {
+                        self.sender = Write::Error(err);
+                    }
+                },
+                Write::Writing(mut future) => match Pin::new(&mut future).poll(cx) {
+                    Poll::Pending => {
+                        self.sender = Write::Writing(future);
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(Ok(socket)) => {
+                        self.sender = Write::Idle(socket);
+                    }
+                    Poll::Ready(Err(err)) => {
+                        self.sender = Write::Error(err);
+                    }
+                },
+                Write::Closing(mut future) => match Pin::new(&mut future).poll(cx) {
+                    Poll::Pending => {
+                        self.sender = Write::Closing(future);
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(Ok(())) => {
+                        self.sender = Write::Closed;
+                    }
+                    Poll::Ready(Err(err)) => {
+                        self.sender = Write::Error(err);
+                    }
+                },
+                Write::Closed => return Poll::Ready(Ok(0)), // TODO: is this correct?
+                Write::Error(err) => {
+                    let out_err = convert_err(&err);
+                    self.sender = Write::Error(err);
+                    return Poll::Ready(Err(out_err));
+                }
+                Write::Poisoned => unreachable!(),
+            }
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        loop {
+            match mem::replace(&mut self.sender, Write::Poisoned) {
+                Write::Idle(mut socket) => {
+                    self.sender = Write::Flushing(Box::pin(async move {
+                        socket.flush().await?;
+                        Ok(socket)
+                    }));
+                }
+                Write::Flushing(mut future) => match Pin::new(&mut future).poll(cx) {
+                    Poll::Pending => {
+                        self.sender = Write::Flushing(future);
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(Ok(socket)) => {
+                        self.sender = Write::Idle(socket);
+                        return Poll::Ready(Ok(()));
+                    }
+                    Poll::Ready(Err(err)) => {
+                        self.sender = Write::Error(err);
+                    }
+                },
+                Write::Writing(mut future) => match Pin::new(&mut future).poll(cx) {
+                    Poll::Pending => {
+                        self.sender = Write::Writing(future);
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(Ok(socket)) => {
+                        self.sender = Write::Idle(socket);
+                    }
+                    Poll::Ready(Err(err)) => {
+                        self.sender = Write::Error(err);
+                    }
+                },
+                Write::Closing(mut future) => match Pin::new(&mut future).poll(cx) {
+                    Poll::Pending => {
+                        self.sender = Write::Closing(future);
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(Ok(())) => {
+                        self.sender = Write::Closed;
+                    }
+                    Poll::Ready(Err(err)) => {
+                        self.sender = Write::Error(err);
+                    }
+                },
+                Write::Closed => return Poll::Ready(Ok(())),
+                Write::Error(err) => {
+                    let out_err = convert_err(&err);
+                    self.sender = Write::Error(err);
+                    return Poll::Ready(Err(out_err));
+                }
+                Write::Poisoned => unreachable!(),
+            }
+        }
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        loop {
+            match mem::replace(&mut self.sender, Write::Poisoned) {
+                Write::Idle(mut socket) => {
+                    self.sender = Write::Closing(Box::pin(async move {
+                        socket.close().await?;
+                        Ok(())
+                    }));
+                }
+                Write::Flushing(mut future) => match Pin::new(&mut future).poll(cx) {
+                    Poll::Pending => {
+                        self.sender = Write::Flushing(future);
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(Ok(socket)) => {
+                        self.sender = Write::Idle(socket);
+                    }
+                    Poll::Ready(Err(err)) => {
+                        self.sender = Write::Error(err);
+                    }
+                },
+                Write::Writing(mut future) => match Pin::new(&mut future).poll(cx) {
+                    Poll::Pending => {
+                        self.sender = Write::Writing(future);
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(Ok(socket)) => {
+                        self.sender = Write::Idle(socket);
+                    }
+                    Poll::Ready(Err(err)) => {
+                        self.sender = Write::Error(err);
+                    }
+                },
+                Write::Closing(mut future) => match Pin::new(&mut future).poll(cx) {
+                    Poll::Pending => {
+                        self.sender = Write::Closing(future);
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(Ok(())) => {
+                        self.sender = Write::Closed;
+                        return Poll::Ready(Ok(()));
+                    }
+                    Poll::Ready(Err(err)) => {
+                        self.sender = Write::Error(err);
+                    }
+                },
+                Write::Closed => return Poll::Ready(Ok(())),
+                Write::Error(err) => {
+                    let out_err = convert_err(&err);
+                    self.sender = Write::Error(err);
+                    return Poll::Ready(Err(out_err));
+                }
+                Write::Poisoned => unreachable!(),
+            }
+        }
+    }
+}
+
+fn convert_err(err: &soketto::connection::Error) -> io::Error {
+    match err {
+        soketto::connection::Error::Io(err) => io::Error::new(err.kind(), err.to_string()),
+        soketto::connection::Error::Codec(err) => {
+            io::Error::new(io::ErrorKind::InvalidData, err.to_string())
+        }
+        soketto::connection::Error::Extension(err) => {
+            io::Error::new(io::ErrorKind::InvalidData, err.to_string())
+        }
+        soketto::connection::Error::UnexpectedOpCode(err) => {
+            io::Error::new(io::ErrorKind::InvalidData, err.to_string())
+        }
+        soketto::connection::Error::Utf8(err) => {
+            io::Error::new(io::ErrorKind::InvalidData, err.to_string())
+        }
+        soketto::connection::Error::MessageTooLarge { .. } => {
+            io::Error::from(io::ErrorKind::InvalidData)
+        }
+        soketto::connection::Error::Closed => io::Error::from(io::ErrorKind::ConnectionAborted),
+        _ => io::Error::from(io::ErrorKind::Other),
+    }
+}


### PR DESCRIPTION
Close https://github.com/paritytech/smoldot/issues/2649

Adds support for multiaddresses of the form `.../ws`.

Note that WebSocket secure aren't supported in this PR.
