### PR TITLE
Turn `smoldot-light-base` into a properly usable library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
     - run: RUSTFLAGS=-Dwarnings cargo check --package smoldot --locked --no-default-features --features database-sqlite
     - run: RUSTFLAGS=-Dwarnings cargo check --package smoldot --locked --no-default-features --features std
     - run: RUSTFLAGS=-Dwarnings cargo check --package smoldot --locked --no-default-features --features database-sqlite --features std
+    - run: RUSTFLAGS=-Dwarnings cargo check --package smoldot-light-base --locked --no-default-features
+    - run: RUSTFLAGS=-Dwarnings cargo check --package smoldot-light-base --locked --no-default-features --features std
 
   fuzzing-binaries-compile:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,8 @@ jobs:
     - run: RUSTFLAGS=-Dwarnings cargo check --package smoldot --locked --no-default-features --features database-sqlite
     - run: RUSTFLAGS=-Dwarnings cargo check --package smoldot --locked --no-default-features --features std
     - run: RUSTFLAGS=-Dwarnings cargo check --package smoldot --locked --no-default-features --features database-sqlite --features std
-    - run: RUSTFLAGS=-Dwarnings cargo check --package smoldot-light-base --locked --no-default-features
-    - run: RUSTFLAGS=-Dwarnings cargo check --package smoldot-light-base --locked --no-default-features --features std
+    - run: RUSTFLAGS=-Dwarnings cargo check --package smoldot-light --locked --no-default-features
+    - run: RUSTFLAGS=-Dwarnings cargo check --package smoldot-light --locked --no-default-features --features std
 
   fuzzing-binaries-compile:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +965,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,6 +1291,12 @@ name = "httparse"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "impl-trait-for-tuples"
@@ -2054,6 +2082,8 @@ version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -2363,9 +2393,11 @@ dependencies = [
 name = "smoldot-light"
 version = "0.1.0"
 dependencies = [
+ "async-std",
  "blake2-rfc",
  "derive_more",
  "either",
+ "env_logger",
  "event-listener",
  "fnv",
  "futures",
@@ -2374,6 +2406,7 @@ dependencies = [
  "itertools",
  "log",
  "lru",
+ "parking_lot 0.12.1",
  "rand",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2360,7 +2360,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "smoldot-light-base"
+name = "smoldot-light"
 version = "0.1.0"
 dependencies = [
  "blake2-rfc",
@@ -2395,7 +2395,7 @@ dependencies = [
  "rand",
  "slab",
  "smoldot",
- "smoldot-light-base",
+ "smoldot-light",
 ]
 
 [[package]]

--- a/bin/light-base/Cargo.toml
+++ b/bin/light-base/Cargo.toml
@@ -8,6 +8,10 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 edition = "2021"
 publish = false
 
+[[example]]
+name = "basic"
+required-features = ["std"]
+
 [dependencies]
 blake2-rfc = { version = "0.2.18", default-features = false }
 derive_more = "0.99.17"
@@ -26,6 +30,14 @@ serde_json = "1.0.85"
 slab = { version = "0.4.7", default-features = false }
 smoldot = { version = "0.2.0", path = "../..", default-features = false }
 
+# `std` feature
+# Add here the crates that cannot function without the help of the operating system or environment.
+async-std = { version = "1.12.0", optional = true }
+parking_lot = { version = "0.12.1", optional = true }
+
 [features]
 default = ["std"]
-std = []
+std = ["async-std", "parking_lot", "smoldot/std"]
+
+[dev-dependencies]
+env_logger = "0.9.0"

--- a/bin/light-base/Cargo.toml
+++ b/bin/light-base/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "smoldot-light-base"
+name = "smoldot-light"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Browser bindings to a light client for Substrate-based blockchains"

--- a/bin/light-base/Cargo.toml
+++ b/bin/light-base/Cargo.toml
@@ -6,7 +6,6 @@ description = "Browser bindings to a light client for Substrate-based blockchain
 repository = "https://github.com/paritytech/smoldot"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 edition = "2021"
-publish = false
 
 [[example]]
 name = "basic"

--- a/bin/light-base/Cargo.toml
+++ b/bin/light-base/Cargo.toml
@@ -25,3 +25,7 @@ serde = { version = "1.0.143", default-features = false, features = ["alloc", "d
 serde_json = "1.0.85"
 slab = { version = "0.4.7", default-features = false }
 smoldot = { version = "0.2.0", path = "../..", default-features = false }
+
+[features]
+default = ["std"]
+std = []

--- a/bin/light-base/examples/basic.rs
+++ b/bin/light-base/examples/basic.rs
@@ -1,0 +1,129 @@
+// Smoldot
+// Copyright (C) 2019-2022  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use core::iter;
+use futures::{channel::mpsc, prelude::*};
+
+fn main() {
+    // The `smoldot_light` library uses the `log` crate to emit logs.
+    // We need to register some kind of logs listener, in this example `env_logger`.
+    // See also <https://docs.rs/log>.
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    // The smoldot client will need to spawn tasks that run in the background. In order to do so,
+    // we will need to provide a "tasks spawner" to the client. This block of code initializes
+    // this "tasks spawner".
+    // The tasks sent (by the client) to `tasks_spawner` will be received by `tasks_receiver`.
+    // The `tasks_receiver`.
+    let (tasks_spawner, mut tasks_receiver) = mpsc::unbounded();
+    async_std::task::spawn(async move {
+        let mut all_tasks = stream::FuturesUnordered::new();
+        loop {
+            futures::select! {
+                (_, new_task) = tasks_receiver.select_next_some() => {
+                    all_tasks.push(new_task);
+                },
+                () = all_tasks.select_next_some() => {},
+            }
+        }
+    });
+
+    // Now properly initialize the client. This does nothing except allocate resources.
+    // We pass the "tasks spawner" created above.
+    // The `Client` struct requires a generic parameter that provides platform bindings. In this
+    // example, we provide `AsyncStdTcpWebSocket`, which are the "plug and play" default platform.
+    // Any advance usage, such as embedding a client in WebAssembly, will likely require a custom
+    // implementation of these bindings.
+    let mut client = smoldot_light::Client::<
+        smoldot_light::platform::async_std::AsyncStdTcpWebSocket,
+    >::new(smoldot_light::ClientConfig {
+        tasks_spawner,
+        system_name: env!("CARGO_PKG_NAME").into(),
+        system_version: env!("CARGO_PKG_VERSION").into(),
+    });
+
+    // Once a chain has been added, we will be able to send JSON-RPC requests to it. And in
+    // return, the client will send back JSON-RPC responses. The JSON-RPC responses will be sent
+    // by the client on the `json_rpc_responses_tx` channel (that we inject inside the client).
+    let (json_rpc_responses_tx, mut json_rpc_responses_rx) = mpsc::channel(32);
+
+    // Ask the client to connect to a chain.
+    let chain_id = client.add_chain(smoldot_light::AddChainConfig {
+        // The most important field of the configuration is the chain specification. This is a
+        // JSON document containing all the information necessary for the client to connect to said
+        // chain.
+        specification: include_str!("../../polkadot.json"),
+
+        // See above.
+        // Note that it is possible to pass `None`, in which case the chain will not be able to
+        // handle JSON-RPC requests. This can be used to save up some resources.
+        json_rpc_responses: Some(json_rpc_responses_tx),
+
+        // This field is necessary only if adding a parachain.
+        potential_relay_chains: iter::empty(),
+
+        // After a chain has been added, it is possible to extract a "database" (in the form of a
+        // simple string). This database can later be passed back the next time the same chain is
+        // added again.
+        // A database with an invalid format is simply ignored by the client.
+        // In this example, we don't use this feature, and as such we simply pass an empty string,
+        // which is intentionally an invalid database content.
+        database_content: "",
+
+        // The client gives the possibility to insert an opaque "user data" alongside each chain.
+        // This avoids having to create a separate `HashMap<ChainId, ...>` in parallel of the
+        // client.
+        // In this example, this feature isn't used. The chain simply has `()`.
+        user_data: (),
+    });
+
+    // The `add_chain` function doesn't return a `Result`. Instead, a chain that has failed
+    // initialization still exists but in an "erroneous" state. Before continuing, we need to
+    // check whether the chain is in this erroneous state.
+    if let Some(error_msg) = client.chain_is_erroneous(chain_id) {
+        // Chains in an erroneous state must be removed using `remove_chain`.
+        // Note that this doesn't matter so much here because we end up panicking, but if we
+        // didn't panic it would important to call `remove_chain`.
+        let error_msg = error_msg.to_owned();
+        let _ = client.remove_chain(chain_id);
+        panic!("Error while creating chain: {}", error_msg);
+    }
+
+    // The chain is now properly initialized.
+
+    // Send a JSON-RPC request to the chain.
+    // The example here asks the client to send us notifications whenever the new best block has
+    // changed.
+    // Calling this function only queues the request. It is not processed immediately.
+    // An `Err` is returned immediately if and only if the request isn't a proper JSON-RPC request
+    // or if the channel of JSON-RPC responses is clogged.
+    client
+        .json_rpc_request(
+            r#"{"id":1,"jsonrpc":"2.0","method":"chain_subscribeNewHeads","params":[]}"#,
+            chain_id,
+        )
+        .unwrap();
+
+    // Now block the execution forever and print the responses received on the channel of
+    // JSON-RPC responses.
+    async_std::task::block_on(async move {
+        loop {
+            let response = json_rpc_responses_rx.next().await.unwrap();
+            println!("JSON-RPC response: {}", response);
+        }
+    })
+}

--- a/bin/light-base/src/json_rpc_service.rs
+++ b/bin/light-base/src/json_rpc_service.rs
@@ -42,7 +42,9 @@ mod getters;
 mod state_chain;
 mod transactions;
 
-use crate::{network_service, runtime_service, sync_service, transactions_service, Platform};
+use crate::{
+    network_service, platform::Platform, runtime_service, sync_service, transactions_service,
+};
 
 use futures::{channel::mpsc, lock::Mutex, prelude::*};
 use smoldot::{

--- a/bin/light-base/src/json_rpc_service.rs
+++ b/bin/light-base/src/json_rpc_service.rs
@@ -46,7 +46,22 @@ use crate::{
     network_service, platform::Platform, runtime_service, sync_service, transactions_service,
 };
 
+use alloc::{
+    borrow::ToOwned as _,
+    boxed::Box,
+    format,
+    string::{String, ToString as _},
+    sync::Arc,
+    vec::Vec,
+};
+use core::{
+    iter,
+    num::{NonZeroU32, NonZeroUsize},
+    sync::atomic,
+    time::Duration,
+};
 use futures::{channel::mpsc, lock::Mutex, prelude::*};
+use hashbrown::HashMap;
 use smoldot::{
     chain::fork_tree,
     chain_spec,
@@ -55,14 +70,6 @@ use smoldot::{
     json_rpc::{self, methods, requests_subscriptions},
     libp2p::{multiaddr, PeerId},
     network::protocol,
-};
-use std::{
-    collections::HashMap,
-    iter,
-    num::{NonZeroU32, NonZeroUsize},
-    str,
-    sync::{atomic, Arc},
-    time::Duration,
 };
 
 /// Configuration for [`service`].

--- a/bin/light-base/src/json_rpc_service/chain_head.rs
+++ b/bin/light-base/src/json_rpc_service/chain_head.rs
@@ -17,9 +17,9 @@
 
 //! All JSON-RPC method handlers that related to the `chainHead` API.
 
-use super::{Background, FollowSubscription, Platform, SubscriptionTy};
+use super::{Background, FollowSubscription, SubscriptionTy};
 
-use crate::{runtime_service, sync_service};
+use crate::{platform::Platform, runtime_service, sync_service};
 
 use futures::prelude::*;
 use smoldot::{

--- a/bin/light-base/src/json_rpc_service/chain_head.rs
+++ b/bin/light-base/src/json_rpc_service/chain_head.rs
@@ -21,22 +21,21 @@ use super::{Background, FollowSubscription, SubscriptionTy};
 
 use crate::{platform::Platform, runtime_service, sync_service};
 
+use alloc::{borrow::ToOwned as _, boxed::Box, format, string::ToString as _, sync::Arc, vec::Vec};
+use core::{
+    cmp, iter,
+    num::{NonZeroU32, NonZeroUsize},
+    sync::atomic,
+    time::Duration,
+};
 use futures::prelude::*;
+use hashbrown::HashMap;
 use smoldot::{
     chain::fork_tree,
     executor::{self, runtime_host},
     header,
     json_rpc::{self, methods, requests_subscriptions},
     network::protocol,
-};
-use std::{
-    cmp,
-    collections::HashMap,
-    iter,
-    num::{NonZeroU32, NonZeroUsize},
-    str,
-    sync::{atomic, Arc},
-    time::Duration,
 };
 
 impl<TPlat: Platform> Background<TPlat> {

--- a/bin/light-base/src/json_rpc_service/getters.rs
+++ b/bin/light-base/src/json_rpc_service/getters.rs
@@ -19,12 +19,13 @@
 
 use super::{Background, Platform};
 
+use alloc::{format, string::ToString as _, sync::Arc, vec::Vec};
+use core::num::NonZeroUsize;
 use smoldot::{
     header,
     json_rpc::{methods, requests_subscriptions},
     network::protocol,
 };
-use std::{num::NonZeroUsize, str, sync::Arc};
 
 impl<TPlat: Platform> Background<TPlat> {
     /// Handles a call to [`methods::MethodCall::chain_getFinalizedHead`].

--- a/bin/light-base/src/json_rpc_service/state_chain.rs
+++ b/bin/light-base/src/json_rpc_service/state_chain.rs
@@ -21,6 +21,21 @@ use super::{Background, Platform, RuntimeCallError, SubscriptionTy};
 
 use crate::runtime_service;
 
+use alloc::{
+    borrow::ToOwned as _,
+    boxed::Box,
+    format,
+    string::{String, ToString as _},
+    sync::Arc,
+    vec,
+    vec::Vec,
+};
+use core::{
+    iter,
+    num::{NonZeroU32, NonZeroUsize},
+    sync::atomic,
+    time::Duration,
+};
 use futures::{lock::MutexGuard, prelude::*};
 use smoldot::{
     header,
@@ -28,13 +43,6 @@ use smoldot::{
     json_rpc::{self, methods, requests_subscriptions},
     network::protocol,
     remove_metadata_length_prefix,
-};
-use std::{
-    iter,
-    num::{NonZeroU32, NonZeroUsize},
-    str,
-    sync::{atomic, Arc},
-    time::Duration,
 };
 
 mod sub_utils;

--- a/bin/light-base/src/json_rpc_service/state_chain/sub_utils.rs
+++ b/bin/light-base/src/json_rpc_service/state_chain/sub_utils.rs
@@ -23,9 +23,10 @@ use crate::{
     runtime_service::{Notification, RuntimeError, RuntimeService},
 };
 
+use alloc::{sync::Arc, vec::Vec};
+use core::num::NonZeroUsize;
 use futures::prelude::*;
 use smoldot::{executor, header};
-use std::{num::NonZeroUsize, sync::Arc};
 
 /// Returns the current runtime version, plus an unlimited stream that produces one item every
 /// time the specs of the runtime of the best block are changed.

--- a/bin/light-base/src/json_rpc_service/state_chain/sub_utils.rs
+++ b/bin/light-base/src/json_rpc_service/state_chain/sub_utils.rs
@@ -19,8 +19,8 @@
 //! by the JSON-RPC service.
 
 use crate::{
+    platform::Platform,
     runtime_service::{Notification, RuntimeError, RuntimeService},
-    Platform,
 };
 
 use futures::prelude::*;

--- a/bin/light-base/src/json_rpc_service/transactions.rs
+++ b/bin/light-base/src/json_rpc_service/transactions.rs
@@ -21,12 +21,10 @@ use super::{Background, Platform, SubscriptionTy};
 
 use crate::transactions_service;
 
+use alloc::{borrow::ToOwned as _, boxed::Box, str, string::ToString as _, sync::Arc, vec::Vec};
+use core::sync::atomic;
 use futures::prelude::*;
 use smoldot::json_rpc::{self, methods, requests_subscriptions};
-use std::{
-    str,
-    sync::{atomic, Arc},
-};
 
 impl<TPlat: Platform> Background<TPlat> {
     /// Handles a call to [`methods::MethodCall::author_pendingExtrinsics`].

--- a/bin/light-base/src/lib.rs
+++ b/bin/light-base/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! [`Client::add_chain`] returns a [`ChainId`], which identifies the chain within the [`Client`].
 //! A [`Client`] can be thought of as a collection of chain connections, each identified by their
-//! [`ClientId`]. If [`Chain`] was a `Vec`, then [`ChainId`] would be a `usize`.
+//! [`ChainId`]. If [`Client`] was a `Vec`, then [`ChainId`] would be a `usize`.
 //!
 //! A chain can be removed at any time using [`Client::remove_chain`]. This will cause the client
 //! to stop all connections and clean up its internal services. The [`ChainId`] is instantly

--- a/bin/light-base/src/lib.rs
+++ b/bin/light-base/src/lib.rs
@@ -67,7 +67,8 @@
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![recursion_limit = "512"]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![deny(unused_crate_dependencies)]
+// TODO: the `unused_crate_dependencies` lint is disabled because of dev-dependencies, see <https://github.com/rust-lang/rust/issues/95513>
+// #![deny(unused_crate_dependencies)]
 
 extern crate alloc;
 

--- a/bin/light-base/src/lib.rs
+++ b/bin/light-base/src/lib.rs
@@ -177,7 +177,7 @@ impl From<ChainId> for u32 {
 }
 
 /// Holds a list of chains, connections, and JSON-RPC services.
-pub struct Client<TChain, TPlat: platform::Platform> {
+pub struct Client<TPlat: platform::Platform, TChain = ()> {
     /// Tasks can be spawned by sending it on this channel. The first tuple element is the name
     /// of the task used for debugging purposes.
     new_task_tx: mpsc::UnboundedSender<(String, future::BoxFuture<'static, ()>)>,
@@ -290,7 +290,7 @@ impl<TPlat: platform::Platform> Clone for ChainServices<TPlat> {
     }
 }
 
-impl<TChain, TPlat: platform::Platform> Client<TChain, TPlat> {
+impl<TPlat: platform::Platform, TChain> Client<TPlat, TChain> {
     /// Initializes the smoldot client.
     pub fn new(config: ClientConfig) -> Self {
         let expected_chains = 8;

--- a/bin/light-base/src/lib.rs
+++ b/bin/light-base/src/lib.rs
@@ -56,6 +56,7 @@ pub struct ClientConfig {
     /// In order for the client to function, it needs to be able to spawn tasks in the background
     /// that will run indefinitely. To do so, it will send a task on this channel. The first tuple
     /// element is the name of the task, used for debugging purposes.
+    // TODO: don't expose channels from the `futures` library in the public API
     pub tasks_spawner: mpsc::UnboundedSender<(String, future::BoxFuture<'static, ()>)>,
 
     /// Value returned when a JSON-RPC client requests the name of the client. Reasonable value
@@ -102,6 +103,7 @@ pub struct AddChainConfig<'a, TChain, TRelays> {
     ///
     /// If `None`, then no JSON-RPC service is started for this chain. This saves up a lot of
     /// resources, but will cause all JSON-RPC requests targeting this chain to fail.
+    // TODO: don't expose channels from the `futures` library in the public API
     pub json_rpc_responses: Option<mpsc::Sender<String>>,
 }
 

--- a/bin/light-base/src/network_service.rs
+++ b/bin/light-base/src/network_service.rs
@@ -38,23 +38,26 @@
 
 use crate::platform::{Platform, PlatformConnection, PlatformSubstreamDirection};
 
-use core::{cmp, iter, num::NonZeroUsize, task::Poll, time::Duration};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString as _},
+    sync::Arc,
+    vec,
+    vec::Vec,
+};
+use core::{cmp, iter, num::NonZeroUsize, pin::Pin, task::Poll, time::Duration};
 use futures::{
     channel::{mpsc, oneshot},
     lock::Mutex,
     prelude::*,
 };
+use hashbrown::{hash_map, HashMap, HashSet};
 use itertools::Itertools as _;
 use smoldot::{
     header,
     informant::{BytesDisplay, HashDisplay},
     libp2p::{connection, multiaddr::Multiaddr, peer_id::PeerId, peers, read_write::ReadWrite},
     network::{protocol, service},
-};
-use std::{
-    collections::{hash_map, HashMap, HashSet},
-    pin::Pin,
-    sync::Arc,
 };
 
 pub use service::EncodedMerkleProof;

--- a/bin/light-base/src/network_service.rs
+++ b/bin/light-base/src/network_service.rs
@@ -36,7 +36,7 @@
 //! [`NetworkService::new`]. These channels inform the foreground about updates to the network
 //! connectivity.
 
-use crate::{Platform, PlatformConnection, PlatformSubstreamDirection};
+use crate::platform::{Platform, PlatformConnection, PlatformSubstreamDirection};
 
 use core::{cmp, iter, num::NonZeroUsize, task::Poll, time::Duration};
 use futures::{

--- a/bin/light-base/src/platform.rs
+++ b/bin/light-base/src/platform.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use alloc::string::String;
 use core::{ops, str, time::Duration};
 use futures::prelude::*;
 use smoldot::libp2p::peer_id::PeerId;

--- a/bin/light-base/src/platform.rs
+++ b/bin/light-base/src/platform.rs
@@ -20,6 +20,8 @@ use core::{ops, str, time::Duration};
 use futures::prelude::*;
 use smoldot::libp2p::peer_id::PeerId;
 
+pub mod async_std;
+
 /// Access to a platform's capabilities.
 pub trait Platform: Send + 'static {
     type Delay: Future<Output = ()> + Unpin + Send + 'static;
@@ -40,7 +42,7 @@ pub trait Platform: Send + 'static {
     /// the `Connection` and all its associated substream objects ([`Platform::Stream`]) have
     /// been dropped.
     type Connection: Send + Sync + 'static;
-    type Stream: Send + Sync + 'static;
+    type Stream: Send + 'static;
     type ConnectFuture: Future<Output = Result<PlatformConnection<Self::Stream, Self::Connection>, ConnectError>>
         + Unpin
         + Send

--- a/bin/light-base/src/platform.rs
+++ b/bin/light-base/src/platform.rs
@@ -1,0 +1,155 @@
+// Smoldot
+// Copyright (C) 2019-2022  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use core::{ops, str, time::Duration};
+use futures::prelude::*;
+use smoldot::libp2p::peer_id::PeerId;
+
+/// Access to a platform's capabilities.
+pub trait Platform: Send + 'static {
+    type Delay: Future<Output = ()> + Unpin + Send + 'static;
+    type Instant: Clone
+        + ops::Add<Duration, Output = Self::Instant>
+        + ops::Sub<Self::Instant, Output = Duration>
+        + PartialOrd
+        + Ord
+        + PartialEq
+        + Eq
+        + Send
+        + Sync
+        + 'static;
+
+    /// A multi-stream connection.
+    ///
+    /// This object is merely a handle. The underlying connection should be dropped only after
+    /// the `Connection` and all its associated substream objects ([`Platform::Stream`]) have
+    /// been dropped.
+    type Connection: Send + Sync + 'static;
+    type Stream: Send + Sync + 'static;
+    type ConnectFuture: Future<Output = Result<PlatformConnection<Self::Stream, Self::Connection>, ConnectError>>
+        + Unpin
+        + Send
+        + 'static;
+    type StreamDataFuture: Future<Output = ()> + Unpin + Send + 'static;
+    type NextSubstreamFuture: Future<Output = Option<(Self::Stream, PlatformSubstreamDirection)>>
+        + Unpin
+        + Send
+        + 'static;
+
+    /// Returns the time elapsed since [the Unix Epoch](https://en.wikipedia.org/wiki/Unix_time)
+    /// (i.e. 00:00:00 UTC on 1 January 1970), ignoring leap seconds.
+    ///
+    /// # Panic
+    ///
+    /// Panics if the system time is configured to be below the UNIX epoch. This situation is a
+    /// very very niche edge case that isn't worth handling.
+    ///
+    fn now_from_unix_epoch() -> Duration;
+
+    /// Returns an object that represents "now".
+    fn now() -> Self::Instant;
+
+    /// Creates a future that becomes ready after at least the given duration has elapsed.
+    fn sleep(duration: Duration) -> Self::Delay;
+
+    /// Creates a future that becomes ready after the given instant has been reached.
+    fn sleep_until(when: Self::Instant) -> Self::Delay;
+
+    /// Starts a connection attempt to the given multiaddress.
+    ///
+    /// The multiaddress is passed as a string. If the string can't be parsed, an error should be
+    /// returned where [`ConnectError::is_bad_addr`] is `true`.
+    fn connect(url: &str) -> Self::ConnectFuture;
+
+    /// Queues the opening of an additional outbound substream.
+    ///
+    /// The substream, once opened, must be yielded by [`Platform::next_substream`].
+    fn open_out_substream(connection: &mut Self::Connection);
+
+    /// Waits until a new incoming substream arrives on the connection.
+    ///
+    /// This returns both inbound and outbound substreams. Outbound substreams should only be
+    /// yielded once for every call to [`Platform::open_out_substream`].
+    ///
+    /// The future can also return `None` if the connection has been killed by the remote. If
+    /// the future returns `None`, the user of the `Platform` should drop the `Connection` and
+    /// all its associated `Stream`s as soon as possible.
+    fn next_substream(connection: &mut Self::Connection) -> Self::NextSubstreamFuture;
+
+    /// Returns a future that becomes ready when either the read buffer of the given stream
+    /// contains data, or the remote has closed their sending side.
+    ///
+    /// The future is immediately ready if data is already available or the remote has already
+    /// closed their sending side.
+    ///
+    /// This function can be called multiple times with the same stream, in which case all
+    /// the futures must be notified. The user of this function, however, is encouraged to
+    /// maintain only one active future.
+    ///
+    /// If the future is polled after the stream object has been dropped, the behavior is
+    /// not specified. The polling might panic, or return `Ready`, or return `Pending`.
+    fn wait_more_data(stream: &mut Self::Stream) -> Self::StreamDataFuture;
+
+    /// Gives access to the content of the read buffer of the given stream.
+    ///
+    /// Returns `None` if the remote has closed their sending side or if the stream has been
+    /// reset.
+    fn read_buffer(stream: &mut Self::Stream) -> Option<&[u8]>;
+
+    /// Discards the first `bytes` bytes of the read buffer of this stream. This makes it
+    /// possible for the remote to send more data.
+    ///
+    /// # Panic
+    ///
+    /// Panics if there aren't enough bytes to discard in the buffer.
+    ///
+    fn advance_read_cursor(stream: &mut Self::Stream, bytes: usize);
+
+    /// Queues the given bytes to be sent out on the given connection.
+    // TODO: back-pressure
+    // TODO: allow closing sending side
+    fn send(stream: &mut Self::Stream, data: &[u8]);
+}
+
+/// Type of opened connection. See [`Platform::connect`].
+#[derive(Debug)]
+pub enum PlatformConnection<TStream, TConnection> {
+    /// The connection is a single stream on top of which encryption and multiplexing should be
+    /// negotiated. The division in multiple substreams is handled internally.
+    SingleStream(TStream),
+    /// The connection is made of multiple substreams. The encryption and multiplexing are handled
+    /// externally.
+    MultiStream(TConnection, PeerId),
+}
+
+/// Direction in which a substream has been opened. See [`Platform::next_substream`].
+#[derive(Debug)]
+pub enum PlatformSubstreamDirection {
+    /// Substream has been opened by the remote.
+    Inbound,
+    /// Substream has been opened locally in response to [`Platform::open_out_substream`].
+    Outbound,
+}
+
+/// Error potentially returned by [`Platform::connect`].
+pub struct ConnectError {
+    /// Human-readable error message.
+    pub message: String,
+
+    /// `true` if the error is caused by the address to connect to being forbidden or unsupported.
+    pub is_bad_addr: bool,
+}

--- a/bin/light-base/src/platform/async_std.rs
+++ b/bin/light-base/src/platform/async_std.rs
@@ -1,0 +1,314 @@
+// Smoldot
+// Copyright (C) 2019-2022  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg(feature = "std")]
+#![cfg_attr(docsrs, doc(cfg(feature = "std")))]
+
+use super::{ConnectError, Platform, PlatformConnection, PlatformSubstreamDirection};
+
+use alloc::{collections::VecDeque, sync::Arc};
+use core::{pin::Pin, str, task::Poll, time::Duration};
+use futures::{channel::mpsc, prelude::*};
+use smoldot::libp2p::{
+    multiaddr::{Multiaddr, ProtocolRef},
+    websocket,
+};
+use std::{
+    io::IoSlice,
+    net::{IpAddr, SocketAddr},
+};
+
+/// Implementation of the [`Platform`] trait that uses the `async-std` library and provides TCP
+/// and WebSocket connections.
+pub struct AsyncStdTcpWebSocket;
+
+impl Platform for AsyncStdTcpWebSocket {
+    type Delay = future::BoxFuture<'static, ()>;
+    type Instant = std::time::Instant;
+    type Connection = std::convert::Infallible;
+    type Stream = Stream;
+    type ConnectFuture = future::BoxFuture<
+        'static,
+        Result<PlatformConnection<Self::Stream, Self::Connection>, ConnectError>,
+    >;
+    type StreamDataFuture = future::BoxFuture<'static, ()>;
+    type NextSubstreamFuture = future::Pending<Option<(Self::Stream, PlatformSubstreamDirection)>>;
+
+    fn now_from_unix_epoch() -> Duration {
+        // Intentionally panic if the time is configured earlier than the UNIX EPOCH.
+        std::time::UNIX_EPOCH.elapsed().unwrap()
+    }
+
+    fn now() -> Self::Instant {
+        std::time::Instant::now()
+    }
+
+    fn sleep(duration: Duration) -> Self::Delay {
+        async_std::task::sleep(duration).boxed()
+    }
+
+    fn sleep_until(when: Self::Instant) -> Self::Delay {
+        let duration = when.saturating_duration_since(std::time::Instant::now());
+        Self::sleep(duration)
+    }
+
+    fn connect(multiaddr: &str) -> Self::ConnectFuture {
+        // We simply copy the address to own it. We could be more zero-cost here, but doing so
+        // would considerably complicate the implementation.
+        let multiaddr = multiaddr.to_owned();
+
+        Box::pin(async move {
+            let addr = multiaddr.parse::<Multiaddr>().map_err(|_| ConnectError {
+                is_bad_addr: true,
+                message: format!("Failed to parse address"),
+            })?;
+
+            let mut iter = addr.iter().fuse();
+            let proto1 = iter.next().ok_or(ConnectError {
+                is_bad_addr: true,
+                message: format!("Unknown protocols combination"),
+            })?;
+            let proto2 = iter.next().ok_or(ConnectError {
+                is_bad_addr: true,
+                message: format!("Unknown protocols combination"),
+            })?;
+            let proto3 = iter.next();
+
+            if iter.next().is_some() {
+                return Err(ConnectError {
+                    is_bad_addr: true,
+                    message: format!("Unknown protocols combination"),
+                });
+            }
+
+            // TODO: doesn't support WebSocket secure connections
+
+            // Ensure ahead of time that the multiaddress is supported.
+            let (addr, is_websocket) = match (&proto1, &proto2, &proto3) {
+                (ProtocolRef::Ip4(ip), ProtocolRef::Tcp(port), None) => (
+                    either::Left(SocketAddr::new(IpAddr::V4((*ip).into()), *port)),
+                    false,
+                ),
+                (ProtocolRef::Ip6(ip), ProtocolRef::Tcp(port), None) => (
+                    either::Left(SocketAddr::new(IpAddr::V6((*ip).into()), *port)),
+                    false,
+                ),
+                (ProtocolRef::Ip4(ip), ProtocolRef::Tcp(port), Some(ProtocolRef::Ws)) => (
+                    either::Left(SocketAddr::new(IpAddr::V4((*ip).into()), *port)),
+                    true,
+                ),
+                (ProtocolRef::Ip6(ip), ProtocolRef::Tcp(port), Some(ProtocolRef::Ws)) => (
+                    either::Left(SocketAddr::new(IpAddr::V6((*ip).into()), *port)),
+                    true,
+                ),
+
+                // TODO: we don't care about the differences between Dns, Dns4, and Dns6
+                (
+                    ProtocolRef::Dns(addr) | ProtocolRef::Dns4(addr) | ProtocolRef::Dns6(addr),
+                    ProtocolRef::Tcp(port),
+                    None,
+                ) => (either::Right((addr.to_string(), *port)), false),
+                (
+                    ProtocolRef::Dns(addr) | ProtocolRef::Dns4(addr) | ProtocolRef::Dns6(addr),
+                    ProtocolRef::Tcp(port),
+                    Some(ProtocolRef::Ws),
+                ) => (either::Right((addr.to_string(), *port)), true),
+
+                _ => {
+                    return Err(ConnectError {
+                        is_bad_addr: true,
+                        message: format!("Unknown protocols combination"),
+                    })
+                }
+            };
+
+            let tcp_socket = match addr {
+                either::Left(socket_addr) => async_std::net::TcpStream::connect(socket_addr).await,
+                either::Right((dns, port)) => {
+                    async_std::net::TcpStream::connect((&dns[..], port)).await
+                }
+            };
+
+            if let Ok(tcp_socket) = &tcp_socket {
+                let _ = tcp_socket.set_nodelay(true);
+            }
+
+            let mut socket = match (tcp_socket, is_websocket) {
+                (Ok(tcp_socket), true) => future::Either::Right(
+                    websocket::websocket_client_handshake(tcp_socket)
+                        .await
+                        .map_err(|err| ConnectError {
+                            message: format!("Failed to negotiate WebSocket: {}", err),
+                            is_bad_addr: false,
+                        })?,
+                ),
+                (Ok(tcp_socket), false) => future::Either::Left(tcp_socket),
+                (Err(err), _) => {
+                    return Err(ConnectError {
+                        is_bad_addr: false,
+                        message: format!("Failed to reach peer: {}", err),
+                    })
+                }
+            };
+
+            let shared = Arc::new(StreamShared {
+                guarded: parking_lot::Mutex::new(StreamSharedGuarded {
+                    write_queue: VecDeque::with_capacity(1024),
+                }),
+                write_queue_pushed: event_listener::Event::new(),
+            });
+            let shared_clone = shared.clone();
+
+            let (mut read_data_tx, read_data_rx) = mpsc::channel(2);
+            let mut read_buffer = vec![0; 4096];
+            let mut write_queue_pushed_listener = shared.write_queue_pushed.listen();
+
+            // TODO: this whole code is a mess, but the Platform trait must be modified to fix it
+            // TODO: spawning a task per connection is necessary because the Platform trait isn't suitable for better strategies
+            async_std::task::spawn(future::poll_fn(move |cx| {
+                let mut lock = shared.guarded.lock();
+
+                match Pin::new(&mut read_data_tx).poll_ready(cx) {
+                    Poll::Ready(Ok(())) => {
+                        if let Poll::Ready(result) =
+                            Pin::new(&mut socket).poll_read(cx, &mut read_buffer)
+                        {
+                            match result {
+                                Ok(0) | Err(_) => return Poll::Ready(()), // End the task
+                                Ok(bytes) => {
+                                    let _ = read_data_tx.try_send(read_buffer[..bytes].to_vec());
+                                }
+                            }
+                        }
+                    }
+                    Poll::Ready(Err(_)) => return Poll::Ready(()), // End the task
+                    Poll::Pending => {}
+                }
+
+                if lock.write_queue.is_empty() {
+                    if let Poll::Ready(Err(_)) = Pin::new(&mut socket).poll_flush(cx) {
+                        // End the task
+                        return Poll::Ready(());
+                    }
+                } else {
+                    let write_queue_slices = lock.write_queue.as_slices();
+                    if let Poll::Ready(result) = Pin::new(&mut socket).poll_write_vectored(
+                        cx,
+                        &[
+                            IoSlice::new(write_queue_slices.0),
+                            IoSlice::new(write_queue_slices.1),
+                        ],
+                    ) {
+                        match result {
+                            Ok(bytes) => {
+                                for _ in 0..bytes {
+                                    lock.write_queue.pop_front();
+                                }
+                            }
+                            Err(_) => return Poll::Ready(()), // End the task
+                        }
+                    }
+                }
+
+                if let Poll::Ready(()) = Pin::new(&mut write_queue_pushed_listener).poll(cx) {
+                    write_queue_pushed_listener = shared.write_queue_pushed.listen();
+                }
+
+                Poll::Pending
+            }));
+
+            Ok(PlatformConnection::SingleStream(Stream {
+                shared: shared_clone,
+                read_data_rx: Arc::new(parking_lot::Mutex::new(read_data_rx.peekable())),
+                read_buffer: Some(Vec::with_capacity(4096)),
+            }))
+        })
+    }
+
+    fn open_out_substream(_: &mut Self::Connection) {
+        // This function can only be called with so-called "multi-stream" connections. We never
+        // open such connection.
+        unreachable!()
+    }
+
+    fn next_substream(_: &mut Self::Connection) -> Self::NextSubstreamFuture {
+        // This function can only be called with so-called "multi-stream" connections. We never
+        // open such connection.
+        unreachable!()
+    }
+
+    fn wait_more_data(stream: &mut Self::Stream) -> Self::StreamDataFuture {
+        if stream.read_buffer.as_ref().map_or(true, |b| !b.is_empty()) {
+            return Box::pin(future::ready(()));
+        }
+
+        let read_data_rx = stream.read_data_rx.clone();
+        Box::pin(future::poll_fn(move |cx| {
+            let mut lock = read_data_rx.lock();
+            Pin::new(&mut *lock).poll_peek(cx).map(|_| ())
+        }))
+    }
+
+    fn read_buffer(stream: &mut Self::Stream) -> Option<&[u8]> {
+        if stream.read_buffer.is_none() {
+            return None;
+        }
+
+        let mut lock = stream.read_data_rx.lock();
+        while let Some(buf) = lock.next().now_or_never() {
+            match buf {
+                Some(b) => stream.read_buffer.as_mut().unwrap().extend(b),
+                None => {
+                    stream.read_buffer = None;
+                    return None;
+                }
+            }
+        }
+
+        Some(stream.read_buffer.as_ref().unwrap())
+    }
+
+    fn advance_read_cursor(stream: &mut Self::Stream, bytes: usize) {
+        if let Some(read_buffer) = &mut stream.read_buffer {
+            // TODO: meh for copying
+            *read_buffer = read_buffer[bytes..].to_vec();
+        }
+    }
+
+    fn send(stream: &mut Self::Stream, data: &[u8]) {
+        let mut lock = stream.shared.guarded.lock();
+        lock.write_queue.reserve(data.len());
+        lock.write_queue.extend(data.iter().copied());
+        stream.shared.write_queue_pushed.notify(usize::max_value());
+    }
+}
+
+/// Implementation detail of [`AsyncStdTcpWebSocket`].
+pub struct Stream {
+    shared: Arc<StreamShared>,
+    read_data_rx: Arc<parking_lot::Mutex<stream::Peekable<mpsc::Receiver<Vec<u8>>>>>,
+    read_buffer: Option<Vec<u8>>,
+}
+
+struct StreamShared {
+    guarded: parking_lot::Mutex<StreamSharedGuarded>,
+    write_queue_pushed: event_listener::Event,
+}
+
+struct StreamSharedGuarded {
+    write_queue: VecDeque<u8>,
+}

--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -56,6 +56,21 @@
 
 use crate::{network_service, platform::Platform, sync_service};
 
+use alloc::{
+    boxed::Box,
+    collections::BTreeMap,
+    format,
+    string::{String, ToString as _},
+    sync::{Arc, Weak},
+    vec,
+    vec::Vec,
+};
+use core::{
+    iter, mem,
+    num::{NonZeroU32, NonZeroUsize},
+    pin::Pin,
+    time::Duration,
+};
 use futures::{
     channel::mpsc,
     lock::{Mutex, MutexGuard},
@@ -68,14 +83,6 @@ use smoldot::{
     informant::{BytesDisplay, HashDisplay},
     network::protocol,
     trie::{self, proof_verify},
-};
-use std::{
-    collections::BTreeMap,
-    iter, mem,
-    num::{NonZeroU32, NonZeroUsize},
-    pin::Pin,
-    sync::{Arc, Weak},
-    time::Duration,
 };
 
 /// Configuration for a runtime service.

--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -54,7 +54,7 @@
 //! large, the subscription is force-killed by the [`RuntimeService`].
 //!
 
-use crate::{network_service, sync_service, Platform};
+use crate::{network_service, platform::Platform, sync_service};
 
 use futures::{
     channel::mpsc,

--- a/bin/light-base/src/sync_service.rs
+++ b/bin/light-base/src/sync_service.rs
@@ -26,7 +26,7 @@
 //!
 //! Use [`SyncService::subscribe_all`] to get notified about updates to the state of the chain.
 
-use crate::{network_service, runtime_service, Platform};
+use crate::{network_service, platform::Platform, runtime_service};
 
 use futures::{
     channel::{mpsc, oneshot},

--- a/bin/light-base/src/sync_service.rs
+++ b/bin/light-base/src/sync_service.rs
@@ -28,6 +28,8 @@
 
 use crate::{network_service, platform::Platform, runtime_service};
 
+use alloc::{borrow::ToOwned as _, boxed::Box, format, string::String, sync::Arc, vec::Vec};
+use core::{fmt, num::NonZeroU32, time::Duration};
 use futures::{
     channel::{mpsc, oneshot},
     lock::Mutex,
@@ -40,7 +42,6 @@ use smoldot::{
     network::{protocol, service},
     trie::{self, prefix_proof, proof_verify},
 };
-use std::{fmt, num::NonZeroU32, sync::Arc, time::Duration};
 
 mod parachain;
 mod standalone;

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::ToBackground;
-use crate::{network_service, runtime_service, Platform};
+use crate::{network_service, platform::Platform, runtime_service};
 
 use futures::{channel::mpsc, prelude::*};
 use itertools::Itertools as _;

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -18,7 +18,14 @@
 use super::ToBackground;
 use crate::{network_service, platform::Platform, runtime_service};
 
+use alloc::{borrow::ToOwned as _, string::String, sync::Arc, vec::Vec};
+use core::{
+    iter,
+    num::{NonZeroU32, NonZeroUsize},
+    time::Duration,
+};
 use futures::{channel::mpsc, prelude::*};
+use hashbrown::HashMap;
 use itertools::Itertools as _;
 use smoldot::{
     chain::{self, async_tree},
@@ -28,13 +35,6 @@ use smoldot::{
     libp2p::PeerId,
     network::protocol,
     sync::{all_forks::sources, para},
-};
-use std::{
-    collections::HashMap,
-    iter,
-    num::{NonZeroU32, NonZeroUsize},
-    sync::Arc,
-    time::Duration,
 };
 
 /// Starts a sync service background task to synchronize a parachain.
@@ -69,7 +69,8 @@ pub(super) async fn start_parachain<TPlat: Platform>(
             .number,
     );
     // Maps `PeerId`s to their indices within `sync_sources`.
-    let mut sync_sources_map = HashMap::new();
+    // TODO: use SipHasher
+    let mut sync_sources_map = HashMap::with_capacity_and_hasher(0, fnv::FnvBuildHasher::default());
 
     // This function contains two loops within each other. If the relay chain syncing service has
     // a gap in its blocks, or if the node is overloaded and can't process blocks in time, then

--- a/bin/light-base/src/sync_service/standalone.rs
+++ b/bin/light-base/src/sync_service/standalone.rs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::{BlockNotification, FinalizedBlockRuntime, Notification, SubscribeAll, ToBackground};
-use crate::{network_service, Platform};
+use crate::{network_service, platform::Platform};
 
 use futures::{channel::mpsc, prelude::*};
 use smoldot::{

--- a/bin/light-base/src/transactions_service.rs
+++ b/bin/light-base/src/transactions_service.rs
@@ -67,7 +67,7 @@
 //! transaction.
 //!
 
-use crate::{network_service, runtime_service, sync_service, Platform};
+use crate::{network_service, platform::Platform, runtime_service, sync_service};
 
 use futures::{channel::mpsc, lock::Mutex, prelude::*, stream::FuturesUnordered};
 use itertools::Itertools as _;

--- a/bin/light-base/src/transactions_service.rs
+++ b/bin/light-base/src/transactions_service.rs
@@ -69,6 +69,20 @@
 
 use crate::{network_service, platform::Platform, runtime_service, sync_service};
 
+use alloc::{
+    borrow::ToOwned as _,
+    boxed::Box,
+    format,
+    string::{String, ToString as _},
+    sync::Arc,
+    vec::Vec,
+};
+use core::{
+    cmp, iter,
+    marker::PhantomData,
+    num::{NonZeroU32, NonZeroUsize},
+    time::Duration,
+};
 use futures::{channel::mpsc, lock::Mutex, prelude::*, stream::FuturesUnordered};
 use itertools::Itertools as _;
 use smoldot::{
@@ -77,13 +91,6 @@ use smoldot::{
     libp2p::peer_id::PeerId,
     network::protocol,
     transactions::{light_pool, validate},
-};
-use std::{
-    cmp, iter,
-    marker::PhantomData,
-    num::{NonZeroU32, NonZeroUsize},
-    sync::Arc,
-    time::Duration,
 };
 
 /// Configuration for a [`TransactionsService`].

--- a/bin/wasm-node/rust/Cargo.toml
+++ b/bin/wasm-node/rust/Cargo.toml
@@ -22,4 +22,4 @@ pin-project = "1.0.12"
 rand = "0.8.5"
 slab = { version = "0.4.7", default-features = false }
 smoldot = { version = "0.2.0", path = "../../..", default-features = false }
-smoldot-light-base = { version = "0.1.0", path = "../../light-base" }
+smoldot-light = { version = "0.1.0", path = "../../light-base" }

--- a/bin/wasm-node/rust/Cargo.toml
+++ b/bin/wasm-node/rust/Cargo.toml
@@ -22,4 +22,4 @@ pin-project = "1.0.12"
 rand = "0.8.5"
 slab = { version = "0.4.7", default-features = false }
 smoldot = { version = "0.2.0", path = "../../..", default-features = false }
-smoldot-light = { version = "0.1.0", path = "../../light-base" }
+smoldot-light = { version = "0.1.0", path = "../../light-base", default-features = false }

--- a/bin/wasm-node/rust/src/init.rs
+++ b/bin/wasm-node/rust/src/init.rs
@@ -34,13 +34,13 @@ use std::{
     task,
 };
 
-pub(crate) struct Client<TChain, TPlat: smoldot_light_base::Platform> {
-    pub(crate) smoldot: smoldot_light_base::Client<TChain, TPlat>,
+pub(crate) struct Client<TChain, TPlat: smoldot_light::Platform> {
+    pub(crate) smoldot: smoldot_light::Client<TChain, TPlat>,
 
     pub(crate) new_tasks_spawner: mpsc::UnboundedSender<(String, future::BoxFuture<'static, ()>)>,
 }
 
-pub(crate) fn init<TChain, TPlat: smoldot_light_base::Platform>(
+pub(crate) fn init<TChain, TPlat: smoldot_light::Platform>(
     max_log_level: u32,
     enable_current_task: bool,
     cpu_rate_limit: u32,
@@ -172,7 +172,7 @@ pub(crate) fn init<TChain, TPlat: smoldot_light_base::Platform>(
         ))
         .unwrap();
 
-    let client = smoldot_light_base::Client::new(
+    let client = smoldot_light::Client::new(
         new_task_tx.clone(),
         env!("CARGO_PKG_NAME"),
         env!("CARGO_PKG_VERSION"),

--- a/bin/wasm-node/rust/src/init.rs
+++ b/bin/wasm-node/rust/src/init.rs
@@ -34,13 +34,13 @@ use std::{
     task,
 };
 
-pub(crate) struct Client<TChain, TPlat: smoldot_light::Platform> {
+pub(crate) struct Client<TChain, TPlat: smoldot_light::platform::Platform> {
     pub(crate) smoldot: smoldot_light::Client<TChain, TPlat>,
 
     pub(crate) new_tasks_spawner: mpsc::UnboundedSender<(String, future::BoxFuture<'static, ()>)>,
 }
 
-pub(crate) fn init<TChain, TPlat: smoldot_light::Platform>(
+pub(crate) fn init<TChain, TPlat: smoldot_light::platform::Platform>(
     max_log_level: u32,
     enable_current_task: bool,
     cpu_rate_limit: u32,

--- a/bin/wasm-node/rust/src/init.rs
+++ b/bin/wasm-node/rust/src/init.rs
@@ -34,17 +34,17 @@ use std::{
     task,
 };
 
-pub(crate) struct Client<TChain, TPlat: smoldot_light::platform::Platform> {
-    pub(crate) smoldot: smoldot_light::Client<TChain, TPlat>,
+pub(crate) struct Client<TPlat: smoldot_light::platform::Platform, TChain> {
+    pub(crate) smoldot: smoldot_light::Client<TPlat, TChain>,
 
     pub(crate) new_tasks_spawner: mpsc::UnboundedSender<(String, future::BoxFuture<'static, ()>)>,
 }
 
-pub(crate) fn init<TChain, TPlat: smoldot_light::platform::Platform>(
+pub(crate) fn init<TPlat: smoldot_light::platform::Platform, TChain>(
     max_log_level: u32,
     enable_current_task: bool,
     cpu_rate_limit: u32,
-) -> Client<TChain, TPlat> {
+) -> Client<TPlat, TChain> {
     // Try initialize the logging and the panic hook.
     let _ = log::set_boxed_logger(Box::new(Logger)).map(|()| {
         log::set_max_level(match max_log_level {

--- a/bin/wasm-node/rust/src/init.rs
+++ b/bin/wasm-node/rust/src/init.rs
@@ -172,11 +172,11 @@ pub(crate) fn init<TChain, TPlat: smoldot_light::platform::Platform>(
         ))
         .unwrap();
 
-    let client = smoldot_light::Client::new(
-        new_task_tx.clone(),
-        env!("CARGO_PKG_NAME"),
-        env!("CARGO_PKG_VERSION"),
-    );
+    let client = smoldot_light::Client::new(smoldot_light::ClientConfig {
+        tasks_spawner: new_task_tx.clone(),
+        system_name: env!("CARGO_PKG_NAME").into(),
+        system_version: env!("CARGO_PKG_VERSION").into(),
+    });
 
     Client {
         smoldot: client,

--- a/bin/wasm-node/rust/src/lib.rs
+++ b/bin/wasm-node/rust/src/lib.rs
@@ -194,7 +194,7 @@ fn add_chain(
         raw_data
             .chunks(4)
             .map(|c| u32::from_le_bytes(<[u8; 4]>::try_from(c).unwrap()))
-            .map(smoldot_light_base::ChainId::from)
+            .map(smoldot_light::ChainId::from)
             .collect()
     };
 
@@ -218,18 +218,17 @@ fn add_chain(
     };
 
     // Insert the chain in the client.
-    let chain_id =
-        client_lock
-            .as_mut()
-            .unwrap()
-            .smoldot
-            .add_chain(smoldot_light_base::AddChainConfig {
-                user_data: abort_handle.into_iter().collect(),
-                specification: str::from_utf8(&chain_spec).unwrap(),
-                database_content: str::from_utf8(&database_content).unwrap(),
-                json_rpc_responses,
-                potential_relay_chains: potential_relay_chains.into_iter(),
-            });
+    let chain_id = client_lock
+        .as_mut()
+        .unwrap()
+        .smoldot
+        .add_chain(smoldot_light::AddChainConfig {
+            user_data: abort_handle.into_iter().collect(),
+            specification: str::from_utf8(&chain_spec).unwrap(),
+            database_content: str::from_utf8(&database_content).unwrap(),
+            json_rpc_responses,
+            potential_relay_chains: potential_relay_chains.into_iter(),
+        });
 
     // Spawn the task if necessary.
     // See explanations above.
@@ -263,7 +262,7 @@ fn remove_chain(chain_id: u32) {
         .as_mut()
         .unwrap()
         .smoldot
-        .remove_chain(smoldot_light_base::ChainId::from(chain_id));
+        .remove_chain(smoldot_light::ChainId::from(chain_id));
 
     // Abort the tasks that retrieve the database content or poll the channel and send out the
     // JSON-RPC responses. This prevents any database callback from being called, and any new
@@ -283,7 +282,7 @@ fn chain_is_ok(chain_id: u32) -> u32 {
         .as_mut()
         .unwrap()
         .smoldot
-        .chain_is_erroneous(smoldot_light_base::ChainId::from(chain_id))
+        .chain_is_erroneous(smoldot_light::ChainId::from(chain_id))
         .is_some()
     {
         0
@@ -298,7 +297,7 @@ fn chain_error_len(chain_id: u32) -> u32 {
         .as_mut()
         .unwrap()
         .smoldot
-        .chain_is_erroneous(smoldot_light_base::ChainId::from(chain_id))
+        .chain_is_erroneous(smoldot_light::ChainId::from(chain_id))
         .map(|msg| msg.as_bytes().len())
         .unwrap_or(0);
     u32::try_from(len).unwrap()
@@ -310,14 +309,14 @@ fn chain_error_ptr(chain_id: u32) -> u32 {
         .as_mut()
         .unwrap()
         .smoldot
-        .chain_is_erroneous(smoldot_light_base::ChainId::from(chain_id))
+        .chain_is_erroneous(smoldot_light::ChainId::from(chain_id))
         .map(|msg| msg.as_bytes().as_ptr() as usize)
         .unwrap_or(0);
     u32::try_from(ptr).unwrap()
 }
 
 fn json_rpc_send(ptr: u32, len: u32, chain_id: u32) {
-    let chain_id = smoldot_light_base::ChainId::from(chain_id);
+    let chain_id = smoldot_light::ChainId::from(chain_id);
 
     let json_rpc_request: Box<[u8]> = {
         let ptr = usize::try_from(ptr).unwrap();
@@ -343,7 +342,7 @@ fn json_rpc_send(ptr: u32, len: u32, chain_id: u32) {
 }
 
 fn database_content(chain_id: u32, max_size: u32) {
-    let client_chain_id = smoldot_light_base::ChainId::from(chain_id);
+    let client_chain_id = smoldot_light::ChainId::from(chain_id);
 
     let mut client_lock = CLIENT.lock().unwrap();
     let init::Client {
@@ -381,7 +380,7 @@ fn database_content(chain_id: u32, max_size: u32) {
         .unwrap();
 }
 
-fn emit_json_rpc_response(rpc: &str, chain_id: smoldot_light_base::ChainId) {
+fn emit_json_rpc_response(rpc: &str, chain_id: smoldot_light::ChainId) {
     unsafe {
         bindings::json_rpc_respond(
             u32::try_from(rpc.as_bytes().as_ptr() as usize).unwrap(),

--- a/bin/wasm-node/rust/src/lib.rs
+++ b/bin/wasm-node/rust/src/lib.rs
@@ -114,7 +114,7 @@ impl Sub<Instant> for Instant {
 }
 
 lazy_static::lazy_static! {
-    static ref CLIENT: Mutex<Option<init::Client<Vec<future::AbortHandle>, platform::Platform>>> = Mutex::new(None);
+    static ref CLIENT: Mutex<Option<init::Client<platform::Platform, Vec<future::AbortHandle>>>> = Mutex::new(None);
 }
 
 fn init(max_log_level: u32, enable_current_task: u32, cpu_rate_limit: u32) {

--- a/bin/wasm-node/rust/src/platform.rs
+++ b/bin/wasm-node/rust/src/platform.rs
@@ -17,7 +17,7 @@
 
 use crate::{bindings, timers::Delay};
 
-use smoldot_light_base::{ConnectError, PlatformSubstreamDirection};
+use smoldot_light::{ConnectError, PlatformSubstreamDirection};
 
 use core::{cmp, mem, slice, str, time::Duration};
 use futures::prelude::*;
@@ -38,22 +38,19 @@ pub static TOTAL_BYTES_SENT: AtomicUsize = AtomicUsize::new(0);
 
 pub(crate) struct Platform;
 
-impl smoldot_light_base::Platform for Platform {
+impl smoldot_light::Platform for Platform {
     type Delay = Delay;
     type Instant = crate::Instant;
     type Connection = ConnectionWrapper; // Entry in the ̀`CONNECTIONS` map.
     type Stream = StreamWrapper; // Entry in the ̀`STREAMS` map and a read buffer.
     type ConnectFuture = future::BoxFuture<
         'static,
-        Result<
-            smoldot_light_base::PlatformConnection<Self::Stream, Self::Connection>,
-            ConnectError,
-        >,
+        Result<smoldot_light::PlatformConnection<Self::Stream, Self::Connection>, ConnectError>,
     >;
     type StreamDataFuture = future::BoxFuture<'static, ()>;
     type NextSubstreamFuture = future::BoxFuture<
         'static,
-        Option<(Self::Stream, smoldot_light_base::PlatformSubstreamDirection)>,
+        Option<(Self::Stream, smoldot_light::PlatformSubstreamDirection)>,
     >;
 
     fn now_from_unix_epoch() -> Duration {
@@ -146,7 +143,7 @@ impl smoldot_light_base::Platform for Platform {
                         buffer_first_offset: 0,
                     };
 
-                    Ok(smoldot_light_base::PlatformConnection::SingleStream(
+                    Ok(smoldot_light::PlatformConnection::SingleStream(
                         StreamWrapper((connection_id, 0), read_buffer),
                     ))
                 }
@@ -156,7 +153,7 @@ impl smoldot_light_base::Platform for Platform {
                     ..
                 } => {
                     *connection_handles_alive += 1;
-                    Ok(smoldot_light_base::PlatformConnection::MultiStream(
+                    Ok(smoldot_light::PlatformConnection::MultiStream(
                         ConnectionWrapper(connection_id),
                         peer_id.clone(),
                     ))
@@ -458,9 +455,9 @@ enum ConnectionInner {
     SingleStream,
     MultiStream {
         /// Peer id we're connected to.
-        peer_id: smoldot_light_base::PeerId,
+        peer_id: smoldot_light::PeerId,
         /// List of substreams that the host (i.e. JavaScript side) has reported have been opened,
-        /// but that haven't been reported through [`smoldot_light_base::Platform::next_substream`]
+        /// but that haven't been reported through [`smoldot_light::Platform::next_substream`]
         /// yet.
         opened_substreams_to_pick_up: VecDeque<(u32, PlatformSubstreamDirection)>,
         /// Number of objects (connections and streams) in the [`Platform`] API that reference
@@ -529,7 +526,7 @@ pub(crate) fn connection_open_multi_stream(connection_id: u32, peer_id_ptr: u32,
                 peer_id_len,
             ))
         };
-        smoldot_light_base::PeerId::from_bytes(bytes.into()).unwrap()
+        smoldot_light::PeerId::from_bytes(bytes.into()).unwrap()
     };
 
     let mut lock = STATE.try_lock().unwrap();

--- a/bin/wasm-node/rust/src/platform.rs
+++ b/bin/wasm-node/rust/src/platform.rs
@@ -463,8 +463,8 @@ enum ConnectionInner {
         /// Peer id we're connected to.
         peer_id: smoldot_light::PeerId,
         /// List of substreams that the host (i.e. JavaScript side) has reported have been opened,
-        /// but that haven't been reported through [`smoldot_light::Platform::next_substream`]
-        /// yet.
+        /// but that haven't been reported through
+        /// [`smoldot_light::platform::Platform::next_substream`] yet.
         opened_substreams_to_pick_up: VecDeque<(u32, PlatformSubstreamDirection)>,
         /// Number of objects (connections and streams) in the [`Platform`] API that reference
         /// this connection. If it switches from 1 to 0, the connection must be removed.

--- a/bin/wasm-node/rust/src/platform.rs
+++ b/bin/wasm-node/rust/src/platform.rs
@@ -17,7 +17,7 @@
 
 use crate::{bindings, timers::Delay};
 
-use smoldot_light::{ConnectError, PlatformSubstreamDirection};
+use smoldot_light::platform::{ConnectError, PlatformSubstreamDirection};
 
 use core::{cmp, mem, slice, str, time::Duration};
 use futures::prelude::*;
@@ -38,19 +38,25 @@ pub static TOTAL_BYTES_SENT: AtomicUsize = AtomicUsize::new(0);
 
 pub(crate) struct Platform;
 
-impl smoldot_light::Platform for Platform {
+impl smoldot_light::platform::Platform for Platform {
     type Delay = Delay;
     type Instant = crate::Instant;
     type Connection = ConnectionWrapper; // Entry in the ̀`CONNECTIONS` map.
     type Stream = StreamWrapper; // Entry in the ̀`STREAMS` map and a read buffer.
     type ConnectFuture = future::BoxFuture<
         'static,
-        Result<smoldot_light::PlatformConnection<Self::Stream, Self::Connection>, ConnectError>,
+        Result<
+            smoldot_light::platform::PlatformConnection<Self::Stream, Self::Connection>,
+            ConnectError,
+        >,
     >;
     type StreamDataFuture = future::BoxFuture<'static, ()>;
     type NextSubstreamFuture = future::BoxFuture<
         'static,
-        Option<(Self::Stream, smoldot_light::PlatformSubstreamDirection)>,
+        Option<(
+            Self::Stream,
+            smoldot_light::platform::PlatformSubstreamDirection,
+        )>,
     >;
 
     fn now_from_unix_epoch() -> Duration {
@@ -143,7 +149,7 @@ impl smoldot_light::Platform for Platform {
                         buffer_first_offset: 0,
                     };
 
-                    Ok(smoldot_light::PlatformConnection::SingleStream(
+                    Ok(smoldot_light::platform::PlatformConnection::SingleStream(
                         StreamWrapper((connection_id, 0), read_buffer),
                     ))
                 }
@@ -153,7 +159,7 @@ impl smoldot_light::Platform for Platform {
                     ..
                 } => {
                     *connection_handles_alive += 1;
-                    Ok(smoldot_light::PlatformConnection::MultiStream(
+                    Ok(smoldot_light::platform::PlatformConnection::MultiStream(
                         ConnectionWrapper(connection_id),
                         peer_id.clone(),
                     ))


### PR DESCRIPTION
Close https://github.com/paritytech/smoldot/issues/2671
Close https://github.com/paritytech/smoldot/issues/2542

This PR does the following:

- Move parameters provided to `Client::new` to a `ClientConfig` struct.
- Swap the two template parameters of `Client`.
- Make the `smoldot-light-base` properly no-std-friendly.
- Move the `Platform` trait in a separate module.
- Add a `std` feature to `smoldot-light-base` enabled by default.
- Add an implementation of the `Platform` trait based on `async-std`, gated behind the `std` feature. (see remarks below)
- Rename `smoldot-light-base` to `smoldot-light`.
- Add a lot of documentation.

Can be reviewed commit by commit.

The objective of this PR is to turn this library into a properly usable library that can be embedded in other Rust applications.

I'm aware that the example currently doesn't work. This is because the example doesn't support WebSocket Secure connections, and that almost all the non-WSS nodes seem to be full.
It seems, however, that there are problems other than nodes being full. Smoldot seems to try the same nodes over and over again.
I will investigate this, but the fix for that problem is out of scope of this PR. As far as I can tell, the code in this PR works as intended.

Some remarks about `async-std`: I know there's an active question of `async-std` vs `tokio`, and I want to pro-actively address his. The trait implementation provided by this PR uses `async-std` because it just works in all situations. This would not be the case with `tokio`. The objective of this trait implementation is specifically to be "plug and plug". In order to comply with this objective, only `async-std` makes sense. I will **not** add a separate trait implementation for `tokio`. Please realize that there's a trade-off between simplicity and performance, and in the case of async-std vs tokio, the balance weights very heavily in favor of keeping it simple by having only one trait implementation. In other words, I really don't care about saving 2% of CPU if it bloats the library's code. I have nothing against `tokio`, but if you want to use `tokio`, just reimplement the trait yourself.
