### PR TITLE
Process incoming foreground messages while subscribing

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix parachain initialization unnecessarily waiting for its corresponding relay chain initialization to be finished.
+- Fix parachain initialization unnecessarily waiting for its corresponding relay chain initialization to be finished. ([#2705](https://github.com/paritytech/smoldot/pull/2705))
 
 ## 0.6.31 - 2022-08-30
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix parachain initialization unnecessarily waiting for its corresponding relay chain initialization to be finished.
+
 ## 0.6.31 - 2022-08-30
 
 ### Changed


### PR DESCRIPTION
Calling `relay_chain_sync.subscribe_all(...).await` might take a long time (as it waits for the runtime of the chain to have been downloaded), during which messages coming from the public API of the sync service just pile up and aren't answered.
This PR fixes this by answering messages while we wait for the subscription to happen.

The consequence is that a parachain initialization now finishes quickly, while before it was waiting for its relay chain initialization to finish.
It also means that we now properly clean up parachains if we remove them, even if their relay chain never downloads its runtime. Before, the clean up didn't happen because the clean up never happens before initialization is complete.

I'm not really happy with the code duplication here, and would perform a refactoring that moves local variables into a struct, and adds methods to that struct, similar to `standalone.rs`.
