### PR TITLE
Implement TrieStructure::remove_prefix

### DIFF
--- a/src/trie/calculate_root.rs
+++ b/src/trie/calculate_root.rs
@@ -182,17 +182,13 @@ impl CalculationCache {
 
     /// Notify the cache that all the storage values whose key start with the given prefix have
     /// been removed.
-    pub fn prefix_remove_update(&mut self, _prefix: &[u8]) {
-        let _structure = match &mut self.structure {
+    pub fn prefix_remove_update(&mut self, prefix: &[u8]) {
+        let structure = match &mut self.structure {
             Some(s) => s,
             None => return,
         };
 
-        // TODO: implement correctly
-        self.structure = None;
-
-        /*
-        if let Some(mut node) = structure.remove_prefix(bytes_to_nibbles(prefix).iter().cloned()) {
+        if let Some(mut node) = structure.remove_prefix(bytes_to_nibbles(prefix.iter().cloned())) {
             node.user_data().merkle_value = None;
             let mut parent = node.into_parent();
             while let Some(mut p) = parent.take() {
@@ -201,7 +197,7 @@ impl CalculationCache {
             }
         } else if let Some(mut root_node) = structure.root_node() {
             root_node.user_data().merkle_value = None;
-        }*/
+        }
     }
 }
 

--- a/src/trie/trie_structure.rs
+++ b/src/trie/trie_structure.rs
@@ -365,6 +365,9 @@ impl<TUd> TrieStructure<TUd> {
             } => {
                 let key_len = self.node_full_key(ancestor).count();
                 let child_index = prefix.skip(key_len).next().unwrap();
+                debug_assert!(
+                    self.nodes[ancestor].children[usize::from(u8::from(child_index))].is_some()
+                );
                 Some((ancestor, child_index))
             }
         };

--- a/src/trie/trie_structure.rs
+++ b/src/trie/trie_structure.rs
@@ -359,16 +359,19 @@ impl<TUd> TrieStructure<TUd> {
             }
             ExistingNodeInnerResult::NotFound {
                 closest_ancestor: None,
-            } => None,
+            } => None, // TODO: is this correct?
             ExistingNodeInnerResult::NotFound {
                 closest_ancestor: Some(ancestor),
             } => {
                 let key_len = self.node_full_key(ancestor).count();
                 let child_index = prefix.skip(key_len).next().unwrap();
-                debug_assert!(
-                    self.nodes[ancestor].children[usize::from(u8::from(child_index))].is_some()
-                );
-                Some((ancestor, child_index))
+                // It is possible that there is simply no node at all with the given prefix, in
+                // which case there is closest ancestor but nothing to clear.
+                if self.nodes[ancestor].children[usize::from(u8::from(child_index))].is_some() {
+                    Some((ancestor, child_index))
+                } else {
+                    return Some(self.node_by_index_inner(ancestor).unwrap());
+                }
             }
         };
 

--- a/src/trie/trie_structure.rs
+++ b/src/trie/trie_structure.rs
@@ -669,7 +669,6 @@ impl<TUd> TrieStructure<TUd> {
     ///
     /// Panics if `node_index` is not a valid index.
     fn descendants(&'_ self, node_index: usize) -> impl Iterator<Item = usize> + '_ {
-        // TODO: implementation looks wrong
         // First element is `node_index`. Each successor is the first child of `current` or,
         // if `current` doesn't have any children, the next sibling of `current`.
         // Since `node_index` must explicitly not be included, we skip the first element.

--- a/src/trie/trie_structure.rs
+++ b/src/trie/trie_structure.rs
@@ -22,7 +22,7 @@
 
 use super::nibble::Nibble;
 
-use alloc::{borrow::ToOwned as _, vec::Vec};
+use alloc::{borrow::ToOwned as _, vec, vec::Vec};
 use core::{fmt, iter, mem};
 use either::Either;
 use slab::Slab;

--- a/src/trie/trie_structure.rs
+++ b/src/trie/trie_structure.rs
@@ -373,9 +373,30 @@ impl<TUd> TrieStructure<TUd> {
             ExistingNodeInnerResult::NotFound {
                 closest_ancestor: None,
             } => {
-                // Either the trie is empty, or the key of the root node of the trie doesn't
-                // start with the requested prefix.
-                // Nothing to do.
+                // The trie is empty, or the key of the root node of the trie doesn't start with
+                // the requested prefix, or the key of the root node of the trie starts with the
+                // requested prefix.
+                let root_index = if let Some(i) = self.root_index {
+                    i
+                } else {
+                    // Trie is empty. Nothing to do.
+                    return None;
+                };
+
+                // Compare root key with the prefix.
+                if !self.nodes[root_index]
+                    .partial_key
+                    .iter()
+                    .zip(prefix)
+                    .all(|(a, b)| *a == b)
+                {
+                    // Root node key doesn't match the prefix. Nothing to do.
+                    return None;
+                }
+
+                // Root node key starts with the requested prefix. Clear the entire trie.
+                self.nodes.clear();
+                self.root_index = None;
                 return None;
             }
             ExistingNodeInnerResult::NotFound {

--- a/src/trie/trie_structure/tests.rs
+++ b/src/trie/trie_structure/tests.rs
@@ -353,6 +353,7 @@ fn fuzzing() {
         // Create multiple tries, each with a different order of insertion for the nodes.
         let mut tries = Vec::new();
         for _ in 0..16 {
+            #[derive(Debug, Copy, Clone)]
             enum Op {
                 Insert,
                 Remove,
@@ -433,7 +434,7 @@ fn fuzzing() {
 
             // Create a trie and applies `operations` on it.
             let mut trie = TrieStructure::new();
-            for (key, op) in operations {
+            for (op_index, (key, op)) in operations.clone().into_iter().enumerate() {
                 match op {
                     Op::Insert => match trie.node(key.into_iter()) {
                         super::Entry::Vacant(e) => {
@@ -442,14 +443,20 @@ fn fuzzing() {
                         super::Entry::Occupied(super::NodeAccess::Branch(e)) => {
                             e.insert_storage_value();
                         }
-                        super::Entry::Occupied(super::NodeAccess::Storage(_)) => unreachable!(),
+                        super::Entry::Occupied(super::NodeAccess::Storage(_)) => {
+                            unreachable!("index: {}\nops:{:?}", op_index, operations)
+                        }
                     },
                     Op::Remove => match trie.node(key.into_iter()) {
                         super::Entry::Occupied(super::NodeAccess::Storage(e)) => {
                             e.remove();
                         }
-                        super::Entry::Vacant(_) => unreachable!(),
-                        super::Entry::Occupied(super::NodeAccess::Branch(_)) => unreachable!(),
+                        super::Entry::Vacant(_) => {
+                            unreachable!("index: {}\nops:{:?}", op_index, operations)
+                        }
+                        super::Entry::Occupied(super::NodeAccess::Branch(_)) => {
+                            unreachable!("index: {}\nops:{:?}", op_index, operations)
+                        }
                     },
                     Op::ClearPrefix => {
                         trie.remove_prefix(key.into_iter());

--- a/src/trie/trie_structure/tests.rs
+++ b/src/trie/trie_structure/tests.rs
@@ -406,7 +406,7 @@ fn fuzzing() {
                     .position(|(k, _)| k.starts_with(&base_key))
                     .unwrap_or(operations.len());
 
-                let remove_index =
+                let mut remove_index =
                     Uniform::new_inclusive(0, max_remove_index).sample(&mut rand::thread_rng());
                 operations.insert(remove_index, (base_key.clone(), Op::ClearPrefix));
 
@@ -427,6 +427,7 @@ fn fuzzing() {
                     let insert_index =
                         Uniform::new_inclusive(0, remove_index).sample(&mut rand::thread_rng());
                     operations.insert(insert_index, (base_key, Op::Insert));
+                    remove_index += 1;
                 }
             }
 


### PR DESCRIPTION
Before this PR, whenever we want to clear all the nodes with a prefix, we simply clear the entire Merkle root calculation cache.
After this PR, we only clear from the cache the entries that have the given prefix.
The idea is to speed up blocks verification (and authorship).

Tests need to be written before merging.

Furthermore, I've discovered that the `descendants` function in this module doesn't look right at all, which would make tests pass more than they should. This should be investigated beforehand as well.
