### PR TITLE
Properly iterate over the trie structure

### DIFF
--- a/src/trie/trie_structure.rs
+++ b/src/trie/trie_structure.rs
@@ -456,7 +456,7 @@ impl<TUd> TrieStructure<TUd> {
         }
     }
 
-    /// Iterates over all nodes of the trie, in a specific but undeterminate order.
+    /// Iterates over all nodes of the trie, in a specific but unspecified order.
     fn all_nodes_ordered(&'_ self) -> impl Iterator<Item = usize> + '_ {
         fn ancestry_order_next<TUd>(tree: &TrieStructure<TUd>, node_index: usize) -> Option<usize> {
             if let Some(first_child) = tree

--- a/src/trie/trie_structure/tests.rs
+++ b/src/trie/trie_structure/tests.rs
@@ -416,3 +416,31 @@ fn fuzzing() {
         }
     }
 }
+
+#[test]
+fn iter_properly_traverses() {
+    let mut trie = TrieStructure::new();
+
+    // Fill the trie with entries with randomly generated keys.
+    for _ in 0..Uniform::new_inclusive(0, 32).sample(&mut rand::thread_rng()) {
+        let mut key = Vec::new();
+        for _ in 0..Uniform::new_inclusive(0, 12).sample(&mut rand::thread_rng()) {
+            key.push(
+                Nibble::try_from(Uniform::new_inclusive(0, 15).sample(&mut rand::thread_rng()))
+                    .unwrap(),
+            );
+        }
+
+        match trie.node(key.into_iter()) {
+            super::Entry::Vacant(e) => {
+                e.insert_storage_value().insert((), ());
+            }
+            super::Entry::Occupied(super::NodeAccess::Branch(e)) => {
+                e.insert_storage_value();
+            }
+            super::Entry::Occupied(super::NodeAccess::Storage(_)) => {}
+        }
+    }
+
+    assert_eq!(trie.all_nodes_ordered().count(), trie.nodes.len());
+}


### PR DESCRIPTION
cc my remark in https://github.com/paritytech/smoldot/pull/2663

The `descendants` and `all_nodes_ordered` functions were misimplemented, meaning that `structure_equal` would return `true` even when the structures were not necessarily equal.

I've also added a test, and this test indeed fails before the bugfix is applied.
