### PR TITLE
Remove hack that checks for duplicate finality

### DIFF
--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -1917,11 +1917,7 @@ impl<TPlat: Platform> Background<TPlat> {
                 finalized_block,
                 ..
             } => {
-                // TODO: this if is a small hack because the sync service currently sends multiple identical finalized notifications
-                if finalized_block.hash == hash_to_finalize {
-                    return;
-                }
-
+                debug_assert_ne!(finalized_block.hash, hash_to_finalize);
                 let node_to_finalize = tree
                     .input_iter_unordered()
                     .find(|block| block.user_data.hash == hash_to_finalize)


### PR DESCRIPTION
https://github.com/paritytech/smoldot/pull/2658 removed the code that sometimes erroneously sent a `Notification::Finalized` about a block that was already finalized. As such, we can remove the hack in `runtime_service` that checks for this.