### PR TITLE
Refactor parachains service

### DIFF
--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -197,10 +197,6 @@ impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
 
         match self.subscription_state {
             ParachainBackgroundState::NotSubscribed { ref mut subscribe_future, .. } => {
-
-        
-            log::debug!(target: &self.log_target, "Subscriptions <= Reset");
-
                 // While we wait for the `subscribe_future` future to be ready, we still need to
                 // process messages coming from the public API of the syncing service.
                 futures::select! {
@@ -280,6 +276,7 @@ impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
                         Some(n) => n,
                         None => {
                             // Recreate the channel.
+                            log::debug!(target: &self.log_target, "Subscriptions <= Reset");
                             self.subscription_state = ParachainBackgroundState::NotSubscribed {
                                 all_subscriptions: Vec::new(),
                                 subscribe_future: {
@@ -602,6 +599,7 @@ impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
                 // The relay chain runtime service has some kind of gap or issue and
                 // has discarded the runtime.
                 // Destroy the subscription to recreate the channel.
+                log::debug!(target: &self.log_target, "Subscriptions <= Reset");
                 self.subscription_state = ParachainBackgroundState::NotSubscribed {
                     all_subscriptions: Vec::new(),
                     subscribe_future: {

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -181,10 +181,9 @@ impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
         // Report to the outside any block in the `async_tree` that is now ready.
         self.advance_and_report_notifications().await;
 
-        let runtime_subscription = match self.subscription_state {
-            ParachainBackgroundState::Subscribed(ref mut s) => s,
+        match self.subscription_state {
             ParachainBackgroundState::NotSubscribed { .. } => {
-                
+
         self.subscription_state = ParachainBackgroundState::Subscribed({
             log::debug!(target: &self.log_target, "Subscriptions <= Reset");
 
@@ -273,8 +272,9 @@ impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
             }
         });
 
-        continue;
-    }};
+    }
+
+    ParachainBackgroundState::Subscribed(ref mut runtime_subscription) => {
 
             // Internal state check.
             debug_assert_eq!(
@@ -360,7 +360,7 @@ impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
                     self.process_network_event(network_event.unwrap())
                 }
             }
-    }
+    }}}
 }
 
     async fn process_foreground_message(&mut self, foreground_message: ToBackground) {

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -124,8 +124,8 @@ struct ParachainBackgroundTask<TPlat: Platform> {
     relay_chain_sync: Arc<runtime_service::RuntimeService<TPlat>>,
 
     /// Last-known finalized parachain header. Can be very old and obsolete.
-    /// Updated after we successfully fetch the parahead of a relay chain finalized block, and left
-    /// untouched if the fetch fails.
+    /// Updated after we successfully fetch the parachain head of a relay chain finalized block,
+    /// and left untouched if the fetch fails.
     /// Initialized to the parachain genesis block header.
     obsolete_finalized_parahead: Vec<u8>,
 
@@ -171,31 +171,31 @@ struct ParachainBackgroundTaskAfterSubscription<TPlat: Platform> {
     relay_chain_subscribe_all: runtime_service::Subscription<TPlat>,
 
     /// Hash of the best parachain that has been reported to the subscriptions.
-    /// `None` if and only if no finalized parahead is known yet.
+    /// `None` if and only if no finalized parachain head is known yet.
     reported_best_parahead_hash: Option<[u8; 32]>,
 
     /// Tree of relay chain blocks. Blocks are inserted when received from the relay chain
-    /// sync service. Once inside, their corresponding parahead is fetched. Once the parahead
-    /// is fetched, this parahead is reported to our subscriptions.
+    /// sync service. Once inside, their corresponding parachain head is fetched. Once the
+    /// parachain head is fetched, this parachain head is reported to our subscriptions.
     ///
     /// The root of the tree is a "virtual" block. It can be thought as the parent of the relay
     /// chain finalized block, but is there even if the relay chain finalized block is block 0.
     ///
-    /// All block in the tree has an associated parahead behind an `Option`. This `Option`
+    /// All block in the tree has an associated parachain head behind an `Option`. This `Option`
     /// always contains `Some`, except for the "virtual" root block for which it is `None`.
     ///
-    /// If the output finalized block has a parahead equal to `None`, it therefore means that
-    /// no finalized parahead is known yet.
+    /// If the output finalized block has a parachain head equal to `None`, it therefore means
+    /// that no finalized parachain head is known yet.
     /// Note that, when it is the case, `SubscribeAll` messages from the frontend are still
     /// answered with a single finalized block set to `obsolete_finalized_parahead`. Once a
     /// finalized parahead is known, it is important to reset all subscriptions.
     ///
-    /// The set of blocks in this tree whose parahead hasn't been fetched yet is the same as
-    /// the set of blocks that is maintained pinned on the runtime service. Blocks are unpinned
-    /// when their parahead fetching succeeds or when they are removed from the tree.
+    /// The set of blocks in this tree whose parachain block hasn't been fetched yet is the same
+    /// as the set of blocks that is maintained pinned on the runtime service. Blocks are unpinned
+    /// when their parachain head fetching succeeds or when they are removed from the tree.
     async_tree: async_tree::AsyncTree<TPlat::Instant, [u8; 32], Option<Vec<u8>>>,
 
-    /// List of in-progress parahead fetching operations.
+    /// List of in-progress parachain head fetching operations.
     ///
     /// The operations require some blocks to be pinned within the relay chain runtime service,
     /// which is guaranteed by the fact that `relay_chain_subscribe_all.new_blocks` stays
@@ -205,7 +205,7 @@ struct ParachainBackgroundTaskAfterSubscription<TPlat: Platform> {
         future::BoxFuture<'static, (async_tree::AsyncOpId, Result<Vec<u8>, ParaheadError>)>,
     >,
 
-    /// Future that is ready when we need to start a new parahead fetch operation.
+    /// Future that is ready when we need to start a new parachain head fetch operation.
     next_start_parahead_fetch: future::Either<future::Fuse<TPlat::Delay>, future::Pending<()>>,
 }
 
@@ -567,7 +567,7 @@ impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
         }
     }
 
-    /// Start fetching paraheads of new blocks whose parahead needs to be fetched.
+    /// Start fetching parachain headers of new blocks whose parachain block needs to be fetched.
     fn start_paraheads_fetch(&mut self) {
         let mut runtime_subscription = match &mut self.subscription_state {
             ParachainBackgroundState::NotSubscribed { .. } => return,

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -594,7 +594,8 @@ impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
                     break;
                 }
                 async_tree::NextNecessaryAsyncOp::NotReady { when: None } => {
-                    runtime_subscription.next_start_parahead_fetch = future::Either::Right(future::pending());
+                    runtime_subscription.next_start_parahead_fetch =
+                        future::Either::Right(future::pending());
                     break;
                 }
                 async_tree::NextNecessaryAsyncOp::Ready(op) => {

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -37,6 +37,64 @@ use smoldot::{
     sync::{all_forks::sources, para},
 };
 
+/// Starts a sync service background task to synchronize a parachain.
+pub(super) async fn start_parachain<TPlat: Platform>(
+    log_target: String,
+    chain_information: chain::chain_information::ValidChainInformation,
+    block_number_bytes: usize,
+    relay_chain_sync: Arc<runtime_service::RuntimeService<TPlat>>,
+    relay_chain_block_number_bytes: usize,
+    parachain_id: u32,
+    from_foreground: mpsc::Receiver<ToBackground>,
+    network_chain_index: usize,
+    from_network_service: stream::BoxStream<'static, network_service::Event>,
+) {
+    let task = {
+        let obsolete_finalized_parahead = chain_information
+            .as_ref()
+            .finalized_block_header
+            .scale_encoding_vec(block_number_bytes);
+
+        ParachainBackgroundTask {
+            log_target,
+            from_foreground,
+            block_number_bytes,
+            relay_chain_block_number_bytes,
+            parachain_id,
+            network_chain_index,
+            from_network_service: from_network_service.fuse(),
+            sync_sources: sources::AllForksSources::new(
+                40,
+                header::decode(&obsolete_finalized_parahead, block_number_bytes)
+                    .unwrap()
+                    .number,
+            ),
+            obsolete_finalized_parahead,
+            sync_sources_map: HashMap::with_capacity_and_hasher(0, fnv::FnvBuildHasher::default()),
+            subscription_state: ParachainBackgroundState::NotSubscribed {
+                all_subscriptions: Vec::new(),
+                subscribe_future: {
+                    let relay_chain_sync = relay_chain_sync.clone();
+                    async move {
+                        relay_chain_sync
+                            .subscribe_all(
+                                "parachain-sync",
+                                32,
+                                NonZeroUsize::new(usize::max_value()).unwrap(),
+                            )
+                            .await
+                    }
+                    .boxed()
+                    .fuse()
+                },
+            },
+            relay_chain_sync,
+        }
+    };
+
+    task.run().await;
+}
+
 /// Task that is running in the background.
 struct ParachainBackgroundTask<TPlat: Platform> {
     log_target: String,
@@ -131,64 +189,6 @@ struct ParachainBackgroundTaskAfterSubscription<TPlat: Platform> {
 
     /// Future that is ready when we need to wake up the `select!` below.
     wakeup_deadline: future::Either<future::Fuse<TPlat::Delay>, future::Pending<()>>,
-}
-
-/// Starts a sync service background task to synchronize a parachain.
-pub(super) async fn start_parachain<TPlat: Platform>(
-    log_target: String,
-    chain_information: chain::chain_information::ValidChainInformation,
-    block_number_bytes: usize,
-    relay_chain_sync: Arc<runtime_service::RuntimeService<TPlat>>,
-    relay_chain_block_number_bytes: usize,
-    parachain_id: u32,
-    from_foreground: mpsc::Receiver<ToBackground>,
-    network_chain_index: usize,
-    from_network_service: stream::BoxStream<'static, network_service::Event>,
-) {
-    let task = {
-        let obsolete_finalized_parahead = chain_information
-            .as_ref()
-            .finalized_block_header
-            .scale_encoding_vec(block_number_bytes);
-
-        ParachainBackgroundTask {
-            log_target,
-            from_foreground,
-            block_number_bytes,
-            relay_chain_block_number_bytes,
-            parachain_id,
-            network_chain_index,
-            from_network_service: from_network_service.fuse(),
-            sync_sources: sources::AllForksSources::new(
-                40,
-                header::decode(&obsolete_finalized_parahead, block_number_bytes)
-                    .unwrap()
-                    .number,
-            ),
-            obsolete_finalized_parahead,
-            sync_sources_map: HashMap::with_capacity_and_hasher(0, fnv::FnvBuildHasher::default()),
-            subscription_state: ParachainBackgroundState::NotSubscribed {
-                all_subscriptions: Vec::new(),
-                subscribe_future: {
-                    let relay_chain_sync = relay_chain_sync.clone();
-                    async move {
-                        relay_chain_sync
-                            .subscribe_all(
-                                "parachain-sync",
-                                32,
-                                NonZeroUsize::new(usize::max_value()).unwrap(),
-                            )
-                            .await
-                    }
-                    .boxed()
-                    .fuse()
-                },
-            },
-            relay_chain_sync,
-        }
-    };
-
-    task.run().await;
 }
 
 impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -188,7 +188,7 @@ struct ParachainBackgroundTaskAfterSubscription<TPlat: Platform> {
     /// that no finalized parachain head is known yet.
     /// Note that, when it is the case, `SubscribeAll` messages from the frontend are still
     /// answered with a single finalized block set to `obsolete_finalized_parahead`. Once a
-    /// finalized parahead is known, it is important to reset all subscriptions.
+    /// finalized parachain head is known, it is important to reset all subscriptions.
     ///
     /// The set of blocks in this tree whose parachain block hasn't been fetched yet is the same
     /// as the set of blocks that is maintained pinned on the runtime service. Blocks are unpinned

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -178,6 +178,9 @@ impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
         // Start fetching paraheads of new blocks whose parahead needs to be fetched.
         self.start_paraheads_fetch();
 
+        // Report to the outside any block in the `async_tree` that is now ready.
+        self.advance_and_report_notifications().await;
+
         let runtime_subscription = match self.subscription_state {
             ParachainBackgroundState::Subscribed(ref mut s) => s,
             ParachainBackgroundState::NotSubscribed { .. } => {
@@ -278,211 +281,6 @@ impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
                 runtime_subscription.reported_best_parahead_hash.is_some(),
                 runtime_subscription.async_tree.finalized_async_user_data().is_some()
             );
-
-            // Report to the outside any block in the `async_tree` that is now ready.
-            while let Some(update) = runtime_subscription.async_tree.try_advance_output() {
-                match update {
-                    async_tree::OutputUpdate::Finalized {
-                        async_op_user_data: new_finalized_parahead,
-                        former_finalized_async_op_user_data: former_finalized_parahead,
-                        pruned_blocks,
-                        ..
-                    } if *new_finalized_parahead != former_finalized_parahead => {
-                        debug_assert!(new_finalized_parahead.is_some());
-
-                        // If this is the first time (in this loop) a finalized parahead is known,
-                        // any `SubscribeAll` message that has been answered beforehand was
-                        // answered in a dummy way with a potentially obsolete finalized header.
-                        // For this reason, we reset all subscriptions to force all subscribers to
-                        // re-subscribe.
-                        if former_finalized_parahead.is_none() {
-                            runtime_subscription.all_subscriptions.clear();
-                        }
-
-                        let hash = header::hash_from_scale_encoded_header(
-                            new_finalized_parahead.as_ref().unwrap(),
-                        );
-
-                        self.obsolete_finalized_parahead = new_finalized_parahead.clone().unwrap();
-
-                        if let Ok(header) =
-                            header::decode(&self.obsolete_finalized_parahead, self.block_number_bytes)
-                        {
-                            self.sync_sources.set_finalized_block_height(header.number);
-                            // TODO: what about an `else`? does sync_sources leak if the block can't be decoded?
-                        }
-
-                        // Must unpin the pruned blocks if they haven't already been unpinned.
-                        for (_, hash, pruned_block_parahead) in pruned_blocks {
-                            if pruned_block_parahead.is_none() {
-                                runtime_subscription.relay_chain_subscribe_all
-                                    .unpin_block(&hash)
-                                    .await;
-                            }
-                        }
-
-                        log::debug!(
-                            target: &self.log_target,
-                            "Subscriptions <= ParablockFinalized(hash={})",
-                            HashDisplay(&hash)
-                        );
-
-                        let best_block_hash = runtime_subscription.async_tree
-                            .best_block_index()
-                            .map(|(_, parahead)| {
-                                header::hash_from_scale_encoded_header(parahead.as_ref().unwrap())
-                            })
-                            .unwrap_or(hash);
-                        runtime_subscription.reported_best_parahead_hash = Some(best_block_hash);
-
-                        // Elements in `all_subscriptions` are removed one by one and
-                        // inserted back if the channel is still open.
-                        for index in (0..runtime_subscription.all_subscriptions.len()).rev() {
-                            let mut sender = runtime_subscription.all_subscriptions.swap_remove(index);
-                            let notif = super::Notification::Finalized {
-                                hash,
-                                best_block_hash,
-                            };
-                            if sender.try_send(notif).is_ok() {
-                                runtime_subscription.all_subscriptions.push(sender);
-                            }
-                        }
-                    }
-                    async_tree::OutputUpdate::Finalized { .. }
-                    | async_tree::OutputUpdate::BestBlockChanged { .. } => {
-                        // Do not report anything to subscriptions if no finalized parahead is
-                        // known yet.
-                        let finalized_parahead = match runtime_subscription.async_tree.finalized_async_user_data() {
-                            Some(p) => p,
-                            None => continue,
-                        };
-
-                        // Calculate hash of the parablock corresponding to the new best relay
-                        // chain block.
-                        let parahash = header::hash_from_scale_encoded_header(
-                            runtime_subscription.async_tree
-                                .best_block_index()
-                                .map(|(_, b)| b.as_ref().unwrap())
-                                .unwrap_or(&finalized_parahead),
-                        );
-
-                        if runtime_subscription.reported_best_parahead_hash.as_ref() != Some(&parahash) {
-                            runtime_subscription.reported_best_parahead_hash = Some(parahash);
-
-                            log::debug!(
-                                target: &self.log_target,
-                                "Subscriptions <= BestBlockChanged(hash={})",
-                                HashDisplay(&parahash)
-                            );
-
-                            // Elements in `all_subscriptions` are removed one by one and
-                            // inserted back if the channel is still open.
-                            for index in (0..runtime_subscription.all_subscriptions.len()).rev() {
-                                let mut sender = runtime_subscription.all_subscriptions.swap_remove(index);
-                                let notif =
-                                    super::Notification::BestBlockChanged { hash: parahash };
-                                if sender.try_send(notif).is_ok() {
-                                    runtime_subscription.all_subscriptions.push(sender);
-                                }
-                            }
-                        }
-                    }
-                    async_tree::OutputUpdate::Block(block) => {
-                        // `block` borrows `async_tree`. We need to mutably access `async_tree`
-                        // below, so deconstruct `block` beforehand.
-                        let is_new_best = block.is_new_best;
-                        let scale_encoded_header: Vec<u8> =
-                            block.async_op_user_data.clone().unwrap();
-                        let parahash =
-                            header::hash_from_scale_encoded_header(&scale_encoded_header);
-                        let block_index = block.index;
-
-                        // Do not report anything to subscriptions if no finalized parahead is
-                        // known yet.
-                        let finalized_parahead = match runtime_subscription.async_tree.finalized_async_user_data() {
-                            Some(p) => p,
-                            None => continue,
-                        };
-
-                        // Do not report the new block if it has already been reported in the
-                        // past. This covers situations where the parahead is identical to the
-                        // relay chain's parent's parahead, but also situations where multiple
-                        // sibling relay chain blocks have the same parahead.
-                        if *finalized_parahead == scale_encoded_header
-                            || runtime_subscription.async_tree
-                                .input_iter_unordered()
-                                .filter(|item| item.id != block_index)
-                                .filter_map(|item| item.async_op_user_data)
-                                .any(|item| item.as_ref() == Some(&scale_encoded_header))
-                        {
-                            // While the parablock has already been reported, it is possible that
-                            // it becomes the new best block while it wasn't before, in which
-                            // case we should send a notification.
-                            if is_new_best
-                                && runtime_subscription.reported_best_parahead_hash.as_ref() != Some(&parahash)
-                            {
-                                runtime_subscription.reported_best_parahead_hash = Some(parahash);
-
-                                log::debug!(
-                                    target: &self.log_target,
-                                    "Subscriptions <= BestBlockChanged(hash={})",
-                                    HashDisplay(&parahash)
-                                );
-
-                                // Elements in `all_subscriptions` are removed one by one and
-                                // inserted back if the channel is still open.
-                                for index in (0..runtime_subscription.all_subscriptions.len()).rev() {
-                                    let mut sender = runtime_subscription.all_subscriptions.swap_remove(index);
-                                    let notif =
-                                        super::Notification::BestBlockChanged { hash: parahash };
-                                    if sender.try_send(notif).is_ok() {
-                                        runtime_subscription.all_subscriptions.push(sender);
-                                    }
-                                }
-                            }
-
-                            continue;
-                        }
-
-                        log::debug!(
-                            target: &self.log_target,
-                            "Subscriptions <= NewParablock(hash={})",
-                            HashDisplay(&parahash)
-                        );
-
-                        if is_new_best {
-                            runtime_subscription.reported_best_parahead_hash = Some(parahash);
-                        }
-
-                        let parent_hash = header::hash_from_scale_encoded_header(
-                            &runtime_subscription.async_tree
-                                .parent(block_index)
-                                .map(|idx| {
-                                    runtime_subscription.async_tree
-                                        .block_async_user_data(idx)
-                                        .unwrap()
-                                        .as_ref()
-                                        .unwrap()
-                                })
-                                .unwrap_or(&finalized_parahead),
-                        );
-
-                        // Elements in `all_subscriptions` are removed one by one and
-                        // inserted back if the channel is still open.
-                        for index in (0..runtime_subscription.all_subscriptions.len()).rev() {
-                            let mut sender = runtime_subscription.all_subscriptions.swap_remove(index);
-                            let notif = super::Notification::Block(super::BlockNotification {
-                                is_new_best,
-                                parent_hash,
-                                scale_encoded_header: scale_encoded_header.clone(),
-                            });
-                            if sender.try_send(notif).is_ok() {
-                                runtime_subscription.all_subscriptions.push(sender);
-                            }
-                        }
-                    }
-                }
-            }
 
             futures::select! {
                 () = &mut runtime_subscription.wakeup_deadline => {
@@ -860,6 +658,217 @@ impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
                 );
 
                 runtime_subscription.async_tree.async_op_failure(async_op_id, &TPlat::now());
+            }
+        }
+    }
+
+    async fn advance_and_report_notifications(&mut self) {
+        let runtime_subscription = match &mut self.subscription_state {
+            ParachainBackgroundState::NotSubscribed { .. } => return,
+            ParachainBackgroundState::Subscribed(s) => s,
+        };
+
+        while let Some(update) = runtime_subscription.async_tree.try_advance_output() {
+            match update {
+                async_tree::OutputUpdate::Finalized {
+                    async_op_user_data: new_finalized_parahead,
+                    former_finalized_async_op_user_data: former_finalized_parahead,
+                    pruned_blocks,
+                    ..
+                } if *new_finalized_parahead != former_finalized_parahead => {
+                    debug_assert!(new_finalized_parahead.is_some());
+
+                    // If this is the first time (in this loop) a finalized parahead is known,
+                    // any `SubscribeAll` message that has been answered beforehand was
+                    // answered in a dummy way with a potentially obsolete finalized header.
+                    // For this reason, we reset all subscriptions to force all subscribers to
+                    // re-subscribe.
+                    if former_finalized_parahead.is_none() {
+                        runtime_subscription.all_subscriptions.clear();
+                    }
+
+                    let hash = header::hash_from_scale_encoded_header(
+                        new_finalized_parahead.as_ref().unwrap(),
+                    );
+
+                    self.obsolete_finalized_parahead = new_finalized_parahead.clone().unwrap();
+
+                    if let Ok(header) =
+                        header::decode(&self.obsolete_finalized_parahead, self.block_number_bytes)
+                    {
+                        self.sync_sources.set_finalized_block_height(header.number);
+                        // TODO: what about an `else`? does sync_sources leak if the block can't be decoded?
+                    }
+
+                    // Must unpin the pruned blocks if they haven't already been unpinned.
+                    for (_, hash, pruned_block_parahead) in pruned_blocks {
+                        if pruned_block_parahead.is_none() {
+                            runtime_subscription.relay_chain_subscribe_all
+                                .unpin_block(&hash)
+                                .await;
+                        }
+                    }
+
+                    log::debug!(
+                        target: &self.log_target,
+                        "Subscriptions <= ParablockFinalized(hash={})",
+                        HashDisplay(&hash)
+                    );
+
+                    let best_block_hash = runtime_subscription.async_tree
+                        .best_block_index()
+                        .map(|(_, parahead)| {
+                            header::hash_from_scale_encoded_header(parahead.as_ref().unwrap())
+                        })
+                        .unwrap_or(hash);
+                    runtime_subscription.reported_best_parahead_hash = Some(best_block_hash);
+
+                    // Elements in `all_subscriptions` are removed one by one and
+                    // inserted back if the channel is still open.
+                    for index in (0..runtime_subscription.all_subscriptions.len()).rev() {
+                        let mut sender = runtime_subscription.all_subscriptions.swap_remove(index);
+                        let notif = super::Notification::Finalized {
+                            hash,
+                            best_block_hash,
+                        };
+                        if sender.try_send(notif).is_ok() {
+                            runtime_subscription.all_subscriptions.push(sender);
+                        }
+                    }
+                }
+                async_tree::OutputUpdate::Finalized { .. }
+                | async_tree::OutputUpdate::BestBlockChanged { .. } => {
+                    // Do not report anything to subscriptions if no finalized parahead is
+                    // known yet.
+                    let finalized_parahead = match runtime_subscription.async_tree.finalized_async_user_data() {
+                        Some(p) => p,
+                        None => continue,
+                    };
+
+                    // Calculate hash of the parablock corresponding to the new best relay
+                    // chain block.
+                    let parahash = header::hash_from_scale_encoded_header(
+                        runtime_subscription.async_tree
+                            .best_block_index()
+                            .map(|(_, b)| b.as_ref().unwrap())
+                            .unwrap_or(&finalized_parahead),
+                    );
+
+                    if runtime_subscription.reported_best_parahead_hash.as_ref() != Some(&parahash) {
+                        runtime_subscription.reported_best_parahead_hash = Some(parahash);
+
+                        log::debug!(
+                            target: &self.log_target,
+                            "Subscriptions <= BestBlockChanged(hash={})",
+                            HashDisplay(&parahash)
+                        );
+
+                        // Elements in `all_subscriptions` are removed one by one and
+                        // inserted back if the channel is still open.
+                        for index in (0..runtime_subscription.all_subscriptions.len()).rev() {
+                            let mut sender = runtime_subscription.all_subscriptions.swap_remove(index);
+                            let notif =
+                                super::Notification::BestBlockChanged { hash: parahash };
+                            if sender.try_send(notif).is_ok() {
+                                runtime_subscription.all_subscriptions.push(sender);
+                            }
+                        }
+                    }
+                }
+                async_tree::OutputUpdate::Block(block) => {
+                    // `block` borrows `async_tree`. We need to mutably access `async_tree`
+                    // below, so deconstruct `block` beforehand.
+                    let is_new_best = block.is_new_best;
+                    let scale_encoded_header: Vec<u8> =
+                        block.async_op_user_data.clone().unwrap();
+                    let parahash =
+                        header::hash_from_scale_encoded_header(&scale_encoded_header);
+                    let block_index = block.index;
+
+                    // Do not report anything to subscriptions if no finalized parahead is
+                    // known yet.
+                    let finalized_parahead = match runtime_subscription.async_tree.finalized_async_user_data() {
+                        Some(p) => p,
+                        None => continue,
+                    };
+
+                    // Do not report the new block if it has already been reported in the
+                    // past. This covers situations where the parahead is identical to the
+                    // relay chain's parent's parahead, but also situations where multiple
+                    // sibling relay chain blocks have the same parahead.
+                    if *finalized_parahead == scale_encoded_header
+                        || runtime_subscription.async_tree
+                            .input_iter_unordered()
+                            .filter(|item| item.id != block_index)
+                            .filter_map(|item| item.async_op_user_data)
+                            .any(|item| item.as_ref() == Some(&scale_encoded_header))
+                    {
+                        // While the parablock has already been reported, it is possible that
+                        // it becomes the new best block while it wasn't before, in which
+                        // case we should send a notification.
+                        if is_new_best
+                            && runtime_subscription.reported_best_parahead_hash.as_ref() != Some(&parahash)
+                        {
+                            runtime_subscription.reported_best_parahead_hash = Some(parahash);
+
+                            log::debug!(
+                                target: &self.log_target,
+                                "Subscriptions <= BestBlockChanged(hash={})",
+                                HashDisplay(&parahash)
+                            );
+
+                            // Elements in `all_subscriptions` are removed one by one and
+                            // inserted back if the channel is still open.
+                            for index in (0..runtime_subscription.all_subscriptions.len()).rev() {
+                                let mut sender = runtime_subscription.all_subscriptions.swap_remove(index);
+                                let notif =
+                                    super::Notification::BestBlockChanged { hash: parahash };
+                                if sender.try_send(notif).is_ok() {
+                                    runtime_subscription.all_subscriptions.push(sender);
+                                }
+                            }
+                        }
+
+                        continue;
+                    }
+
+                    log::debug!(
+                        target: &self.log_target,
+                        "Subscriptions <= NewParablock(hash={})",
+                        HashDisplay(&parahash)
+                    );
+
+                    if is_new_best {
+                        runtime_subscription.reported_best_parahead_hash = Some(parahash);
+                    }
+
+                    let parent_hash = header::hash_from_scale_encoded_header(
+                        &runtime_subscription.async_tree
+                            .parent(block_index)
+                            .map(|idx| {
+                                runtime_subscription.async_tree
+                                    .block_async_user_data(idx)
+                                    .unwrap()
+                                    .as_ref()
+                                    .unwrap()
+                            })
+                            .unwrap_or(&finalized_parahead),
+                    );
+
+                    // Elements in `all_subscriptions` are removed one by one and
+                    // inserted back if the channel is still open.
+                    for index in (0..runtime_subscription.all_subscriptions.len()).rev() {
+                        let mut sender = runtime_subscription.all_subscriptions.swap_remove(index);
+                        let notif = super::Notification::Block(super::BlockNotification {
+                            is_new_best,
+                            parent_hash,
+                            scale_encoded_header: scale_encoded_header.clone(),
+                        });
+                        if sender.try_send(notif).is_ok() {
+                            runtime_subscription.all_subscriptions.push(sender);
+                        }
+                    }
+                }
             }
         }
     }

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -42,16 +42,16 @@ struct ParachainBackgroundTask<TPlat: Platform> {
     /// Events coming from the networking service.
     from_network_service: stream::Fuse<stream::BoxStream<'static, network_service::Event>>,
 
-    // Last-known finalized parachain header. Can be very old and obsolete.
-    // Updated after we successfully fetch the parahead of a relay chain finalized block, and left
-    // untouched if the fetch fails.
-    // Initialized to the parachain genesis block header.
+    /// Last-known finalized parachain header. Can be very old and obsolete.
+    /// Updated after we successfully fetch the parahead of a relay chain finalized block, and left
+    /// untouched if the fetch fails.
+    /// Initialized to the parachain genesis block header.
     obsolete_finalized_parahead: Vec<u8>,
 
-    // State machine that tracks the list of parachain network sources and their known blocks.
+    /// State machine that tracks the list of parachain network sources and their known blocks.
     sync_sources: sources::AllForksSources<(PeerId, protocol::Role)>,
 
-    // Maps `PeerId`s to their indices within `sync_sources`.
+    /// Maps `PeerId`s to their indices within `sync_sources`.
     // TODO: use SipHasher
     sync_sources_map: HashMap<PeerId, sources::SourceId, fnv::FnvBuildHasher>,
 

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -97,13 +97,24 @@ pub(super) async fn start_parachain<TPlat: Platform>(
 
 /// Task that is running in the background.
 struct ParachainBackgroundTask<TPlat: Platform> {
+    /// Target to use for all logs.
     log_target: String,
 
+    /// Channel receiving message from the sync service frontend.
     from_foreground: mpsc::Receiver<ToBackground>,
 
+    /// Number of bytes to use to encode the parachain block numbers in headers.
     block_number_bytes: usize,
+
+    /// Number of bytes to use to encode the relay chain block numbers in headers.
     relay_chain_block_number_bytes: usize,
+
+    /// Id of the parachain registered within the relay chain. Chosen by the user.
     parachain_id: u32,
+
+    /// Index of the chain within the associated network service.
+    ///
+    /// Used to filter events from [`ParachainBackgroundTask::from_network_service`].
     network_chain_index: usize,
 
     /// Events coming from the networking service.
@@ -131,13 +142,17 @@ struct ParachainBackgroundTask<TPlat: Platform> {
 }
 
 enum ParachainBackgroundState<TPlat: Platform> {
+    /// Currently subscribing to the relay chain runtime service.
     NotSubscribed {
         /// List of senders that get notified when the tree of blocks is modified.
         all_subscriptions: Vec<mpsc::Sender<super::Notification>>,
 
+        /// Future when the subscription has finished.
         subscribe_future:
             future::Fuse<future::BoxFuture<'static, runtime_service::SubscribeAll<TPlat>>>,
     },
+
+    /// Subscribed to the relay chain runtime service.
     Subscribed(ParachainBackgroundTaskAfterSubscription<TPlat>),
 }
 

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -196,7 +196,7 @@ impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
         self.advance_and_report_notifications().await;
 
         match self.subscription_state {
-            ParachainBackgroundState::NotSubscribed { .. } => {
+            ParachainBackgroundState::NotSubscribed { ref mut subscribe_future, .. } => {
 
         
             log::debug!(target: &self.log_target, "Subscriptions <= Reset");
@@ -204,10 +204,7 @@ impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
                 // While we wait for the `subscribe_future` future to be ready, we still need to
                 // process messages coming from the public API of the syncing service.
                 futures::select! {
-                    relay_chain_subscribe_all = match self.subscription_state {
-                        ParachainBackgroundState::NotSubscribed { ref mut subscribe_future, .. } => subscribe_future,
-                        _ => unreachable!()
-                     } => {
+                    relay_chain_subscribe_all = &mut *subscribe_future => {
                         // Subscription finished.
                         log::debug!(
                             target: &self.log_target,

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -278,12 +278,6 @@ impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
 
     ParachainBackgroundState::Subscribed(ref mut runtime_subscription) => {
 
-            // Internal state check.
-            debug_assert_eq!(
-                runtime_subscription.reported_best_parahead_hash.is_some(),
-                runtime_subscription.async_tree.finalized_async_user_data().is_some()
-            );
-
             futures::select! {
                 () = &mut runtime_subscription.wakeup_deadline => {
                     // Do nothing. This is simply to wake up and loop again.
@@ -575,6 +569,12 @@ impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
             ParachainBackgroundState::NotSubscribed { .. } => return,
             ParachainBackgroundState::Subscribed(s) => s,
         };
+
+        // Internal state check.
+        debug_assert_eq!(
+            runtime_subscription.reported_best_parahead_hash.is_some(),
+            runtime_subscription.async_tree.finalized_async_user_data().is_some()
+        );
 
         while runtime_subscription.in_progress_paraheads.len() < 4 {
             match runtime_subscription.async_tree.next_necessary_async_op(&TPlat::now()) {

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -144,7 +144,10 @@ struct ParachainBackgroundTask<TPlat: Platform> {
 enum ParachainBackgroundState<TPlat: Platform> {
     /// Currently subscribing to the relay chain runtime service.
     NotSubscribed {
-        /// List of senders that get notified when the tree of blocks is modified.
+        /// List of senders that will get notified when the tree of blocks is modified.
+        ///
+        /// These subscriptions are pending and no notification should be sent to them until the
+        /// subscription to the relay chain runtime service is finished.
         all_subscriptions: Vec<mpsc::Sender<super::Notification>>,
 
         /// Future when the subscription has finished.
@@ -1027,6 +1030,7 @@ impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
                 &relay_chain_subscribe_all.finalized_block_scale_encoded_header
             ))
         );
+        log::debug!(target: &self.log_target, "ParaheadFetchOperations <= Clear");
 
         let async_tree = {
             let mut async_tree =
@@ -1051,8 +1055,6 @@ impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
             }
             async_tree
         };
-
-        log::debug!(target: &self.log_target, "ParaheadFetchOperations <= Clear");
 
         self.subscription_state =
             ParachainBackgroundState::Subscribed(ParachainBackgroundTaskAfterSubscription {


### PR DESCRIPTION
This PR refactors the parachains service to make it easier to read and understand.

No change to the logic has been performed.
Can be reviewed commit by commit. I've intentionally done `rustfmt`almost at the end in order to not pollute the diff.
