### PR TITLE
Pin GHA versions

### DIFF
--- a/.github/workflows/ci-post-workflow.yml
+++ b/.github/workflows/ci-post-workflow.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
     steps:
       # TODO: use download-artifact action
-      - uses: actions/github-script@v3.1.0
+      - uses: actions/github-script@v6.1.1
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({
@@ -43,14 +43,14 @@ jobs:
       - id: twiggy-diff
         # This step is purely meant to turn the diff into an GitHub action output that can be picked up by the further steps.
         # This code has been found here: https://github.community/t/set-output-truncates-multiline-strings/16852/16
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6.1.1
         with:
           script: |
             const fs = require('fs');
             return fs.readFileSync('./twiggy-diff', 'utf8').toString();
           result-encoding: string
       - id: pr-num
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6.1.1
         # This step grabs the pull request number from the artifacts to know where to comment.
         # This pull request number is untrusted and could be malicious. However the harm that
         # could be done is very limited (spammy comments), and so this is not considered a
@@ -60,13 +60,13 @@ jobs:
             const fs = require('fs');
             return fs.readFileSync('./number', 'utf8').toString();
           result-encoding: string
-      - uses: peter-evans/find-comment@v2
+      - uses: peter-evans/find-comment@1769778a0c5bd330272d749d12c036d65e70d39d # v2.0.0
         id: find-comment
         with:
           issue-number: ${{ steps.pr-num.outputs.result }}
           comment-author: 'github-actions[bot]'
           body-includes: twiggy diff report
-      - uses: peter-evans/create-or-update-comment@v2
+      - uses: peter-evans/create-or-update-comment@c9fcb64660bc90ec1cc535646af190c992007c32 # v2.0.0
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ steps.pr-num.outputs.result }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
             components: clippy
             override: true
       - uses: Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0  # Note that this is done after switching the compiler version to nightly
-      - uses: actions-rs/clippy@v1
+      - uses: actions-rs/clippy@master # action is in development stage
         with:
           args: --all-features --all-targets
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
             components: clippy
             override: true
       - uses: Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0  # Note that this is done after switching the compiler version to nightly
-      - uses: actions-rs/clippy@master # action is in development stage
+      - uses: actions-rs/clippy@9e02862195d5c88dabdda3c1e7fa53a45ed35ec1 # action is in development stage pinned to latest good version
         with:
           args: --all-features --all-targets
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       image: rust:1.61
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0
     - run: RUSTFLAGS=-Dwarnings cargo test --locked --workspace --all-features
 
   test-32bits:
@@ -40,7 +40,7 @@ jobs:
     steps:
     - run: apt-get update && apt install -y libc6-dev-i386
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0
     - run: rustup target add i686-unknown-linux-gnu
     - run: RUSTFLAGS=-Dwarnings cargo test --target i686-unknown-linux-gnu --locked --workspace --all-features
 
@@ -51,11 +51,11 @@ jobs:
     steps:
     - run: apt-get update && apt install -y binaryen # For `wasm-opt`
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0
     - uses: actions/setup-node@v3.4.1
       with:
         node-version: '12'  # An old version is used to ensure compatibility
-    - uses: denoland/setup-deno@v1
+    - uses: denoland/setup-deno@004814556e37c54a2f6e31384c9e18e983317366 # v1.1.0
       with:
         deno-version: v1.x
     - run: cd bin/wasm-node/javascript && RUSTFLAGS=-Dwarnings npm install-ci-test
@@ -69,11 +69,11 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0  # Necessary to fetch pull request base below
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0
     - uses: actions/setup-node@v3.4.1
       with:
         node-version: '14'  # Because this step doesn't actually check anything, we use a more liberal version
-    - uses: baptiste0928/cargo-install@v1  # This action ensures that the twiggy compilation is cached.
+    - uses: baptiste0928/cargo-install@bf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0  # This action ensures that the twiggy compilation is cached.
       with:
         crate: twiggy
         version: 0.6
@@ -101,7 +101,7 @@ jobs:
       image: rust:1.61
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0
     - run: RUSTFLAGS=-Dwarnings cargo check --package smoldot --locked --no-default-features
     - run: RUSTFLAGS=-Dwarnings cargo check --package smoldot --locked --no-default-features --features database-sqlite
     - run: RUSTFLAGS=-Dwarnings cargo check --package smoldot --locked --no-default-features --features std
@@ -120,10 +120,10 @@ jobs:
         # is completely arbitrary.
         toolchain: nightly-2022-06-05
         override: true
-    - uses: baptiste0928/cargo-install@v1  # This action ensures that the compilation is cached.
+    - uses: baptiste0928/cargo-install@bf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0  # This action ensures that the compilation is cached.
       with:
         crate: cargo-fuzz
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0
       with:
         working-directory: ./bin/fuzz
     - run: cargo fuzz build --fuzz-dir ./bin/fuzz
@@ -134,7 +134,7 @@ jobs:
       image: rust:1.61
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0
     - run: cargo doc --verbose --workspace --all-features --no-deps --document-private-items
 
   fmt:
@@ -167,8 +167,8 @@ jobs:
             toolchain: nightly
             components: clippy
             override: true
-      - uses: Swatinem/rust-cache@v1  # Note that this is done after switching the compiler version to nightly
-      - uses: actions-rs/clippy@master
+      - uses: Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0  # Note that this is done after switching the compiler version to nightly
+      - uses: actions-rs/clippy@v1
         with:
           args: --all-features --all-targets
 
@@ -182,7 +182,7 @@ jobs:
           - bans licenses sources
     steps:
     - uses: actions/checkout@v3
-    - uses: EmbarkStudios/cargo-deny-action@v1
+    - uses: EmbarkStudios/cargo-deny-action@7257a18a9c2fe3f92b85d41ae473520dff953c97 # v1.3.2
       with:
         command: check --config .github/cargo-deny.toml ${{ matrix.checks }}
         arguments: --workspace --all-features
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: baptiste0928/cargo-install@v1  # This action ensures that the compilation is cached.
+    - uses: baptiste0928/cargo-install@bf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0  # This action ensures that the compilation is cached.
       with:
         crate: cargo-spellcheck
         version: 0.11.2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: docker/setup-qemu-action@v2
     - uses: docker/setup-buildx-action@v2
     - uses: actions/checkout@v3
-    - uses: docker/login-action@v2 
+    - uses: docker/login-action@v2
       # This `if` adds an additional safety against accidental pushes.
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       with:
@@ -61,12 +61,12 @@ jobs:
           # Ideally we don't want to install any toolchain, but the GH action doesn't support this.
           toolchain: stable
           profile: minimal
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0
       - run: npm install
         working-directory: ./bin/wasm-node/javascript
       - run: npm publish --unsafe-perm --dry-run
         working-directory: ./bin/wasm-node/javascript
-      - uses: JS-DevTools/npm-publish@v1
+      - uses: JS-DevTools/npm-publish@0f451a94170d1699fd50710966d48fb26194d939 # v1.4.3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         # Warning: this GitHub action doesn't seem to run prepublish scripts, hence
         # the `npm publish --dry-run` done right above is important to ensure this.
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/setup-node@v3.4.1
         with:
           node-version: 12
-      - uses: denoland/setup-deno@v1
+      - uses: denoland/setup-deno@004814556e37c54a2f6e31384c9e18e983317366 # v1.1.0
         with:
           deno-version: v1.x
       - run: sudo apt-get update && sudo apt install -y binaryen # For `wasm-opt`
@@ -95,7 +95,7 @@ jobs:
           # Ideally we don't want to install any toolchain, but the GH action doesn't support this.
           toolchain: stable
           profile: minimal
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0
       - id: compute-tag  # Compute the tag that we might push.
         run: echo "::set-output name=tag::light-js-deno-v`jq -r .version ./bin/wasm-node/javascript/package.json`"
       - id: check-tag-exists  # Check whether the tag already exists.


### PR DESCRIPTION
In order to improve our security posture with GitHub Actions usage. I've made a version pinning ether to commit hash or to specific version.

Related issues and policy:
https://github.com/paritytech/ci_cd/issues/464
https://github.com/paritytech/ci_cd/wiki/Policies-and-regulations:-GitHub-Actions-usage-policies
