### PR TITLE
No longer verify commit messages immediately

### DIFF
--- a/bin/light-base/src/sync_service/standalone.rs
+++ b/bin/light-base/src/sync_service/standalone.rs
@@ -1182,34 +1182,21 @@ impl<TPlat: Platform> Task<TPlat> {
                 message,
             } if chain_index == self.network_chain_index => {
                 let sync_source_id = *self.peers_source_id_map.get(&peer_id).unwrap();
-                match self.sync.grandpa_commit_message(
-                    sync_source_id,
-                    &message.as_encoded(),
-                    rand::random(),
-                ) {
-                    Ok(()) => {
-                        // TODO: print more details
+                match self
+                    .sync
+                    .grandpa_commit_message(sync_source_id, message.into_encoded())
+                {
+                    all::GrandpaCommitMessageOutcome::Queued => {
+                        // TODO: print more details?
                         log::debug!(
                             target: &self.log_target,
-                            "Sync => GrandpaCommitVerified"
+                            "Sync <= QueuedGrandpaCommit"
                         );
-
-                        self.network_up_to_date_finalized = false; // TODO: only do if commit message has been processed
-                        self.known_finalized_runtime = None; // TODO: only do if commit message has been processed and if there was no RuntimeUpdated log item in the finalized blocks
-                        self.network_up_to_date_best = false; // TODO: done in case finality changes the best block; make this clearer in the sync layer
-                        self.dispatch_all_subscribers(Notification::Finalized {
-                            hash: self
-                                .sync
-                                .finalized_block_header()
-                                .hash(self.sync.block_number_bytes()),
-                            best_block_hash: self.sync.best_block_hash(),
-                        });
                     }
-                    Err(err) => {
-                        log::warn!(
+                    all::GrandpaCommitMessageOutcome::Discarded => {
+                        log::debug!(
                             target: &self.log_target,
-                            "Error when verifying GrandPa commit message: {}",
-                            err
+                            "Sync <= IgnoredGrandpaCommit"
                         );
                     }
                 }

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -2672,8 +2672,15 @@ pub struct EncodedGrandpaCommitMessage {
 
 impl EncodedGrandpaCommitMessage {
     /// Returns the encoded bytes of the commit message.
+    pub fn into_encoded(mut self) -> Vec<u8> {
+        // Skip the first byte because `self.message` is a `GrandpaNotificationRef`.
+        self.message.remove(0);
+        self.message
+    }
+
+    /// Returns the encoded bytes of the commit message.
     pub fn as_encoded(&self) -> &[u8] {
-        // Skip the first byte because `self.0` is a `GrandpaNotificationRef`.
+        // Skip the first byte because `self.message` is a `GrandpaNotificationRef`.
         &self.message[1..]
     }
 

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -84,6 +84,7 @@
 
 use crate::{
     chain::{blocks_tree, chain_information},
+    finality::grandpa,
     header, verify,
 };
 
@@ -909,65 +910,34 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
 
     /// Update the state machine with a Grandpa commit message received from the network.
     ///
-    /// On success, the finalized block has been updated.
-    ///
-    /// A randomness seed must be provided and will be used during the verification. Note that the
-    /// verification is nonetheless deterministic.
-    /// TODO: randomness seed will be removed at some point
+    /// This function only inserts the commit message into the state machine, and does not
+    /// immediately verify it.
     ///
     /// # Panic
     ///
     /// Panics if `source_id` is invalid.
     ///
-    // TODO: return which blocks are removed as finalized
-    // TODO: this should probably just insert the commit in the state machine and not verify it immediately; also remove the randomness seed then
     pub fn grandpa_commit_message(
         &mut self,
         source_id: SourceId,
-        scale_encoded_commit: &[u8],
-        randomness_seed: [u8; 32],
-    ) -> Result<(), blocks_tree::CommitVerifyError> {
-        // Grabbing the source is done early on in order to panic if the `source_id` is invalid.
+        scale_encoded_commit: Vec<u8>,
+    ) -> GrandpaCommitMessageOutcome {
         let source = &mut self.inner.blocks[source_id];
 
-        let block_number = match self
-            .chain
-            .verify_grandpa_commit_message(scale_encoded_commit, randomness_seed)
-        {
-            Ok(apply) => {
-                apply.apply();
-                return Ok(());
-            }
-            // In case where the commit message concerns a block older or equal to the finalized
-            // block, the operation is silently considered successful.
-            Err(blocks_tree::CommitVerifyError::FinalityVerify(
-                blocks_tree::FinalityVerifyError::EqualToFinalized
-                | blocks_tree::FinalityVerifyError::BelowFinalized,
-            )) => return Ok(()),
-            Err(
-                blocks_tree::CommitVerifyError::FinalityVerify(
-                    blocks_tree::FinalityVerifyError::UnknownTargetBlock { block_number, .. },
-                )
-                | blocks_tree::CommitVerifyError::FinalityVerify(
-                    blocks_tree::FinalityVerifyError::TooFarAhead {
-                        justification_block_number: block_number,
-                        ..
-                    },
-                )
-                | blocks_tree::CommitVerifyError::NotEnoughKnownBlocks {
-                    target_block_number: block_number,
-                },
-            ) => block_number,
-            Err(err) => return Err(err),
+        let block_number = match grandpa::commit::decode::decode_grandpa_commit(
+            &scale_encoded_commit,
+            self.chain.block_number_bytes(),
+        ) {
+            Ok(msg) => msg.message.target_number,
+            Err(_) => return GrandpaCommitMessageOutcome::ParseError,
         };
 
-        // If we reach here, the commit can't be verified yet. The commit is stored for later.
-        source.pending_finality_proofs.insert(
+        source.unverified_finality_proofs.insert(
             block_number,
-            FinalityProofs::GrandpaCommit(scale_encoded_commit.to_vec()),
+            FinalityProofs::GrandpaCommit(scale_encoded_commit),
         );
 
-        Ok(())
+        GrandpaCommitMessageOutcome::Queued
     }
 
     /// Process the next block in the queue of verification.
@@ -2098,6 +2068,15 @@ impl<TBl, TRq, TSrc> FinalityProofVerify<TBl, TRq, TSrc> {
     pub fn cancel(self) -> AllForksSync<TBl, TRq, TSrc> {
         self.parent
     }
+}
+
+/// See [`AllSync::grandpa_commit_message`].
+#[derive(Debug, Clone)]
+pub enum GrandpaCommitMessageOutcome {
+    /// Failed to parse message. Commit has been silently discarded.
+    ParseError, // TODO: should probably contain the error, but difficult due to lifetimes in said error
+    /// Message has been queued for later verification.
+    Queued,
 }
 
 /// State of the processing of blocks.

--- a/src/sync/all_forks.rs
+++ b/src/sync/all_forks.rs
@@ -2070,7 +2070,7 @@ impl<TBl, TRq, TSrc> FinalityProofVerify<TBl, TRq, TSrc> {
     }
 }
 
-/// See [`AllSync::grandpa_commit_message`].
+/// See [`AllForksSync::grandpa_commit_message`].
 #[derive(Debug, Clone)]
 pub enum GrandpaCommitMessageOutcome {
     /// Failed to parse message. Commit has been silently discarded.


### PR DESCRIPTION
When a commit message is received from the network, we now store it for later verification, as intended.
This should also fix issues where the sync service was reporting the same block as finalized multiple times.
