### PR TITLE
Bump smoldot to 0.4.0 and smoldot-light to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,7 +2257,7 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "smoldot"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arrayvec 0.7.2",
  "async-std",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-std",
  "blake2-rfc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Primitives to build a client for Substrate-based blockchains"
 repository = "https://github.com/paritytech/smoldot"

--- a/bin/full-node/Cargo.toml
+++ b/bin/full-node/Cargo.toml
@@ -30,7 +30,7 @@ hashbrown = { version = "0.12.3", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 mick-jaeger = "0.1.8"
 rand = "0.8.5"
-smoldot = { version = "0.3.0", path = "../..", default-features = false, features = ["database-sqlite", "std"] }
+smoldot = { version = "0.4.0", path = "../..", default-features = false, features = ["database-sqlite", "std"] }
 terminal_size = "0.2.1"
 tracing = { version = "0.1.36", features = ["attributes"] }
 tracing-subscriber = { version = "0.2.25", default-features = false, features = ["ansi", "chrono", "env-filter", "json", "fmt", "parking_lot", "smallvec"] }

--- a/bin/light-base/Cargo.toml
+++ b/bin/light-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Browser bindings to a light client for Substrate-based blockchains"
 repository = "https://github.com/paritytech/smoldot"
@@ -27,7 +27,7 @@ rand = "0.8.5"
 serde = { version = "1.0.144", default-features = false, features = ["alloc", "derive"] }
 serde_json = "1.0.85"
 slab = { version = "0.4.7", default-features = false }
-smoldot = { version = "0.3.0", path = "../..", default-features = false }
+smoldot = { version = "0.4.0", path = "../..", default-features = false }
 
 # `std` feature
 # Add here the crates that cannot function without the help of the operating system or environment.

--- a/bin/wasm-node/rust/Cargo.toml
+++ b/bin/wasm-node/rust/Cargo.toml
@@ -21,5 +21,5 @@ log = { version = "0.4.17", features = ["std"] }
 pin-project = "1.0.12"
 rand = "0.8.5"
 slab = { version = "0.4.7", default-features = false }
-smoldot = { version = "0.3.0", path = "../../..", default-features = false }
-smoldot-light = { version = "0.1.0", path = "../../light-base", default-features = false }
+smoldot = { version = "0.4.0", path = "../../..", default-features = false }
+smoldot-light = { version = "0.2.0", path = "../../light-base", default-features = false }


### PR DESCRIPTION
Releasing a new version of `smoldot-light` after the latest API changes.
I believe that the current API is now not bad and stable-ish for now. Changes to the `Platform` trait might happen again, but not in the very short term.
