### PR TITLE
Add a limit to the number of inbound substreams

### DIFF
--- a/bin/fuzz/fuzz_targets/network-connection-encrypted.rs
+++ b/bin/fuzz/fuzz_targets/network-connection-encrypted.rs
@@ -141,6 +141,7 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
         handshake::Handshake::Success { connection, .. } => connection
             .into_connection::<_, (), ()>(Config {
                 first_out_ping: Duration::new(60, 0),
+                max_inbound_substreams: 10,
                 notifications_protocols: Vec::new(),
                 request_protocols: vec![ConfigRequestResponse {
                     inbound_allowed: true,

--- a/bin/fuzz/fuzz_targets/network-connection-raw.rs
+++ b/bin/fuzz/fuzz_targets/network-connection-raw.rs
@@ -34,6 +34,7 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
         smoldot::libp2p::collection::Network::new(smoldot::libp2p::collection::Config {
             randomness_seed: [0; 32],
             capacity: 0,
+            max_inbound_substreams: 10,
             notification_protocols: Vec::new(),
             request_response_protocols: Vec::new(),
             // This timeout doesn't matter as we pass dummy time values.

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- A limit to the number of substreams a remote can maintain open over a connection is now enforced. ([#2724](https://github.com/paritytech/smoldot/pull/2724))
+
 ## 0.6.32 - 2022-09-07
 
 ### Fixed

--- a/src/libp2p/collection/multi_stream.rs
+++ b/src/libp2p/collection/multi_stream.rs
@@ -92,6 +92,7 @@ where
     pub(super) fn new(
         randomness_seed: [u8; 32],
         now: TNow,
+        max_inbound_substreams: usize,
         notification_protocols: Arc<[OverlayNetwork]>,
         request_response_protocols: Arc<[ConfigRequestResponse]>,
         ping_protocol: Arc<str>,
@@ -108,6 +109,7 @@ where
                         })
                         .collect(),
                     request_protocols: request_response_protocols.to_vec(), // TODO: overhead
+                    max_inbound_substreams,
                     randomness_seed,
                     ping_protocol: ping_protocol.to_string(), // TODO: cloning :-/
                     ping_interval: Duration::from_secs(20),   // TODO: hardcoded

--- a/src/libp2p/collection/single_stream.rs
+++ b/src/libp2p/collection/single_stream.rs
@@ -64,6 +64,9 @@ enum SingleStreamConnectionTaskInner<TNow> {
         /// See [`super::Config::noise_key`].
         noise_key: Arc<NoiseKey>,
 
+        /// See [`super::Config::max_inbound_substreams`].
+        max_inbound_substreams: usize,
+
         /// See [`OverlayNetwork`].
         notification_protocols: Arc<[OverlayNetwork]>,
 
@@ -130,6 +133,7 @@ where
         is_initiator: bool,
         handshake_timeout: TNow,
         noise_key: Arc<NoiseKey>,
+        max_inbound_substreams: usize,
         notification_protocols: Arc<[OverlayNetwork]>,
         request_response_protocols: Arc<[ConfigRequestResponse]>,
         ping_protocol: Arc<str>,
@@ -140,6 +144,7 @@ where
                 randomness_seed,
                 timeout: handshake_timeout,
                 noise_key,
+                max_inbound_substreams,
                 notification_protocols,
                 request_response_protocols,
                 ping_protocol,
@@ -627,6 +632,7 @@ where
                 randomness_seed,
                 timeout,
                 noise_key,
+                max_inbound_substreams,
                 notification_protocols,
                 request_response_protocols,
                 ping_protocol,
@@ -690,6 +696,7 @@ where
                                 randomness_seed,
                                 timeout,
                                 noise_key,
+                                max_inbound_substreams,
                                 notification_protocols,
                                 request_response_protocols,
                                 ping_protocol,
@@ -718,6 +725,7 @@ where
                                         })
                                         .collect(),
                                     request_protocols: request_response_protocols.to_vec(), // TODO: overhead
+                                    max_inbound_substreams,
                                     randomness_seed,
                                     ping_protocol: ping_protocol.to_string(), // TODO: cloning :-/
                                     ping_interval: Duration::from_secs(20),   // TODO: hardcoded

--- a/src/libp2p/connection/established.rs
+++ b/src/libp2p/connection/established.rs
@@ -193,6 +193,8 @@ pub enum Event<TRqUd, TNotifUd> {
 // TODO: this struct isn't zero-cost, but making it zero-cost is kind of hard and annoying
 #[derive(Debug, Clone)]
 pub struct Config<TNow> {
+    /// Maximum number of substreams that the remote can have simultaneously opened.
+    pub max_inbound_substreams: usize,
     /// List of request-response protocols supported for incoming substreams.
     pub request_protocols: Vec<ConfigRequestResponse>,
     /// List of notifications protocols supported for incoming substreams.

--- a/src/libp2p/connection/established/multi_stream.rs
+++ b/src/libp2p/connection/established/multi_stream.rs
@@ -81,6 +81,9 @@ pub struct MultiStream<TNow, TSubId, TRqUd, TNotifUd> {
     /// unnecessary code being included in the binary and reduces the binary size.
     ping_payload_randomness: rand_chacha::ChaCha20Rng,
 
+    /// See [`Config::max_inbound_substreams`].
+    // TODO: not enforced at the moment
+    _max_inbound_substreams: usize,
     /// See [`Config::request_protocols`].
     request_protocols: Vec<ConfigRequestResponse>,
     /// See [`Config::notifications_protocols`].
@@ -139,6 +142,7 @@ where
             ping_substream: None,
             next_ping: config.first_out_ping,
             ping_payload_randomness: randomness,
+            _max_inbound_substreams: config.max_inbound_substreams,
             request_protocols: config.request_protocols,
             notifications_protocols: config.notifications_protocols,
             ping_protocol: config.ping_protocol,

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -80,6 +80,16 @@ pub struct Config {
     /// Capacity to initially reserve to the list of peers.
     pub peers_capacity: usize,
 
+    /// Maximum number of substreams that each remote can have simultaneously opened on each
+    /// connection.
+    ///
+    /// If there exists multiple connections with the same remote, the limit is enforced for
+    /// each connection separately.
+    ///
+    /// > **Note**: This limit is necessary in order to avoid DoS attacks where a remote opens too
+    /// >           many substreams.
+    pub max_inbound_substreams: usize,
+
     pub notification_protocols: Vec<NotificationProtocolConfig>,
 
     pub request_response_protocols: Vec<ConfigRequestResponse>,
@@ -206,6 +216,7 @@ where
             inner: collection::Network::new(collection::Config {
                 capacity: config.connections_capacity,
                 noise_key: config.noise_key,
+                max_inbound_substreams: config.max_inbound_substreams,
                 notification_protocols: config.notification_protocols,
                 request_response_protocols: config.request_response_protocols,
                 ping_protocol: config.ping_protocol,

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -379,10 +379,21 @@ where
             })
             .collect::<Vec<_>>();
 
+        // Maximum number that each remote is allowed to open.
+        // Note that this maximum doesn't have to be precise. There only needs to be *a* limit
+        // that is not exaggerately large, and this limit shouldn't be too low as to cause
+        // legitimate substreams to be refused.
+        // According to the protocol, a remote can only open one substream of each protocol at
+        // a time. However, we multiply this value by 2 in order to be generous. We also add 1
+        // to account for the ping protocol.
+        let max_inbound_substreams = chains.len()
+            * (1 + REQUEST_RESPONSE_PROTOCOLS_PER_CHAIN + NOTIFICATIONS_PROTOCOLS_PER_CHAIN) * 2;
+
         ChainNetwork {
             inner: peers::Peers::new(peers::Config {
                 connections_capacity: config.connections_capacity,
                 peers_capacity: config.peers_capacity,
+                max_inbound_substreams,
                 request_response_protocols,
                 noise_key: config.noise_key,
                 randomness_seed: randomness.sample(rand::distributions::Standard),

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -387,7 +387,8 @@ where
         // a time. However, we multiply this value by 2 in order to be generous. We also add 1
         // to account for the ping protocol.
         let max_inbound_substreams = chains.len()
-            * (1 + REQUEST_RESPONSE_PROTOCOLS_PER_CHAIN + NOTIFICATIONS_PROTOCOLS_PER_CHAIN) * 2;
+            * (1 + REQUEST_RESPONSE_PROTOCOLS_PER_CHAIN + NOTIFICATIONS_PROTOCOLS_PER_CHAIN)
+            * 2;
 
         ChainNetwork {
             inner: peers::Peers::new(peers::Config {


### PR DESCRIPTION
In order to avoid DoS attacks, it is important to prevent remotes from opening an unlimited number of substreams.
