### PR TITLE
Refactor the Yamux implementation

### DIFF
--- a/src/libp2p/connection/established/single_stream.rs
+++ b/src/libp2p/connection/established/single_stream.rs
@@ -412,7 +412,7 @@ where
         loop {
             let mut substream = inner.yamux.substream_by_id_mut(substream_id).unwrap();
 
-            let state_machine = match substream.user_data().take() {
+            let state_machine = match substream.user_data_mut().take() {
                 Some(s) => s,
                 None => break (total_read, None),
             };
@@ -457,7 +457,7 @@ where
             }
 
             match substream_update {
-                Some(s) => *substream.user_data() = Some(s),
+                Some(s) => *substream.user_data_mut() = Some(s),
                 None => {
                     // TODO: only reset if not already closed
                     inner

--- a/src/libp2p/connection/established/single_stream.rs
+++ b/src/libp2p/connection/established/single_stream.rs
@@ -422,8 +422,8 @@ where
                 None => break (total_read, None),
             };
 
-            let read_is_closed = substream.is_remote_closed();
-            let write_is_closed = substream.is_closed();
+            let read_is_closed = !substream.can_receive();
+            let write_is_closed = !substream.can_send();
 
             let mut substream_read_write = ReadWrite {
                 now: outer_read_write.now.clone(),

--- a/src/libp2p/connection/established/single_stream.rs
+++ b/src/libp2p/connection/established/single_stream.rs
@@ -283,6 +283,10 @@ where
                     self.encryption
                         .consume_inbound_data(yamux_decode.bytes_read);
                 }
+
+                Some(yamux::IncomingDataDetail::GoAway(_)) => {
+                    todo!() // TODO: handle properly
+                }
             };
         }
 

--- a/src/libp2p/connection/established/single_stream.rs
+++ b/src/libp2p/connection/established/single_stream.rs
@@ -287,6 +287,11 @@ where
                 Some(yamux::IncomingDataDetail::GoAway(_)) => {
                     todo!() // TODO: handle properly
                 }
+
+                Some(yamux::IncomingDataDetail::PingResponse) => {
+                    // Can only happen if we send out pings, which we never do.
+                    unreachable!()
+                }
             };
         }
 

--- a/src/libp2p/connection/established/single_stream.rs
+++ b/src/libp2p/connection/established/single_stream.rs
@@ -345,6 +345,10 @@ where
                 buffers.push(buffer.as_ref().to_vec()); // TODO: copy
             }
 
+            if buffers.is_empty() {
+                break;
+            }
+
             let (_read, written) = self.encryption.encrypt(
                 buffers.into_iter(),
                 match read_write.outgoing_buffer.as_mut() {

--- a/src/libp2p/connection/yamux.rs
+++ b/src/libp2p/connection/yamux.rs
@@ -1279,20 +1279,6 @@ pub enum IncomingDataDetail {
 pub enum Error {
     /// Failed to decode an incoming yamux header.
     HeaderDecode(header::YamuxHeaderDecodeError),
-    /// Unknown version number in a header.
-    #[display(fmt = "Unknown version number in a header")]
-    UnknownVersion(u8),
-    /// Unrecognized value for the type of frame as indicated in the header.
-    #[display(fmt = "Unrecognized value for the type of frame as indicated in the header")]
-    BadFrameType(u8),
-    /// Received flags whose meaning is unknown.
-    #[display(fmt = "Received flags whose meaning is unknown")]
-    UnknownFlags(u16),
-    /// Received a PING frame with invalid flags.
-    #[display(fmt = "Received a PING frame with invalid flags")]
-    BadPingFlags(u16),
-    /// Substream ID was zero in a data of window update frame.
-    ZeroSubstreamId,
     /// Received a SYN flag with a known substream ID.
     #[display(fmt = "Received a SYN flag with a known substream ID")]
     UnexpectedSyn(NonZeroU32),

--- a/src/libp2p/connection/yamux.rs
+++ b/src/libp2p/connection/yamux.rs
@@ -267,19 +267,13 @@ impl<T> Yamux<T> {
     }
 
     /// Process some incoming data.
-    ///
-    /// # Panic
-    ///
-    /// Panics if pending incoming substream.
-    ///
     // TODO: explain that reading might be blocked on writing
-    // TODO: reword panic reason
     pub fn incoming_data(mut self, mut data: &[u8]) -> Result<IncomingDataOutcome<T>, Error> {
         let mut total_read: usize = 0;
 
         while !data.is_empty() {
             match self.incoming {
-                Incoming::PendingIncomingSubstream { .. } => panic!(),
+                Incoming::PendingIncomingSubstream { .. } => break,
 
                 Incoming::DataFrame {
                     substream_id,

--- a/src/libp2p/connection/yamux.rs
+++ b/src/libp2p/connection/yamux.rs
@@ -579,8 +579,7 @@ impl<T> Yamux<T> {
                                     .checked_sub(u64::from(length))
                                     .ok_or(Error::CreditsExceeded)?;
 
-                                // TODO: uh?! why these two changes?
-                                substream.first_message_queued = true;
+                                // TODO: make this behavior tweakable by the user!
                                 substream.remote_window_pending_increase += 256 * 1024;
                             }
 

--- a/src/libp2p/connection/yamux.rs
+++ b/src/libp2p/connection/yamux.rs
@@ -428,7 +428,6 @@ impl<T> Yamux<T> {
                                 )
                                 .unwrap();
                             self.incoming = Incoming::Header(arrayvec::ArrayVec::new());
-                            continue;
                         }
                         header::DecodedYamuxHeader::PingResponse { .. } => {
                             // TODO: ping handling

--- a/src/libp2p/connection/yamux.rs
+++ b/src/libp2p/connection/yamux.rs
@@ -883,7 +883,6 @@ pub struct Config {
 }
 
 /// Reference to a substream within the [`Yamux`].
-// TODO: Debug
 pub struct SubstreamRef<'a, T> {
     id: SubstreamId,
     substream: &'a Substream<T>,
@@ -924,8 +923,16 @@ impl<'a, T> SubstreamRef<'a, T> {
     }
 }
 
+impl<'a, T> fmt::Debug for SubstreamRef<'a, T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Substream").field(self.user_data()).finish()
+    }
+}
+
 /// Reference to a substream within the [`Yamux`].
-// TODO: Debug
 pub struct SubstreamMut<'a, T> {
     substream: OccupiedEntry<'a, NonZeroU32, Substream<T>, SipHasherBuild>,
 }
@@ -937,7 +944,12 @@ impl<'a, T> SubstreamMut<'a, T> {
     }
 
     /// Returns the user data associated to this substream.
-    pub fn user_data(&mut self) -> &mut T {
+    pub fn user_data(&self) -> &T {
+        &self.substream.get().user_data
+    }
+
+    /// Returns the user data associated to this substream.
+    pub fn user_data_mut(&mut self) -> &mut T {
         &mut self.substream.get_mut().user_data
     }
 
@@ -1036,6 +1048,15 @@ impl<'a, T> SubstreamMut<'a, T> {
         substream.write_buffers.clear();
         substream.first_write_buffer_offset = 0;
         substream.was_reset = true;
+    }
+}
+
+impl<'a, T> fmt::Debug for SubstreamMut<'a, T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Substream").field(self.user_data()).finish()
     }
 }
 

--- a/src/libp2p/connection/yamux.rs
+++ b/src/libp2p/connection/yamux.rs
@@ -817,6 +817,11 @@ impl<T> Yamux<T> {
     /// Panics if no incoming substream is currently pending.
     ///
     pub fn reject_pending_substream(&mut self) {
+        // Implementation note: the rejection mechanism could alternatively be implemented by
+        // queuing the substream rejection, rather than immediately putting it in `self.outgoing`.
+        // However, this could open a DoS attack vector, as the remote could send a huge number
+        // of substream open request which would inevitably increase the memory consumption of the
+        // local node.
         match self.incoming {
             Incoming::PendingIncomingSubstream {
                 substream_id,

--- a/src/libp2p/connection/yamux.rs
+++ b/src/libp2p/connection/yamux.rs
@@ -66,6 +66,21 @@ mod header;
 /// Name of the protocol, typically used when negotiated it using *multistream-select*.
 pub const PROTOCOL_NAME: &str = "/yamux/1.0.0";
 
+/// Configuration for a new [`Yamux`].
+#[derive(Debug)]
+pub struct Config {
+    /// `true` if the local machine has initiated the connection. Otherwise, `false`.
+    pub is_initiator: bool,
+
+    /// Expected number of substreams simultaneously open, both inbound and outbound substreams
+    /// combined.
+    pub capacity: usize,
+
+    /// Seed used for the randomness. Used to avoid HashDoS attack and determines the order in
+    /// which the data on substreams is sent out.
+    pub randomness_seed: [u8; 16],
+}
+
 pub struct Yamux<T> {
     /// List of substreams currently open in the Yamux state machine.
     ///
@@ -867,19 +882,6 @@ where
             .field("substreams", &List(self))
             .finish()
     }
-}
-
-/// Configuration for a new [`Yamux`].
-#[derive(Debug)]
-pub struct Config {
-    /// `true` if the local machine has initiated the connection. Otherwise, `false`.
-    pub is_initiator: bool,
-    /// Expected number of substreams simultaneously open, both inbound and outbound substreams
-    /// combined.
-    pub capacity: usize,
-    /// Seed used for the randomness. Used to avoid HashDoS attack and determines the order in
-    /// which the data on substreams is sent out.
-    pub randomness_seed: [u8; 16],
 }
 
 /// Reference to a substream within the [`Yamux`].

--- a/src/libp2p/connection/yamux.rs
+++ b/src/libp2p/connection/yamux.rs
@@ -401,7 +401,6 @@ impl<T> Yamux<T> {
                     if *remaining_bytes == 0 {
                         self.incoming = Incoming::Header(arrayvec::ArrayVec::new());
                     }
-                    continue;
                 }
 
                 Incoming::Header(ref mut incoming_header) => {

--- a/src/libp2p/connection/yamux/header.rs
+++ b/src/libp2p/connection/yamux/header.rs
@@ -136,16 +136,16 @@ fn decode<'a>(bytes: &'a [u8]) -> nom::IResult<&'a [u8], DecodedYamuxHeader> {
             nom::combinator::map(
                 nom::sequence::tuple((
                     nom::bytes::complete::tag(&[3]),
-                    nom::bytes::complete::tag(&[0]),
+                    nom::bytes::complete::tag(&[0, 0]),
                     nom::bytes::complete::tag(&[0, 0, 0, 0]),
                     nom::branch::alt((
-                        nom::combinator::map(nom::bytes::complete::tag(&[0]), |_| {
+                        nom::combinator::map(nom::bytes::complete::tag(0u32.to_be_bytes()), |_| {
                             GoAwayErrorCode::NormalTermination
                         }),
-                        nom::combinator::map(nom::bytes::complete::tag(&[1]), |_| {
+                        nom::combinator::map(nom::bytes::complete::tag(1u32.to_be_bytes()), |_| {
                             GoAwayErrorCode::ProtocolError
                         }),
-                        nom::combinator::map(nom::bytes::complete::tag(&[2]), |_| {
+                        nom::combinator::map(nom::bytes::complete::tag(2u32.to_be_bytes()), |_| {
                             GoAwayErrorCode::InternalError
                         }),
                     )),

--- a/src/libp2p/connection/yamux/header.rs
+++ b/src/libp2p/connection/yamux/header.rs
@@ -1,0 +1,170 @@
+// Smoldot
+// Copyright (C) 2019-2022  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use core::num::NonZeroU32;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum DecodedYamuxHeader {
+    Data {
+        syn: bool,
+        ack: bool,
+        fin: bool,
+        rst: bool,
+        stream_id: NonZeroU32,
+        length: u32,
+    },
+    Window {
+        syn: bool,
+        ack: bool,
+        fin: bool,
+        rst: bool,
+        stream_id: NonZeroU32,
+        length: u32,
+    },
+    PingRequest {
+        opaque_value: u32,
+    },
+    PingResponse {
+        opaque_value: u32,
+    },
+    GoAway {
+        error_code: GoAwayErrorCode,
+    },
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum GoAwayErrorCode {
+    NormalTermination = 0x0,
+    ProtocolError = 0x1,
+    InternalError = 0x2,
+}
+
+pub fn decode_yamux_header(bytes: &[u8]) -> Result<DecodedYamuxHeader, YamuxHeaderDecodeError> {
+    match nom::combinator::all_consuming(nom::combinator::complete(decode))(bytes) {
+        Ok((_, h)) => Ok(h),
+        Err(_) => todo!(), // TODO: /!\
+    }
+}
+
+/// Error while decoding a Yamux header.
+#[derive(Debug, derive_more::Display)]
+pub enum YamuxHeaderDecodeError {
+    /// Unknown version number in a header.
+    #[display(fmt = "Unknown version number in a header")]
+    UnknownVersion(u8),
+    /// Unrecognized value for the type of frame as indicated in the header.
+    #[display(fmt = "Unrecognized value for the type of frame as indicated in the header")]
+    BadFrameType(u8),
+    /// Received flags whose meaning is unknown.
+    #[display(fmt = "Received flags whose meaning is unknown")]
+    UnknownFlags(u16),
+    /// Received a PING frame with invalid flags.
+    #[display(fmt = "Received a PING frame with invalid flags")]
+    BadPingFlags(u16),
+    /// Substream ID was zero in a data of window update frame.
+    ZeroSubstreamId,
+}
+
+fn decode<'a>(bytes: &'a [u8]) -> nom::IResult<&'a [u8], DecodedYamuxHeader> {
+    nom::sequence::preceded(
+        nom::bytes::complete::tag(&[0]),
+        nom::branch::alt((
+            nom::combinator::map(
+                nom::sequence::tuple((
+                    nom::bytes::complete::tag(&[0]),
+                    flags,
+                    nom::combinator::map_opt(nom::number::complete::be_u32, NonZeroU32::new),
+                    nom::number::complete::be_u32,
+                )),
+                |(_, (syn, ack, fin, rst), stream_id, length)| DecodedYamuxHeader::Data {
+                    syn,
+                    ack,
+                    fin,
+                    rst,
+                    stream_id,
+                    length,
+                },
+            ),
+            nom::combinator::map(
+                nom::sequence::tuple((
+                    nom::bytes::complete::tag(&[1]),
+                    flags,
+                    nom::combinator::map_opt(nom::number::complete::be_u32, NonZeroU32::new),
+                    nom::number::complete::be_u32,
+                )),
+                |(_, (syn, ack, fin, rst), stream_id, length)| DecodedYamuxHeader::Window {
+                    syn,
+                    ack,
+                    fin,
+                    rst,
+                    stream_id,
+                    length,
+                },
+            ),
+            nom::combinator::map(
+                nom::sequence::tuple((
+                    nom::bytes::complete::tag(&[2]),
+                    nom::bytes::complete::tag(&[0x0, 0x1]),
+                    nom::bytes::complete::tag(&[0, 0, 0, 0]),
+                    nom::number::complete::be_u32,
+                )),
+                |(_, _, _, opaque_value)| DecodedYamuxHeader::PingRequest { opaque_value },
+            ),
+            nom::combinator::map(
+                nom::sequence::tuple((
+                    nom::bytes::complete::tag(&[2]),
+                    nom::bytes::complete::tag(&[0x0, 0x2]),
+                    nom::bytes::complete::tag(&[0, 0, 0, 0]),
+                    nom::number::complete::be_u32,
+                )),
+                |(_, _, _, opaque_value)| DecodedYamuxHeader::PingResponse { opaque_value },
+            ),
+            nom::combinator::map(
+                nom::sequence::tuple((
+                    nom::bytes::complete::tag(&[3]),
+                    nom::bytes::complete::tag(&[0]),
+                    nom::bytes::complete::tag(&[0, 0, 0, 0]),
+                    nom::branch::alt((
+                        nom::combinator::map(nom::bytes::complete::tag(&[0]), |_| {
+                            GoAwayErrorCode::NormalTermination
+                        }),
+                        nom::combinator::map(nom::bytes::complete::tag(&[1]), |_| {
+                            GoAwayErrorCode::ProtocolError
+                        }),
+                        nom::combinator::map(nom::bytes::complete::tag(&[2]), |_| {
+                            GoAwayErrorCode::InternalError
+                        }),
+                    )),
+                )),
+                |(_, _, _, error_code)| DecodedYamuxHeader::GoAway { error_code },
+            ),
+        )),
+    )(bytes)
+}
+
+fn flags<'a>(bytes: &'a [u8]) -> nom::IResult<&'a [u8], (bool, bool, bool, bool)> {
+    nom::combinator::map_opt(nom::number::complete::be_u16, |flags| {
+        let syn = (flags & 0x1) != 0;
+        let ack = (flags & 0x2) != 0;
+        let fin = (flags & 0x4) != 0;
+        let rst = (flags & 0x8) != 0;
+        if (flags & !0b1111) != 0 {
+            return None;
+        }
+        Some((syn, ack, fin, rst))
+    })(bytes)
+}


### PR DESCRIPTION
This PR refactors the Yamux code to be, normally, fully working.

The major changes are:

- GoAway frames are now reported properly (instead of triggering a `todo!()`).
- Outgoing pings are now supported.
- Dead substreams are no longer removed immediately. This instant removal caused a lot of spaghetti in the upper layer, and the best way to address it was to keep dead substreams in the yamux state machine until they are removed manually by the API user.

While the yamux implementation is not perfect, and still needs some tweaks such as reducing some `O(n)` loops to `O(1)`, it is now probably pretty hard to make it panic.
