### PR TITLE
Make AccountId deserialization accept prefixes larger than 1 byte

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fix inability to decode addresses with prefixes longer than 1 byte in the RPC. ([#2686](https://github.com/paritytech/smoldot/pull/2686))
+- Fix inability to decode addresses with prefixes longer than 1 byte when calling `system_accountNextIndex`. ([#2686](https://github.com/paritytech/smoldot/pull/2686))
 
 ## 0.6.30 - 2022-08-12
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - In case of protocol error, or if a peer refuses a block announces substream, no new substream with the same peer will be attempted for 20 seconds. This avoids loops where the same peer is tried over and over again.
 
+### Fixed
+
+- Fix inability to decode addresses with prefixes longer than 1 byte in the RPC. ([#2686](https://github.com/paritytech/smoldot/pull/2686))
+
 ## 0.6.30 - 2022-08-12
 
 ### Fixed

--- a/src/json_rpc/methods.rs
+++ b/src/json_rpc/methods.rs
@@ -572,15 +572,18 @@ impl<'a> serde::Deserialize<'a> for AccountId {
             Err(_) => return Err(serde::de::Error::custom("AccountId isn't in base58 format")),
         };
 
-        // TODO: soon might be 36 bytes as well
-        if decoded.len() != 35 {
+        // TODO: retrieve the actual prefix length of the current chain
+        if decoded.len() < 35 {
             return Err(serde::de::Error::custom("unexpected length for AccountId"));
         }
 
         // TODO: finish implementing this properly ; must notably check checksum
         // see https://github.com/paritytech/substrate/blob/74a50abd6cbaad1253daf3585d5cdaa4592e9184/primitives/core/src/crypto.rs#L228
 
-        let account_id = <[u8; 32]>::try_from(&decoded[1..33]).unwrap();
+        // TODO: retrieve and use the actual prefix length of the current chain
+        let account_id =
+            <[u8; 32]>::try_from(&decoded[(decoded.len() - 34)..(decoded.len() - 2)]).unwrap();
+
         Ok(AccountId(account_id))
     }
 }


### PR DESCRIPTION
This fixes the issue described in #2685 however it doesn't properly solve it in a clean manner. A perfect solution would be to somehow retrieve the prefix length from the current chain and use that as the offset for the account id byte array.