### PR TITLE
Add per-block finality info in blocks_tree

### DIFF
--- a/src/chain/blocks_tree.rs
+++ b/src/chain/blocks_tree.rs
@@ -138,8 +138,10 @@ impl<T> NonFinalizedTree<T> {
                     } => Finality::Grandpa {
                         after_finalized_block_authorities_set_id,
                         finalized_scheduled_change: finalized_scheduled_change
-                            .map(|(n, l)| (n, Arc::new(l))),
-                        finalized_triggered_authorities: Arc::new(finalized_triggered_authorities),
+                            .map(|(n, l)| (n, l.into_iter().collect())),
+                        finalized_triggered_authorities: finalized_triggered_authorities
+                            .into_iter()
+                            .collect(),
                     },
                 },
                 finalized_consensus: match chain_information.consensus {
@@ -507,15 +509,13 @@ enum Finality {
 
         /// List of GrandPa authorities that need to finalize the block right after the finalized
         /// block.
-        // TODO: consider `Arc<[..]>`
-        finalized_triggered_authorities: Arc<Vec<header::GrandpaAuthority>>,
+        finalized_triggered_authorities: Arc<[header::GrandpaAuthority]>,
 
         /// Change in the GrandPa authorities list that has been scheduled by a block that is already
         /// finalized but not triggered yet. These changes will for sure happen. Contains the block
         /// number where the changes are to be triggered. The descendants of the block with that
         /// number need to be finalized with the new authorities.
-        // TODO: consider `Arc<[..]>`
-        finalized_scheduled_change: Option<(u64, Arc<Vec<header::GrandpaAuthority>>)>,
+        finalized_scheduled_change: Option<(u64, Arc<[header::GrandpaAuthority]>)>,
     },
 }
 
@@ -573,13 +573,13 @@ enum BlockFinality {
         /// List of GrandPa authorities that need to finalize the block right after this block.
         ///
         /// If `triggers_change` is `false`, then this field must be equal to the parent block's.
-        triggered_authorities: Arc<Vec<header::GrandpaAuthority>>,
+        triggered_authorities: Arc<[header::GrandpaAuthority]>,
 
         /// A change in the GrandPa authorities list that has been scheduled for the block with the
         /// given number that descends from this one. The block with that number will trigger the
         /// new authorities, meaning that its descendants will need to be finalized with the new
         /// authorities.
-        scheduled_change: Option<(u64, Arc<Vec<header::GrandpaAuthority>>)>,
+        scheduled_change: Option<(u64, Arc<[header::GrandpaAuthority]>)>,
     },
 }
 

--- a/src/chain/blocks_tree.rs
+++ b/src/chain/blocks_tree.rs
@@ -521,6 +521,8 @@ struct Block<T> {
     hash: [u8; 32],
     /// Changes to the consensus made by the block.
     consensus: BlockConsensus,
+    /// Information about finality attached to each block.
+    finality: BlockFinality,
     /// Opaque data decided by the user.
     user_data: T,
 }
@@ -542,6 +544,13 @@ enum BlockConsensus {
         /// Information about the Babe epoch the block belongs to.
         next_epoch: Arc<chain_information::BabeEpochInformation>,
     },
+}
+
+/// Information about finality attached to each block.
+#[derive(Clone)]
+enum BlockFinality {
+    Outsourced,
+    Grandpa,
 }
 
 /// Access to a block's information and hierarchy.

--- a/src/chain/blocks_tree.rs
+++ b/src/chain/blocks_tree.rs
@@ -561,10 +561,14 @@ enum BlockFinality {
         /// a descendant of A, then B cannot be finalized before A is.
         /// This field contains the height of A, if it is known. Contains `None` if A is the
         /// current finalized block or below, and thus doesn't matter anyway.
+        ///
+        /// If `Some`, the value must always be strictly inferior to the attached block's number.
         prev_auth_change_trigger_number: Option<u64>,
 
         /// Authorities set id that must be used to finalize the blocks that descend from this
         /// one.
+        ///
+        /// If `triggers_change` is `false`, then this field must be equal to the parent block's.
         after_block_authorities_set_id: u64,
 
         /// `true` if this block triggers a change in the list of Grandpa authorities.
@@ -579,6 +583,8 @@ enum BlockFinality {
         /// given number that descends from this one. The block with that number will trigger the
         /// new authorities, meaning that its descendants will need to be finalized with the new
         /// authorities.
+        ///
+        /// If `Some`, the value must always be strictly superior to the attached block's number.
         scheduled_change: Option<(u64, Arc<[header::GrandpaAuthority]>)>,
     },
 }

--- a/src/chain/blocks_tree/finality.rs
+++ b/src/chain/blocks_tree/finality.rs
@@ -37,47 +37,20 @@ impl<T> NonFinalizedTree<T> {
                 // No checkpoint means all blocks allowed.
                 either::Left(iter::empty())
             }
-            Finality::Grandpa {
-                finalized_scheduled_change,
-                ..
-            } => {
-                // Scheduled change that is already finalized.
-                let scheduled = finalized_scheduled_change.as_ref().map(|(n, _)| *n);
-
-                // TODO: this is ~O(n²), but there's no real alternative here
+            Finality::Grandpa { .. } => {
+                // TODO: O(n), could add a cache to make it O(1)
                 let iter = inner
                     .blocks
                     .iter_unordered()
-                    .filter(move |(node_index, block)| {
-                        if scheduled == Some(block.header.number) {
-                            return true;
+                    .filter(move |(_, block)| {
+                        if let BlockFinality::Grandpa {
+                            triggers_change, ..
+                        } = &block.finality
+                        {
+                            *triggers_change
+                        } else {
+                            unreachable!()
                         }
-
-                        for ancestor in inner.blocks.root_to_node_path(*node_index) {
-                            let header = &inner.blocks.get(ancestor).unwrap().header;
-                            for grandpa_digest_item in
-                                header.digest.logs().filter_map(|d| match d {
-                                    header::DigestItemRef::GrandpaConsensus(gp) => Some(gp),
-                                    _ => None,
-                                })
-                            {
-                                match grandpa_digest_item {
-                                    header::GrandpaConsensusLogRef::ScheduledChange(change) => {
-                                        let trigger_block_height = header
-                                            .number
-                                            .checked_add(u64::from(change.delay))
-                                            .unwrap();
-
-                                        if trigger_block_height == block.header.number {
-                                            return true;
-                                        }
-                                    }
-                                    _ => {} // TODO: unimplemented
-                                }
-                            }
-                        }
-
-                        false
                     })
                     .map(|(_, block)| (block.header.number, &block.hash));
 
@@ -215,78 +188,25 @@ impl<T> NonFinalizedTreeInner<T> {
                     }
                 };
 
-                // If any block between the latest finalized one and the target block trigger any GrandPa
-                // authorities change, then we need to finalize that triggering block (or any block
-                // after or including the one that schedules these changes) before finalizing the one
-                // targeted by the justification.
-                // TODO: rethink and reexplain this ^
-
-                // Find out the next block height where an authority change will be triggered.
-                let earliest_trigger = {
-                    // Scheduled change that is already finalized.
-                    let scheduled = finalized_scheduled_change.as_ref().map(|(n, _)| *n);
-
-                    // First change that would be scheduled if we finalize the target block.
-                    let would_happen = {
-                        let mut trigger_height = None;
-                        // TODO: lot of boilerplate code here
-                        for node in self.blocks.root_to_node_path(block_index) {
-                            let header = &self.blocks.get(node).unwrap().header;
-                            for grandpa_digest_item in
-                                header.digest.logs().filter_map(|d| match d {
-                                    header::DigestItemRef::GrandpaConsensus(gp) => Some(gp),
-                                    _ => None,
-                                })
-                            {
-                                match grandpa_digest_item {
-                                    header::GrandpaConsensusLogRef::ScheduledChange(change) => {
-                                        let trigger_block_height = header
-                                            .number
-                                            .checked_add(u64::from(change.delay))
-                                            .unwrap();
-                                        match trigger_height {
-                                            Some(_) => panic!("invalid block!"), // TODO: this problem is not checked during block verification
-                                            None => trigger_height = Some(trigger_block_height),
-                                        }
-                                    }
-                                    _ => {} // TODO: unimplemented
-                                }
-                            }
+                // If any block between the latest finalized one and the target block triggers any
+                // GrandPa authorities change, then we need to finalize that triggering block
+                // before finalizing the one targeted by the justification.
+                if let BlockFinality::Grandpa {
+                    ref prev_auth_change_trigger_number,
+                    ..
+                } = self.blocks.get(block_index).unwrap().finality
+                {
+                    if let Some(prev_auth_change_trigger_number) = prev_auth_change_trigger_number {
+                        if *prev_auth_change_trigger_number > self.finalized_block_header.number {
+                            return Err(FinalityVerifyError::TooFarAhead {
+                                justification_block_number: target_number,
+                                justification_block_hash: *target_hash,
+                                block_to_finalize_number: *prev_auth_change_trigger_number,
+                            });
                         }
-                        trigger_height
-                    };
-
-                    match (scheduled, would_happen) {
-                        (Some(a), Some(b)) => Some(cmp::min(a, b)),
-                        (Some(a), None) => Some(a),
-                        (None, Some(b)) => Some(b),
-                        (None, None) => None,
                     }
-                };
-
-                // As explained above, `target_number` must be <= `earliest_trigger`, otherwise the
-                // finalization is unsecure.
-                if let Some(earliest_trigger) = earliest_trigger {
-                    if target_number > earliest_trigger {
-                        let block_to_finalize_hash = self
-                            .blocks
-                            .node_to_root_path(block_index)
-                            .find_map(|b| {
-                                let b = self.blocks.get(b).unwrap();
-                                if b.header.number == earliest_trigger {
-                                    Some(b.hash)
-                                } else {
-                                    None
-                                }
-                            })
-                            .unwrap();
-                        return Err(FinalityVerifyError::TooFarAhead {
-                            justification_block_number: target_number,
-                            justification_block_hash: *target_hash,
-                            block_to_finalize_number: earliest_trigger,
-                            block_to_finalize_hash,
-                        });
-                    }
+                } else {
+                    unreachable!()
                 }
 
                 // Find which authorities are supposed to finalize the target block.
@@ -430,53 +350,41 @@ impl<T> NonFinalizedTreeInner<T> {
         &mut self,
         block_index_to_finalize: fork_tree::NodeIndex,
     ) -> SetFinalizedBlockIter<T> {
-        let new_finalized_block_height = self
-            .blocks
-            .get_mut(block_index_to_finalize)
-            .unwrap()
-            .header
-            .number;
+        let new_finalized_block = self.blocks.get_mut(block_index_to_finalize).unwrap();
 
         // Update `self.finality`.
-        match &mut self.finality {
-            Finality::Outsourced => {}
-            Finality::Grandpa {
-                after_finalized_block_authorities_set_id,
-                finalized_scheduled_change,
-                finalized_triggered_authorities,
-            } => {
-                // Update the scheduled GrandPa change with the latest scheduled-but-non-finalized change
-                // that could be found.
-                *finalized_scheduled_change = None;
-                for node in self.blocks.root_to_node_path(block_index_to_finalize) {
-                    let node = self.blocks.get(node).unwrap();
-                    for grandpa_digest_item in node.header.digest.logs().filter_map(|d| match d {
-                        header::DigestItemRef::GrandpaConsensus(gp) => Some(gp),
-                        _ => None,
-                    }) {
-                        match grandpa_digest_item {
-                            header::GrandpaConsensusLogRef::ScheduledChange(change) => {
-                                let trigger_block_height = node
-                                    .header
-                                    .number
-                                    .checked_add(u64::from(change.delay))
-                                    .unwrap();
-                                if trigger_block_height > new_finalized_block_height {
-                                    *finalized_scheduled_change = Some((
-                                        trigger_block_height,
-                                        change.next_authorities.map(Into::into).collect(),
-                                    ));
-                                } else {
-                                    *finalized_triggered_authorities =
-                                        change.next_authorities.map(Into::into).collect();
-                                    *after_finalized_block_authorities_set_id += 1;
-                                }
-                            }
-                            _ => {} // TODO: unimplemented
-                        }
-                    }
-                }
+        match (&mut self.finality, &new_finalized_block.finality) {
+            (Finality::Outsourced, BlockFinality::Outsourced) => {}
+            (
+                Finality::Grandpa {
+                    after_finalized_block_authorities_set_id,
+                    finalized_scheduled_change,
+                    finalized_triggered_authorities,
+                },
+                BlockFinality::Grandpa {
+                    after_block_authorities_set_id,
+                    triggered_authorities,
+                    scheduled_change,
+                    ..
+                },
+            ) => {
+                // Some sanity checks.
+                debug_assert!(
+                    *after_finalized_block_authorities_set_id <= *after_block_authorities_set_id
+                );
+                debug_assert!(scheduled_change
+                    .as_ref()
+                    .map(|(n, _)| *n > new_finalized_block.header.number)
+                    .unwrap_or(true));
+
+                *after_finalized_block_authorities_set_id = *after_block_authorities_set_id;
+                *finalized_triggered_authorities = triggered_authorities.clone();
+                *finalized_scheduled_change = scheduled_change.clone();
             }
+
+            // Mismatch between chain finality algorithm and block finality algorithm. Should never
+            // happen.
+            _ => unreachable!(),
         }
 
         // If the best block isn't a descendant of the block being finalized, then the best
@@ -706,8 +614,6 @@ pub enum FinalityVerifyError {
         justification_block_hash: [u8; 32],
         /// Number of the block to finalize first.
         block_to_finalize_number: u64,
-        /// Hash of the block to finalize first.
-        block_to_finalize_hash: [u8; 32],
     },
 }
 

--- a/src/chain/blocks_tree/verify.rs
+++ b/src/chain/blocks_tree/verify.rs
@@ -522,12 +522,7 @@ impl<T> VerifyContext<T> {
                                 None => {
                                     scheduled_change = Some((
                                         trigger_block_height,
-                                        Arc::new(
-                                            change
-                                                .next_authorities
-                                                .map(|a| a.into())
-                                                .collect::<Vec<_>>(),
-                                        ),
+                                        change.next_authorities.map(|a| a.into()).collect(),
                                     ));
                                 }
                             }

--- a/src/chain/blocks_tree/verify.rs
+++ b/src/chain/blocks_tree/verify.rs
@@ -517,6 +517,9 @@ impl<T> VerifyContext<T> {
                                 .checked_add(u64::from(change.delay))
                                 .unwrap();
 
+                            // It is forbidden to schedule a change while a change is already
+                            // scheduled, otherwise the block is invalid. This is verified during
+                            // the block verification.
                             match scheduled_change {
                                 Some(_) => panic!("invalid block!"), // TODO: this problem is not checked during block verification
                                 None => {
@@ -543,9 +546,10 @@ impl<T> VerifyContext<T> {
                     }
                 }
 
+                // Some sanity checks.
                 debug_assert!(scheduled_change
                     .as_ref()
-                    .map(|(n, _)| *n >= self.header.number)
+                    .map(|(n, _)| *n > self.header.number)
                     .unwrap_or(true));
                 debug_assert!(parent_prev_auth_change_trigger_number
                     .as_ref()


### PR DESCRIPTION
This PR makes all the finality-related operations in the `BlocksTree` O(1).

Before this PR, we sometimes needed to traverse the tree of blocks in order to find an information concerning finality.
After this PR, this information is now stored in each block whenever it is inserted.
In order to not sure too much information, the list of authorities has been put in an `Arc`, meaning that it can be duplicated between all blocks that use the same list relatively cheaply.

I must admit that GrandPa is quite complicated, and I've re-read what I've done multiple times, to be sure to not mix scheduling block, triggering block, not have an off-by-one problem with scheduled changes, etc.
