### PR TITLE
Move erronous chain system to wasm-node code

### DIFF
--- a/bin/light-base/examples/basic.rs
+++ b/bin/light-base/examples/basic.rs
@@ -47,46 +47,36 @@ fn main() {
     let (json_rpc_responses_tx, mut json_rpc_responses_rx) = mpsc::channel(32);
 
     // Ask the client to connect to a chain.
-    let chain_id = client.add_chain(smoldot_light::AddChainConfig {
-        // The most important field of the configuration is the chain specification. This is a
-        // JSON document containing all the information necessary for the client to connect to said
-        // chain.
-        specification: include_str!("../../polkadot.json"),
+    let chain_id = client
+        .add_chain(smoldot_light::AddChainConfig {
+            // The most important field of the configuration is the chain specification. This is a
+            // JSON document containing all the information necessary for the client to connect to said
+            // chain.
+            specification: include_str!("../../polkadot.json"),
 
-        // See above.
-        // Note that it is possible to pass `None`, in which case the chain will not be able to
-        // handle JSON-RPC requests. This can be used to save up some resources.
-        json_rpc_responses: Some(json_rpc_responses_tx),
+            // See above.
+            // Note that it is possible to pass `None`, in which case the chain will not be able to
+            // handle JSON-RPC requests. This can be used to save up some resources.
+            json_rpc_responses: Some(json_rpc_responses_tx),
 
-        // This field is necessary only if adding a parachain.
-        potential_relay_chains: iter::empty(),
+            // This field is necessary only if adding a parachain.
+            potential_relay_chains: iter::empty(),
 
-        // After a chain has been added, it is possible to extract a "database" (in the form of a
-        // simple string). This database can later be passed back the next time the same chain is
-        // added again.
-        // A database with an invalid format is simply ignored by the client.
-        // In this example, we don't use this feature, and as such we simply pass an empty string,
-        // which is intentionally an invalid database content.
-        database_content: "",
+            // After a chain has been added, it is possible to extract a "database" (in the form of a
+            // simple string). This database can later be passed back the next time the same chain is
+            // added again.
+            // A database with an invalid format is simply ignored by the client.
+            // In this example, we don't use this feature, and as such we simply pass an empty string,
+            // which is intentionally an invalid database content.
+            database_content: "",
 
-        // The client gives the possibility to insert an opaque "user data" alongside each chain.
-        // This avoids having to create a separate `HashMap<ChainId, ...>` in parallel of the
-        // client.
-        // In this example, this feature isn't used. The chain simply has `()`.
-        user_data: (),
-    });
-
-    // The `add_chain` function doesn't return a `Result`. Instead, a chain that has failed
-    // initialization still exists but in an "erroneous" state. Before continuing, we need to
-    // check whether the chain is in this erroneous state.
-    if let Some(error_msg) = client.chain_is_erroneous(chain_id) {
-        // Chains in an erroneous state must be removed using `remove_chain`.
-        // Note that this doesn't matter so much here because we end up panicking, but if we
-        // didn't panic it would important to call `remove_chain`.
-        let error_msg = error_msg.to_owned();
-        let _ = client.remove_chain(chain_id);
-        panic!("Error while creating chain: {}", error_msg);
-    }
+            // The client gives the possibility to insert an opaque "user data" alongside each chain.
+            // This avoids having to create a separate `HashMap<ChainId, ...>` in parallel of the
+            // client.
+            // In this example, this feature isn't used. The chain simply has `()`.
+            user_data: (),
+        })
+        .unwrap();
 
     // The chain is now properly initialized.
 

--- a/bin/wasm-node/rust/src/init.rs
+++ b/bin/wasm-node/rust/src/init.rs
@@ -38,6 +38,14 @@ pub(crate) struct Client<TPlat: smoldot_light::platform::Platform, TChain> {
     pub(crate) smoldot: smoldot_light::Client<TPlat, TChain>,
 
     pub(crate) new_tasks_spawner: mpsc::UnboundedSender<(String, future::BoxFuture<'static, ()>)>,
+
+    /// List of all chains that have been added by the user.
+    pub(crate) chains: slab::Slab<Chain>,
+}
+
+pub(crate) enum Chain {
+    Healthy(smoldot_light::ChainId),
+    Erroneous { error: String },
 }
 
 pub(crate) fn init<TPlat: smoldot_light::platform::Platform, TChain>(
@@ -184,6 +192,7 @@ pub(crate) fn init<TPlat: smoldot_light::platform::Platform, TChain>(
     Client {
         smoldot: client,
         new_tasks_spawner: new_task_tx,
+        chains: slab::Slab::with_capacity(8),
     }
 }
 

--- a/bin/wasm-node/rust/src/lib.rs
+++ b/bin/wasm-node/rust/src/lib.rs
@@ -146,13 +146,17 @@ fn add_chain(
     // OOM errors. The threshold is completely empirical and should probably be updated
     // regularly to account for changes in the implementation.
     if alloc::total_alloc_bytes() >= usize::max_value() - 400 * 1024 * 1024 {
-        let chain_id = client_lock.as_mut().unwrap().smoldot.add_erroneous_chain(
-            "Wasm node is running low on memory and will prevent any new chain from being added"
-                .into(),
-            Vec::new(),
-        );
+        let chain_id = client_lock
+            .as_mut()
+            .unwrap()
+            .chains
+            .insert(init::Chain::Erroneous {
+            error:
+                "Wasm node is running low on memory and will prevent any new chain from being added"
+                    .into(),
+        });
 
-        return chain_id.into();
+        return u32::try_from(chain_id).unwrap();
     }
 
     // Retrieve the chain spec parameter passed through the FFI layer.
@@ -194,7 +198,19 @@ fn add_chain(
         raw_data
             .chunks(4)
             .map(|c| u32::from_le_bytes(<[u8; 4]>::try_from(c).unwrap()))
-            .map(smoldot_light::ChainId::from)
+            .filter_map(|c| {
+                if let Some(init::Chain::Healthy(id)) = client_lock
+                    .as_ref()
+                    .unwrap()
+                    .chains
+                    .get(usize::try_from(c).unwrap())
+                // TODO: don't unwrap here
+                {
+                    Some(*id)
+                } else {
+                    None
+                }
+            })
             .collect()
     };
 
@@ -218,24 +234,42 @@ fn add_chain(
     };
 
     // Insert the chain in the client.
-    let chain_id = client_lock
+    let smoldot_chain_id =
+        match client_lock
+            .as_mut()
+            .unwrap()
+            .smoldot
+            .add_chain(smoldot_light::AddChainConfig {
+                user_data: abort_handle.into_iter().collect(),
+                specification: str::from_utf8(&chain_spec).unwrap(),
+                database_content: str::from_utf8(&database_content).unwrap(),
+                json_rpc_responses,
+                potential_relay_chains: potential_relay_chains.into_iter(),
+            }) {
+            Ok(c) => c,
+            Err(error) => {
+                let chain_id = client_lock
+                    .as_mut()
+                    .unwrap()
+                    .chains
+                    .insert(init::Chain::Erroneous { error });
+
+                return u32::try_from(chain_id).unwrap();
+            }
+        };
+
+    let outer_chain_id = client_lock
         .as_mut()
         .unwrap()
-        .smoldot
-        .add_chain(smoldot_light::AddChainConfig {
-            user_data: abort_handle.into_iter().collect(),
-            specification: str::from_utf8(&chain_spec).unwrap(),
-            database_content: str::from_utf8(&database_content).unwrap(),
-            json_rpc_responses,
-            potential_relay_chains: potential_relay_chains.into_iter(),
-        });
+        .chains
+        .insert(init::Chain::Healthy(smoldot_chain_id));
 
     // Spawn the task if necessary.
     // See explanations above.
     if let Some((mut responses_rx, abort_registration)) = responses_rx_and_reg {
         let messages_out_task = async move {
             while let Some(response) = responses_rx.next().await {
-                emit_json_rpc_response(&response, chain_id);
+                emit_json_rpc_response(&response, outer_chain_id);
             }
         };
 
@@ -252,17 +286,23 @@ fn add_chain(
             .unwrap();
     }
 
-    chain_id.into()
+    u32::try_from(outer_chain_id).unwrap()
 }
 
 fn remove_chain(chain_id: u32) {
     let mut client_lock = CLIENT.lock().unwrap();
 
-    let abort_handles = client_lock
+    let abort_handles = match client_lock
         .as_mut()
         .unwrap()
-        .smoldot
-        .remove_chain(smoldot_light::ChainId::from(chain_id));
+        .chains
+        .remove(usize::try_from(chain_id).unwrap())
+    {
+        init::Chain::Healthy(inner_id) => {
+            client_lock.as_mut().unwrap().smoldot.remove_chain(inner_id)
+        }
+        init::Chain::Erroneous { .. } => Vec::new(),
+    };
 
     // Abort the tasks that retrieve the database content or poll the channel and send out the
     // JSON-RPC responses. This prevents any database callback from being called, and any new
@@ -277,47 +317,53 @@ fn remove_chain(chain_id: u32) {
 }
 
 fn chain_is_ok(chain_id: u32) -> u32 {
-    let mut client_lock = CLIENT.lock().unwrap();
-    if client_lock
-        .as_mut()
-        .unwrap()
-        .smoldot
-        .chain_is_erroneous(smoldot_light::ChainId::from(chain_id))
-        .is_some()
-    {
-        0
-    } else {
+    let client_lock = CLIENT.lock().unwrap();
+    if matches!(
+        client_lock
+            .as_ref()
+            .unwrap()
+            .chains
+            .get(usize::try_from(chain_id).unwrap())
+            .unwrap(),
+        init::Chain::Healthy(_)
+    ) {
         1
+    } else {
+        0
     }
 }
 
 fn chain_error_len(chain_id: u32) -> u32 {
-    let mut client_lock = CLIENT.lock().unwrap();
-    let len = client_lock
-        .as_mut()
+    let client_lock = CLIENT.lock().unwrap();
+    match client_lock
+        .as_ref()
         .unwrap()
-        .smoldot
-        .chain_is_erroneous(smoldot_light::ChainId::from(chain_id))
-        .map(|msg| msg.as_bytes().len())
-        .unwrap_or(0);
-    u32::try_from(len).unwrap()
+        .chains
+        .get(usize::try_from(chain_id).unwrap())
+        .unwrap()
+    {
+        init::Chain::Healthy(_) => 0,
+        init::Chain::Erroneous { error } => u32::try_from(error.as_bytes().len()).unwrap(),
+    }
 }
 
 fn chain_error_ptr(chain_id: u32) -> u32 {
-    let mut client_lock = CLIENT.lock().unwrap();
-    let ptr = client_lock
-        .as_mut()
+    let client_lock = CLIENT.lock().unwrap();
+    match client_lock
+        .as_ref()
         .unwrap()
-        .smoldot
-        .chain_is_erroneous(smoldot_light::ChainId::from(chain_id))
-        .map(|msg| msg.as_bytes().as_ptr() as usize)
-        .unwrap_or(0);
-    u32::try_from(ptr).unwrap()
+        .chains
+        .get(usize::try_from(chain_id).unwrap())
+        .unwrap()
+    {
+        init::Chain::Healthy(_) => 0,
+        init::Chain::Erroneous { error } => {
+            u32::try_from(error.as_bytes().as_ptr() as usize).unwrap()
+        }
+    }
 }
 
 fn json_rpc_send(ptr: u32, len: u32, chain_id: u32) {
-    let chain_id = smoldot_light::ChainId::from(chain_id);
-
     let json_rpc_request: Box<[u8]> = {
         let ptr = usize::try_from(ptr).unwrap();
         let len = usize::try_from(len).unwrap();
@@ -328,27 +374,42 @@ fn json_rpc_send(ptr: u32, len: u32, chain_id: u32) {
     let json_rpc_request: String = String::from_utf8(json_rpc_request.into()).unwrap();
 
     let mut client_lock = CLIENT.lock().unwrap();
+    let client_chain_id = match client_lock
+        .as_ref()
+        .unwrap()
+        .chains
+        .get(usize::try_from(chain_id).unwrap())
+        .unwrap()
+    {
+        init::Chain::Healthy(id) => *id,
+        init::Chain::Erroneous { .. } => panic!(),
+    };
 
     if let Err(err) = client_lock
         .as_mut()
         .unwrap()
         .smoldot
-        .json_rpc_request(json_rpc_request, chain_id)
+        .json_rpc_request(json_rpc_request, client_chain_id)
     {
         if let Some(response) = err.into_json_rpc_error() {
-            emit_json_rpc_response(&response, chain_id);
+            emit_json_rpc_response(&response, usize::try_from(chain_id).unwrap());
         }
     }
 }
 
 fn database_content(chain_id: u32, max_size: u32) {
-    let client_chain_id = smoldot_light::ChainId::from(chain_id);
-
     let mut client_lock = CLIENT.lock().unwrap();
+
     let init::Client {
         smoldot: client,
         new_tasks_spawner,
+        chains,
     } = client_lock.as_mut().unwrap();
+
+    let client_chain_id = match chains.get(usize::try_from(chain_id).unwrap()).unwrap() {
+        init::Chain::Healthy(id) => *id,
+        init::Chain::Erroneous { .. } => panic!(),
+    };
 
     let task = {
         let max_size = usize::try_from(max_size).unwrap();
@@ -380,12 +441,12 @@ fn database_content(chain_id: u32, max_size: u32) {
         .unwrap();
 }
 
-fn emit_json_rpc_response(rpc: &str, chain_id: smoldot_light::ChainId) {
+fn emit_json_rpc_response(rpc: &str, chain_id: usize) {
     unsafe {
         bindings::json_rpc_respond(
             u32::try_from(rpc.as_bytes().as_ptr() as usize).unwrap(),
             u32::try_from(rpc.as_bytes().len()).unwrap(),
-            u32::from(chain_id),
+            u32::try_from(chain_id).unwrap(),
         );
     }
 }


### PR DESCRIPTION
Adding a chain can fail. If adding a chain fails, we need to report the reason for the failure to the user.
Unfortunately, it is rather difficult to pass a string from Rust to JavaScript. The best way to do so is for the JavaScript to call a Rust function that returns a pointer to said string.
And that's exactly what we do if chain initialization fails. If adding a chain fails, we still insert a chain but insert it in "erroneous" mode. When a chain is in erroneous mode, the error message is kept in memory and can be retrieved by the JavaScript. Once retrieved, the JavaScript calls another function that cleans up the chain.

Before this PR, this system was done in the `light-base` library.
Unfortunately, this leads to a rather weird API for the client. It is much more idiomatic if `add_chain()` simply returns a `Result`.
That's what this PR does.
The "erroneous chain" system described above is still present, but is now done entirely in the code of `wasm-node`, as this system is highly specific to the Wasm node.

The unfortunate consequence is that there is now an additional level of indirection. When the JavaScript for example wants to send a JSON-RPC request, we first look up the ID of the chain in a table to determine whether it's healthy and find the actual ID of the chain that the client manipulates. But I think the trade-off is worth it.
