### PR TITLE
General clean-up of the single stream connections code

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix parachain initialization unnecessarily waiting for its corresponding relay chain initialization to be finished. ([#2705](https://github.com/paritytech/smoldot/pull/2705))
+- Fix crash when receiving a Yamux GoAway frame. ([#2708](https://github.com/paritytech/smoldot/pull/2708))
 
 ## 0.6.31 - 2022-08-30
 

--- a/src/libp2p/collection/multi_stream.rs
+++ b/src/libp2p/collection/multi_stream.rs
@@ -168,6 +168,15 @@ where
                 outbound_substreams_reverse,
             } => {
                 let event = match established.pull_event() {
+                    Some(established::Event::NewOutboundSubstreamsForbidden) => {
+                        // TODO: handle properly
+                        self.connection = MultiStreamConnectionTaskInner::ShutdownWaitingAck {
+                            start_shutdown_message_to_send: Some(None),
+                            shutdown_finish_message_sent: false,
+                            initiator: ShutdownInitiator::Coordinator,
+                        };
+                        Some(ConnectionToCoordinatorInner::StartShutdown(None))
+                    }
                     Some(established::Event::InboundError(err)) => {
                         Some(ConnectionToCoordinatorInner::InboundError(err))
                     }

--- a/src/libp2p/collection/single_stream.rs
+++ b/src/libp2p/collection/single_stream.rs
@@ -488,6 +488,20 @@ where
                     }
 
                     match event {
+                        Some(established::Event::NewOutboundSubstreamsForbidden) => {
+                            // TODO: handle properly
+                            self.pending_messages.push_back(
+                                ConnectionToCoordinatorInner::StartShutdown(Some(
+                                    ShutdownCause::CleanShutdown,
+                                )),
+                            );
+                            self.pending_messages
+                                .push_back(ConnectionToCoordinatorInner::ShutdownFinished);
+                            self.connection = SingleStreamConnectionTaskInner::ShutdownWaitingAck {
+                                initiator: ShutdownInitiator::Remote,
+                            };
+                            return;
+                        }
                         Some(established::Event::InboundError(err)) => {
                             self.pending_messages
                                 .push_back(ConnectionToCoordinatorInner::InboundError(err));

--- a/src/libp2p/connection/established.rs
+++ b/src/libp2p/connection/established.rs
@@ -69,6 +69,11 @@ impl SubstreamId {
 #[must_use]
 #[derive(Debug)]
 pub enum Event<TRqUd, TNotifUd> {
+    /// The connection is now in a mode where opening new substreams (i.e. starting requests
+    /// and opening notifications substreams) is forbidden, but the remote is still able to open
+    /// substreams and messages on existing substreams are still allowed to be sent and received.
+    NewOutboundSubstreamsForbidden,
+
     /// Received an incoming substream, but this substream has produced an error.
     ///
     /// > **Note**: This event exists only for diagnostic purposes. No action is expected in

--- a/src/libp2p/connection/established/single_stream.rs
+++ b/src/libp2p/connection/established/single_stream.rs
@@ -312,10 +312,9 @@ where
                 }
 
                 Some(yamux::IncomingDataDetail::GoAway(_)) => {
-                    // TODO: somehow report the content of the GoAway on the external API?
+                    // TODO: somehow report the GoAway error code on the external API?
                     self.encryption
                         .consume_inbound_data(yamux_decode.bytes_read);
-                    // TODO: also forbid new substreams from being opened
                     return Ok((self, Some(Event::NewOutboundSubstreamsForbidden)));
                 }
 
@@ -626,6 +625,11 @@ where
     /// The timeout is the time between the moment the substream is opened and the moment the
     /// response is sent back. If the emitter doesn't send the request or if the receiver doesn't
     /// answer during this time window, the request is considered failed.
+    ///
+    /// # Panic
+    ///
+    /// Panics if a [`Event::NewOutboundSubstreamsForbidden`] event has been generated in the past.
+    ///
     pub fn add_request(
         &mut self,
         protocol_index: usize,
@@ -705,6 +709,10 @@ where
     ///
     /// Assuming that the remote is using the same implementation, an
     /// [`Event::NotificationsInOpen`] will be generated on its side.
+    ///
+    /// # Panic
+    ///
+    /// Panics if a [`Event::NewOutboundSubstreamsForbidden`] event has been generated in the past.
     ///
     pub fn open_notifications_substream(
         &mut self,

--- a/src/libp2p/connection/established/single_stream.rs
+++ b/src/libp2p/connection/established/single_stream.rs
@@ -312,7 +312,11 @@ where
                 }
 
                 Some(yamux::IncomingDataDetail::GoAway(_)) => {
-                    todo!() // TODO: handle properly
+                    // TODO: somehow report the content of the GoAway on the external API?
+                    self.encryption
+                        .consume_inbound_data(yamux_decode.bytes_read);
+                    // TODO: also forbid new substreams from being opened
+                    return Ok((self, Some(Event::NewOutboundSubstreamsForbidden)));
                 }
 
                 Some(yamux::IncomingDataDetail::PingResponse) => {

--- a/src/libp2p/connection/established/single_stream.rs
+++ b/src/libp2p/connection/established/single_stream.rs
@@ -216,9 +216,8 @@ where
             // to the remote that these new substreams are denied. However, this is not a problem
             // as the remote interprets our GoAway frame as an automatic refusal of all its pending
             // substream requests.
-            // TODO: instead of checking things here, maybe add a function in Yamux that guarantees that we won't need to send out any more data?
             if self.inner.yamux.is_empty()
-                && self.inner.yamux.goaway_queued_or_sent()
+                && self.inner.yamux.goaway_sent()
                 && self.inner.yamux.received_goaway().is_some()
             {
                 read_write.close_write();

--- a/src/libp2p/connection/established/single_stream.rs
+++ b/src/libp2p/connection/established/single_stream.rs
@@ -149,7 +149,6 @@ where
     /// written are both 0, and the returned [`Event`] is `None`.
     ///
     /// If an error is returned, the socket should be entirely shut down.
-    // TODO: in case of error, we're supposed to first send a yamux goaway frame
     // TODO: consider exposing an API more similar to the one of substream::Substream::read_write?
     pub fn read_write(
         mut self,

--- a/src/libp2p/connection/established/single_stream.rs
+++ b/src/libp2p/connection/established/single_stream.rs
@@ -258,6 +258,10 @@ where
                 if let Some(event) = event {
                     return Ok((self, Some(event)));
                 }
+
+                // Jump back to the beginning of the loop. We don't want to read more data until
+                // this specific substream's data has been processed.
+                continue;
             }
 
             // Transfer data from `incoming_data` to the internal buffer in `self.encryption`.

--- a/src/libp2p/connection/established/single_stream.rs
+++ b/src/libp2p/connection/established/single_stream.rs
@@ -88,12 +88,12 @@ struct Inner<TNow, TRqUd, TNotifUd> {
     yamux: yamux::Yamux<Option<substream::Substream<TNow, TRqUd, TNotifUd>>>,
 
     /// If `Some`, contains the substream and number of bytes that [`Inner::yamux`] has already
-    /// processed but haven't been consumed from the buffer of decrypted data in
+    /// processed but haven't been consumed from the buffer of decoded data in
     /// [`SingleStream::encryption`] yet.
     ///
-    /// After yamux indicates that it has just processed a frame of data belonging to a certain
+    /// After Yamux indicates that it has just processed a frame of data belonging to a certain
     /// substream, we set this value to `Some` but leave the data in the buffer. This way, we can
-    /// process the data at a slower pace than yamux.
+    /// process the data at a slower pace than Yamux.
     current_data_frame: Option<(yamux::SubstreamId, NonZeroUsize)>,
 
     /// Substream in [`Inner::yamux`] used for outgoing pings.
@@ -675,7 +675,7 @@ where
     /// # Panic
     ///
     /// Panic if this function has been called before. It is illegal to call
-    /// [`SingleStream::close_incoming_substreams`] more than one on the same connections.
+    /// [`SingleStream::deny_new_incoming_substreams`] more than one on the same connections.
     ///
     pub fn deny_new_incoming_substreams(&mut self) {
         // TODO: arbitrary yamux error code

--- a/src/libp2p/connection/established/single_stream.rs
+++ b/src/libp2p/connection/established/single_stream.rs
@@ -176,7 +176,7 @@ where
             }
         }
 
-        // Start any outgoing peer if necessary.
+        // Start any outgoing ping if necessary.
         if read_write.now >= self.inner.next_ping {
             self.queue_ping(read_write.now.clone() + self.inner.ping_timeout);
             self.inner.next_ping = read_write.now.clone() + self.inner.ping_interval;

--- a/src/libp2p/connection/established/single_stream.rs
+++ b/src/libp2p/connection/established/single_stream.rs
@@ -662,6 +662,25 @@ where
         }
     }
 
+    /// Close the incoming substreams, automatically denying any new substream request from the
+    /// remote.
+    ///
+    /// Note that this does not prevent incoming-substreams-related events
+    /// (such as [`Event::RequestIn`]) from being generated, as it is possible that the remote has
+    /// already opened a substream but has no sent all the necessary handshake messages yet.
+    ///
+    /// # Panic
+    ///
+    /// Panic if this function has been called before. It is illegal to call
+    /// [`SingleStream::close_incoming_substreams`] more than one on the same connections.
+    ///
+    pub fn deny_new_incoming_substreams(&mut self) {
+        // TODO: arbitrary yamux error code
+        self.inner
+            .yamux
+            .send_goaway(yamux::GoAwayErrorCode::NormalTermination)
+    }
+
     /// Sends a request to the remote.
     ///
     /// Must pass the index of the protocol within [`Config::request_protocols`].

--- a/src/libp2p/connection/yamux.rs
+++ b/src/libp2p/connection/yamux.rs
@@ -272,6 +272,14 @@ impl<T> Yamux<T> {
         }
     }
 
+    /// Returns `true` if there is no substream in the state machine.
+    ///
+    /// > **Note**: After a substream has been closed or reset, it must be removed using
+    /// >           [`Yamux::next_dead_substream`] before this function can return `true`.
+    pub fn is_empty(&self) -> bool {
+        self.substreams.is_empty()
+    }
+
     /// Opens a new substream.
     ///
     /// This method only modifies the state of `self` and reserves an identifier. No message needs

--- a/src/libp2p/connection/yamux.rs
+++ b/src/libp2p/connection/yamux.rs
@@ -1593,8 +1593,6 @@ impl<'a, T> SubstreamMut<'a, T> {
             }
             _ => {}
         }
-
-        // TODO: doesn't write the RST flag
     }
 }
 

--- a/src/libp2p/connection/yamux.rs
+++ b/src/libp2p/connection/yamux.rs
@@ -1044,6 +1044,8 @@ impl<T> Yamux<T> {
                                     });
                                 }
                             }
+
+                            self.incoming = Incoming::Header(arrayvec::ArrayVec::new());
                         }
                     }
                 }

--- a/src/libp2p/connection/yamux.rs
+++ b/src/libp2p/connection/yamux.rs
@@ -89,7 +89,7 @@ pub struct Yamux<T> {
     /// A `SipHasher` is used in order to avoid hash collision attacks on substream IDs.
     substreams: hashbrown::HashMap<NonZeroU32, Substream<T>, SipHasherBuild>,
 
-    /// `Some` if a "GoAway" frame has been received in the past.
+    /// `Some` if a `GoAway` frame has been received in the past.
     received_goaway: Option<GoAwayErrorCode>,
 
     /// What kind of data is expected on the socket next.
@@ -98,7 +98,7 @@ pub struct Yamux<T> {
     /// What to write to the socket next.
     outgoing: Outgoing,
 
-    /// Whether to send out a "GoAway" frame.
+    /// Whether to send out a `GoAway` frame.
     outgoing_goaway: OutgoingGoAway,
 
     /// Id of the next outgoing substream to open.
@@ -235,14 +235,14 @@ enum Outgoing {
 }
 
 enum OutgoingGoAway {
-    /// No "GoAway" frame has been sent or requested. Normal mode of operations.
+    /// No `GoAway` frame has been sent or requested. Normal mode of operations.
     NotRequired,
 
-    /// API user has asked to send a "GoAway" frame. This frame hasn't been queued into
-    /// [`Yamux::Outgoing`] yet.
+    /// API user has asked to send a `GoAway` frame. This frame hasn't been queued into
+    /// [`Yamux::outgoing`] yet.
     Required(GoAwayErrorCode),
 
-    /// A "GoAway" frame has been queued into [`Yamux::Outgoing`] in the past. It has been
+    /// A `GoAway` frame has been queued into [`Yamux::outgoing`] in the past. It has been
     /// possibly sent out, but this isn't tracked by this enum.
     QueuedOrSent,
 }
@@ -323,7 +323,7 @@ impl<T> Yamux<T> {
     /// checked by calling [`Yamux::received_goaway`].
     ///
     pub fn open_substream(&mut self, user_data: T) -> SubstreamMut<T> {
-        // It is forbidden to open new substreams if a "GoAway" frame has been received.
+        // It is forbidden to open new substreams if a `GoAway` frame has been received.
         assert!(self.received_goaway.is_none());
 
         // Make sure that the `loop` below can finish.
@@ -438,13 +438,13 @@ impl<T> Yamux<T> {
 
     /// Returns `true` if [`Yamux::send_goaway`] has been called in the past.
     ///
-    /// In other words, returns `true` if a "GoAway" frame has been either queued for sending
+    /// In other words, returns `true` if a `GoAway` frame has been either queued for sending
     /// (and is available through [`Yamux::extract_out`]) or has already been sent out.
     pub fn goaway_queued_or_sent(&self) -> bool {
         !matches!(self.outgoing_goaway, OutgoingGoAway::NotRequired)
     }
 
-    /// Queues a "GoAway" frame, requesting the remote to no longer open any substream.
+    /// Queues a `GoAway` frame, requesting the remote to no longer open any substream.
     ///
     /// If the state of [`Yamux`] is currently waiting for a confirmation to accept/reject a
     /// substream, then this function automatically implies calling
@@ -1705,7 +1705,7 @@ impl<'a, T> ExtractOut<'a, T> {
                 }
 
                 Outgoing::Idle => {
-                    // Send a "GoAway" frame if demanded.
+                    // Send a `GoAway` frame if demanded.
                     if let OutgoingGoAway::Required(code) = self.yamux.outgoing_goaway {
                         let mut header = arrayvec::ArrayVec::new();
                         header.push(0);
@@ -1933,8 +1933,9 @@ pub enum IncomingDataDetail {
     GoAway {
         /// Error code sent by the remote.
         code: GoAwayErrorCode,
-        /// List of all outgoing substreams that haven't been ACK'ed by the remote yet. These
-        /// substreams are considered as reset, similar to [`IncomingDataDetail::StreamReset`].
+        /// List of all outgoing substreams that haven't been acknowledged by the remote yet.
+        /// These substreams are considered as reset, similar to
+        /// [`IncomingDataDetail::StreamReset`].
         reset_substreams: Vec<SubstreamId>,
     },
 


### PR DESCRIPTION
This PR is a general clean-up of the single stream connection code. It fixes many small issues, and also handles the shutdown phase more properly.
We now properly handle incoming GoAway frames, and have the possibility to send some.

Can be reviewed commit by commit.
I understand that this code is generally extremely complicated, but I don't really have a good solution for this. Networking code *is* extremely complicated, both in terms of logic and implementation.
Maybe a solution is tests, such as https://github.com/paritytech/smoldot/pull/2323, but at the moment the code isn't even robust enough to have tests.
