### PR TITLE
Provide a Host in the WebSocket handshake

### DIFF
--- a/bin/full-node/src/run/network_service.rs
+++ b/bin/full-node/src/run/network_service.rs
@@ -46,8 +46,7 @@ use smoldot::{
         connection,
         multiaddr::{Multiaddr, ProtocolRef},
         peer_id::{self, PeerId},
-        peers,
-        websocket::websocket_client_handshake,
+        peers, websocket,
     },
     network::{protocol, service},
 };
@@ -1412,35 +1411,38 @@ fn multiaddr_to_socket(
     // TODO: doesn't support WebSocket secure connections
 
     // Ensure ahead of time that the multiaddress is supported.
-    let (addr, is_websocket) = match (&proto1, &proto2, &proto3) {
+    let (addr, host_if_websocket) = match (&proto1, &proto2, &proto3) {
         (ProtocolRef::Ip4(ip), ProtocolRef::Tcp(port), None) => (
             either::Left(SocketAddr::new(IpAddr::V4((*ip).into()), *port)),
-            false,
+            None,
         ),
         (ProtocolRef::Ip6(ip), ProtocolRef::Tcp(port), None) => (
             either::Left(SocketAddr::new(IpAddr::V6((*ip).into()), *port)),
-            false,
+            None,
         ),
-        (ProtocolRef::Ip4(ip), ProtocolRef::Tcp(port), Some(ProtocolRef::Ws)) => (
-            either::Left(SocketAddr::new(IpAddr::V4((*ip).into()), *port)),
-            true,
-        ),
-        (ProtocolRef::Ip6(ip), ProtocolRef::Tcp(port), Some(ProtocolRef::Ws)) => (
-            either::Left(SocketAddr::new(IpAddr::V6((*ip).into()), *port)),
-            true,
-        ),
+        (ProtocolRef::Ip4(ip), ProtocolRef::Tcp(port), Some(ProtocolRef::Ws)) => {
+            let addr = SocketAddr::new(IpAddr::V4((*ip).into()), *port);
+            (either::Left(addr), Some(addr.to_string()))
+        }
+        (ProtocolRef::Ip6(ip), ProtocolRef::Tcp(port), Some(ProtocolRef::Ws)) => {
+            let addr = SocketAddr::new(IpAddr::V6((*ip).into()), *port);
+            (either::Left(addr), Some(addr.to_string()))
+        }
 
         // TODO: we don't care about the differences between Dns, Dns4, and Dns6
         (
             ProtocolRef::Dns(addr) | ProtocolRef::Dns4(addr) | ProtocolRef::Dns6(addr),
             ProtocolRef::Tcp(port),
             None,
-        ) => (either::Right((addr.to_string(), *port)), false),
+        ) => (either::Right((addr.to_string(), *port)), None),
         (
             ProtocolRef::Dns(addr) | ProtocolRef::Dns4(addr) | ProtocolRef::Dns6(addr),
             ProtocolRef::Tcp(port),
             Some(ProtocolRef::Ws),
-        ) => (either::Right((addr.to_string(), *port)), true),
+        ) => (
+            either::Right((addr.to_string(), *port)),
+            Some(format!("{}:{}", addr, *port)),
+        ),
 
         _ => return Err(()),
     };
@@ -1464,11 +1466,17 @@ fn multiaddr_to_socket(
             let _ = tcp_socket.set_nodelay(true);
         }
 
-        match (tcp_socket, is_websocket) {
-            (Ok(tcp_socket), true) => websocket_client_handshake(tcp_socket)
+        match (tcp_socket, host_if_websocket) {
+            (Ok(tcp_socket), Some(host)) => {
+                websocket::websocket_client_handshake(websocket::Config {
+                    tcp_socket,
+                    host: &host,
+                    url: "/",
+                })
                 .await
-                .map(future::Either::Right),
-            (Ok(tcp_socket), false) => Ok(future::Either::Left(tcp_socket)),
+                .map(future::Either::Right)
+            }
+            (Ok(tcp_socket), None) => Ok(future::Either::Left(tcp_socket)),
             (Err(err), _) => Err(err),
         }
     })

--- a/src/libp2p/websocket.rs
+++ b/src/libp2p/websocket.rs
@@ -31,13 +31,25 @@ use core::{
 
 use std::io;
 
+/// Configuration for [`websocket_client_handshake`].
+pub struct Config<'a, T> {
+    /// Socket to negotiate WebSocket on top of.
+    pub tcp_socket: T,
+
+    /// Values to pass for the `Host` HTTP header. Example values include `example.com:1234` or
+    /// `127.0.0.1:3337`.
+    pub host: &'a str,
+
+    /// URL to pass to the server during the HTTP handshake. Typically `/`.
+    pub url: &'a str,
+}
+
 /// Negotiates the WebSocket protocol (including the HTTP-like request) on the given socket, and
 /// returns an object that translates reads and writes into WebSocket binary frames.
-pub async fn websocket_client_handshake<T: AsyncRead + AsyncWrite + Send + Unpin + 'static>(
-    tcp_socket: T,
+pub async fn websocket_client_handshake<'a, T: AsyncRead + AsyncWrite + Send + Unpin + 'static>(
+    config: Config<'a, T>,
 ) -> Result<Connection<T>, io::Error> {
-    // TODO: what is the host?
-    let mut client = soketto::handshake::Client::new(tcp_socket, "...", "/");
+    let mut client = soketto::handshake::Client::new(config.tcp_socket, config.host, config.url);
 
     let (sender, receiver) = match client.handshake().await {
         Ok(soketto::handshake::ServerResponse::Accepted { .. }) => client.into_builder().finish(),


### PR DESCRIPTION
Right now, on the client side, we pass `Host: ...` in the HTTP headers.

While libp2p itself doesn't care about the value in the `Host` header, many nodes that use WebSocket have an HTTP reverse proxy in front of them. This reverse proxy does care about this value, and it is thus important to pass it properly.
