### PR TITLE
Perform the multi-stream connections handshake inside smoldot

### DIFF
--- a/bin/light-base/src/network_service/tasks.rs
+++ b/bin/light-base/src/network_service/tasks.rs
@@ -122,13 +122,10 @@ pub(super) async fn connection_task<TPlat: Platform>(
                 .pending_outcome_ok_single_stream(start_connect.id);
             (id, either::Left((socket, task)))
         }
-        PlatformConnection::MultiStream(socket, peer_id) => {
-            let (id, task) = guarded.network.pending_outcome_ok_multi_stream(
-                start_connect.id,
-                TPlat::now(),
-                &peer_id,
-            );
-
+        PlatformConnection::MultiStream(socket) => {
+            let (id, task) = guarded
+                .network
+                .pending_outcome_ok_multi_stream(start_connect.id);
             (id, either::Right((socket, task)))
         }
     };

--- a/bin/light-base/src/platform.rs
+++ b/bin/light-base/src/platform.rs
@@ -18,7 +18,6 @@
 use alloc::string::String;
 use core::{ops, str, time::Duration};
 use futures::prelude::*;
-use smoldot::libp2p::peer_id::PeerId;
 
 pub mod async_std;
 
@@ -136,7 +135,7 @@ pub enum PlatformConnection<TStream, TConnection> {
     SingleStream(TStream),
     /// The connection is made of multiple substreams. The encryption and multiplexing are handled
     /// externally.
-    MultiStream(TConnection, PeerId),
+    MultiStream(TConnection),
 }
 
 /// Direction in which a substream has been opened. See [`Platform::next_substream`].

--- a/bin/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
+++ b/bin/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
@@ -131,7 +131,7 @@ export interface ConnectionConfig {
      *
      * Must only be called once per connection.
      */
-    onOpen: (info: { type: 'single-stream' } | { type: 'multi-stream', peerId: Uint8Array }) => void;
+    onOpen: (info: { type: 'single-stream' } | { type: 'multi-stream' }) => void;
 
     /**
      * Callback called when the connection transitions to the `Closed` state.
@@ -328,9 +328,7 @@ export default function (config: Config): { imports: WebAssembly.ModuleImports, 
                                     break
                                 }
                                 case 'multi-stream': {
-                                    const ptr = instance.exports.alloc(info.peerId.length) >>> 0;
-                                    new Uint8Array(instance.exports.memory.buffer).set(info.peerId, ptr);
-                                    instance.exports.connection_open_multi_stream(connectionId, ptr, info.peerId.length);
+                                    instance.exports.connection_open_multi_stream(connectionId);
                                     break
                                 }
                             }

--- a/bin/wasm-node/javascript/src/instance/bindings.ts
+++ b/bin/wasm-node/javascript/src/instance/bindings.ts
@@ -35,7 +35,7 @@ export interface SmoldotWasmExports extends WebAssembly.Exports {
     database_content: (chainId: number, maxSize: number) => void,
     timer_finished: (timerId: number) => void,
     connection_open_single_stream: (connectionId: number) => void,
-    connection_open_multi_stream: (connectionId: number, peerIdPtr: number, peerIdLen: number) => void,
+    connection_open_multi_stream: (connectionId: number) => void,
     stream_message: (connectionId: number, streamId: number, ptr: number, len: number) => void,
     connection_stream_opened: (connectionId: number, streamId: number, outbound: number) => void,
     connection_closed: (connectionId: number, ptr: number, len: number) => void,

--- a/bin/wasm-node/rust/src/bindings.rs
+++ b/bin/wasm-node/rust/src/bindings.rs
@@ -465,24 +465,14 @@ pub extern "C" fn connection_open_single_stream(connection_id: u32) {
 ///
 /// See also [`connection_new`].
 ///
-/// The API user is responsible for determining the identity of the remote as part of the opening
-/// process of the connection. This identity must then be provided in the form of the binary
-/// representation of a peer ID, through `peer_id_ptr` and `peer_id_len`.
-/// See <https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md#peer-ids> for a
-/// definition of the binary representation of a peer ID.
-/// The buffer **must** have been allocated with [`alloc`]. It is freed when this function is
-/// called.
-///
 /// When in the `Open` state, the connection can receive messages. When a message is received,
 /// [`alloc`] must be called in order to allocate memory for this message, then
 /// [`stream_message`] must be called with the pointer returned by [`alloc`].
 #[no_mangle]
 pub extern "C" fn connection_open_multi_stream(
     connection_id: u32,
-    peer_id_ptr: u32,
-    peer_id_len: u32,
 ) {
-    crate::platform::connection_open_multi_stream(connection_id, peer_id_ptr, peer_id_len)
+    crate::platform::connection_open_multi_stream(connection_id)
 }
 
 /// Notify of a message being received on the stream. The connection associated with that stream

--- a/bin/wasm-node/rust/src/bindings.rs
+++ b/bin/wasm-node/rust/src/bindings.rs
@@ -469,9 +469,7 @@ pub extern "C" fn connection_open_single_stream(connection_id: u32) {
 /// [`alloc`] must be called in order to allocate memory for this message, then
 /// [`stream_message`] must be called with the pointer returned by [`alloc`].
 #[no_mangle]
-pub extern "C" fn connection_open_multi_stream(
-    connection_id: u32,
-) {
+pub extern "C" fn connection_open_multi_stream(connection_id: u32) {
     crate::platform::connection_open_multi_stream(connection_id)
 }
 

--- a/src/libp2p/collection.rs
+++ b/src/libp2p/collection.rs
@@ -377,8 +377,9 @@ where
 
     /// Adds a new multi-stream connection to the collection.
     ///
-    /// Note that no [`Event::HandshakeFinished`] event will be generated. The connection is
-    /// immediately considered as fully established.
+    /// Must be passed the moment (as a `TNow`) when the connection as been established, in order
+    /// to determine when the handshake timeout expires.
+    // TODO: add an is_initiator parameter? right now we're always implicitly the initiator
     pub fn insert_multi_stream<TSubId>(
         &mut self,
         now: TNow,
@@ -394,6 +395,7 @@ where
             self.randomness_seeds.gen(),
             now,
             self.max_inbound_substreams,
+            self.noise_key.clone(),
             self.notification_protocols.clone(),
             self.request_response_protocols.clone(),
             self.ping_protocol.clone(),

--- a/src/libp2p/collection/multi_stream.rs
+++ b/src/libp2p/collection/multi_stream.rs
@@ -145,14 +145,6 @@ where
                 })),
             },
         }
-
-        /*
-        TODO: old code:
-
-
-
-
-        */
     }
 
     /// Pulls a message to send back to the coordinator.

--- a/src/libp2p/collection/multi_stream.rs
+++ b/src/libp2p/collection/multi_stream.rs
@@ -16,10 +16,13 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::{
-    super::{connection::established, read_write::ReadWrite},
+    super::{
+        connection::{established, noise},
+        read_write::ReadWrite,
+    },
     ConfigRequestResponse, ConnectionToCoordinator, ConnectionToCoordinatorInner,
     CoordinatorToConnection, CoordinatorToConnectionInner, NotificationsOutErr, OverlayNetwork,
-    ShutdownCause, SubstreamId,
+    PeerId, ShutdownCause, SubstreamId,
 };
 
 use alloc::{string::ToString as _, sync::Arc};
@@ -35,10 +38,31 @@ pub struct MultiStreamConnectionTask<TNow, TSubId> {
     connection: MultiStreamConnectionTaskInner<TNow, TSubId>,
 }
 enum MultiStreamConnectionTaskInner<TNow, TSubId> {
+    /// Connection is still in its handshake phase.
+    Handshake {
+        /// Substream that has been opened to perform the handshake, if any.
+        opened_substream: Option<TSubId>,
+
+        /// Noise handshake in progress. Always `Some`, except to be temporarily extracted.
+        handshake: Option<noise::HandshakeInProgress>,
+
+        /// State machine used once the connection has been established. Unused during the
+        /// handshake, but created ahead of time. Always `Some`, except to be temporarily
+        /// extracted.
+        established: Option<established::MultiStream<TNow, TSubId, SubstreamId, ()>>,
+    },
+
     /// Connection has been fully established.
     Established {
         // TODO: user data of request redundant with the substreams mapping below
         established: established::MultiStream<TNow, TSubId, SubstreamId, ()>,
+
+        /// If `Some`, contains the substream that was used for the handshake. This substream
+        /// is meant to be closed as soon as possible.
+        handshake_substream: Option<TSubId>,
+
+        /// If `Some`, then no `HandshakeFinished` message has been sent back yet.
+        handshake_finished_message_to_send: Option<PeerId>,
 
         /// Because outgoing substream ids are assigned by the coordinator, we maintain a mapping
         /// of the "outer ids" to "inner ids".
@@ -93,13 +117,16 @@ where
         randomness_seed: [u8; 32],
         now: TNow,
         max_inbound_substreams: usize,
+        noise_key: Arc<noise::NoiseKey>,
         notification_protocols: Arc<[OverlayNetwork]>,
         request_response_protocols: Arc<[ConfigRequestResponse]>,
         ping_protocol: Arc<str>,
     ) -> Self {
         MultiStreamConnectionTask {
-            connection: MultiStreamConnectionTaskInner::Established {
-                established: established::MultiStream::new(established::Config {
+            connection: MultiStreamConnectionTaskInner::Handshake {
+                handshake: Some(noise::HandshakeInProgress::new(&noise_key, true)), // TODO: is_initiator?
+                opened_substream: None,
+                established: Some(established::MultiStream::new(established::Config {
                     notifications_protocols: notification_protocols
                         .iter()
                         .map(|net| established::ConfigNotifications {
@@ -115,17 +142,17 @@ where
                     ping_interval: Duration::from_secs(20),   // TODO: hardcoded
                     ping_timeout: Duration::from_secs(10),    // TODO: hardcoded
                     first_out_ping: now + Duration::from_secs(2), // TODO: hardcoded
-                }),
-                outbound_substreams_map: hashbrown::HashMap::with_capacity_and_hasher(
-                    0,
-                    Default::default(),
-                ), // TODO: capacity?
-                outbound_substreams_reverse: hashbrown::HashMap::with_capacity_and_hasher(
-                    0,
-                    Default::default(),
-                ), // TODO: capacity?
+                })),
             },
         }
+
+        /*
+        TODO: old code:
+
+
+
+
+        */
     }
 
     /// Pulls a message to send back to the coordinator.
@@ -164,11 +191,23 @@ where
         mut self,
     ) -> (Option<Self>, Option<ConnectionToCoordinator>) {
         match &mut self.connection {
+            MultiStreamConnectionTaskInner::Handshake { .. } => (Some(self), None),
             MultiStreamConnectionTaskInner::Established {
                 established,
                 outbound_substreams_map,
                 outbound_substreams_reverse,
+                handshake_finished_message_to_send,
+                ..
             } => {
+                if let Some(remote_peer_id) = handshake_finished_message_to_send.take() {
+                    return (
+                        Some(self),
+                        Some(ConnectionToCoordinator {
+                            inner: ConnectionToCoordinatorInner::HandshakeFinished(remote_peer_id),
+                        }),
+                    );
+                }
+
                 let event = match established.pull_event() {
                     Some(established::Event::NewOutboundSubstreamsForbidden) => {
                         // TODO: handle properly
@@ -307,6 +346,7 @@ where
                     established,
                     outbound_substreams_map,
                     outbound_substreams_reverse,
+                    ..
                 },
             ) => {
                 let inner_substream_id =
@@ -328,6 +368,7 @@ where
                     established,
                     outbound_substreams_map,
                     outbound_substreams_reverse,
+                    ..
                 },
             ) => {
                 let inner_substream_id = established.open_notifications_substream(
@@ -350,6 +391,7 @@ where
                     established,
                     outbound_substreams_map,
                     outbound_substreams_reverse,
+                    ..
                 },
             ) => {
                 // It is possible that the remote has closed the outbound notification substream
@@ -414,7 +456,8 @@ where
             }
             (
                 CoordinatorToConnectionInner::StartShutdown { .. },
-                MultiStreamConnectionTaskInner::Established { .. },
+                MultiStreamConnectionTaskInner::Handshake { .. }
+                | MultiStreamConnectionTaskInner::Established { .. },
             ) => {
                 // TODO: implement proper shutdown
                 self.connection = MultiStreamConnectionTaskInner::ShutdownWaitingAck {
@@ -431,7 +474,8 @@ where
                 | CoordinatorToConnectionInner::OpenOutNotifications { .. }
                 | CoordinatorToConnectionInner::CloseOutNotifications { .. }
                 | CoordinatorToConnectionInner::QueueNotification { .. },
-                MultiStreamConnectionTaskInner::ShutdownAcked { .. },
+                MultiStreamConnectionTaskInner::Handshake { .. }
+                | MultiStreamConnectionTaskInner::ShutdownAcked { .. },
             ) => unreachable!(),
             (
                 CoordinatorToConnectionInner::AcceptInNotifications { .. }
@@ -496,10 +540,20 @@ where
     /// currently being opened, then there is no need to open any additional one.
     pub fn desired_outbound_substreams(&self) -> u32 {
         match &self.connection {
+            MultiStreamConnectionTaskInner::Handshake {
+                opened_substream, ..
+            } => {
+                if opened_substream.is_none() {
+                    1
+                } else {
+                    0
+                }
+            }
             MultiStreamConnectionTaskInner::Established { established, .. } => {
                 established.desired_outbound_substreams()
             }
-            _ => 0,
+            MultiStreamConnectionTaskInner::ShutdownAcked { .. }
+            | MultiStreamConnectionTaskInner::ShutdownWaitingAck { .. } => 0,
         }
     }
 
@@ -517,17 +571,27 @@ where
     ///
     pub fn add_substream(&mut self, id: TSubId, inbound: bool) {
         match &mut self.connection {
+            MultiStreamConnectionTaskInner::Handshake {
+                opened_substream: ref mut opened_substream @ None,
+                ..
+            } if !inbound => {
+                *opened_substream = Some(id);
+            }
+            MultiStreamConnectionTaskInner::Handshake { .. } => {
+                // TODO: protocol has been violated, reset the connection?
+            }
             MultiStreamConnectionTaskInner::Established { established, .. } => {
                 established.add_substream(id, inbound)
             }
-            _ => {
+            MultiStreamConnectionTaskInner::ShutdownAcked { .. }
+            | MultiStreamConnectionTaskInner::ShutdownWaitingAck { .. } => {
                 // TODO: reset the substream or something?
             }
         }
     }
 
-    /// Returns a list of substreams that the state machine would like to see reset. The user is
-    /// encouraged to call [`MultiStreamConnectionTask::substream_read_write`] with this list of
+    /// Returns a list of substreams that the state machine would like to see processed. The user
+    /// is encouraged to call [`MultiStreamConnectionTask::substream_read_write`] with this list of
     /// substream.
     ///
     /// This value doesn't change automatically over time but only after a call to
@@ -541,10 +605,32 @@ where
     /// >           substream being "ready" because it needs to send more data.
     pub fn ready_substreams(&self) -> impl Iterator<Item = &TSubId> {
         match &self.connection {
+            MultiStreamConnectionTaskInner::Handshake {
+                opened_substream: Some(opened_substream),
+                handshake,
+                ..
+            } => {
+                let iter = if handshake.as_ref().unwrap().ready_to_write() {
+                    Some(opened_substream)
+                } else {
+                    None
+                }
+                .into_iter();
+                either::Right(either::Left(iter))
+            }
             MultiStreamConnectionTaskInner::Established { established, .. } => {
+                // Note that the handshake substream is never ready as it never has anything
+                // to write after the end of the handshake.
                 either::Left(established.ready_substreams())
             }
-            _ => either::Right(iter::empty()),
+            MultiStreamConnectionTaskInner::Handshake {
+                opened_substream: None,
+                ..
+            }
+            | MultiStreamConnectionTaskInner::ShutdownAcked { .. }
+            | MultiStreamConnectionTaskInner::ShutdownWaitingAck { .. } => {
+                either::Right(either::Right(iter::empty()))
+            }
         }
     }
 
@@ -607,10 +693,27 @@ where
     ///
     pub fn reset_substream(&mut self, substream_id: &TSubId) {
         match &mut self.connection {
+            MultiStreamConnectionTaskInner::Established {
+                handshake_substream,
+                ..
+            } if handshake_substream
+                .as_ref()
+                .map_or(false, |s| s == substream_id) =>
+            {
+                *handshake_substream = None;
+            }
             MultiStreamConnectionTaskInner::Established { established, .. } => {
                 established.reset_substream(substream_id)
             }
-            _ => {
+            MultiStreamConnectionTaskInner::Handshake {
+                opened_substream: Some(opened_substream),
+                ..
+            } if opened_substream == substream_id => {
+                // TODO: the handshake has failed, kill the connection?
+            }
+            MultiStreamConnectionTaskInner::Handshake { .. }
+            | MultiStreamConnectionTaskInner::ShutdownAcked { .. }
+            | MultiStreamConnectionTaskInner::ShutdownWaitingAck { .. } => {
                 // TODO: panic if substream id invalid?
             }
         }
@@ -633,10 +736,81 @@ where
         read_write: &'_ mut ReadWrite<'_, TNow>,
     ) -> bool {
         match &mut self.connection {
+            MultiStreamConnectionTaskInner::Handshake {
+                handshake,
+                opened_substream,
+                established,
+            } if opened_substream
+                .as_ref()
+                .map_or(false, |s| s == substream_id) =>
+            {
+                // TODO: check the handshake timeout
+                match handshake.take().unwrap().read_write(read_write) {
+                    Ok(noise::NoiseHandshake::InProgress(handshake_update)) => {
+                        *handshake = Some(handshake_update);
+                        false
+                    }
+                    Err(_err) => todo!(), // TODO: /!\
+                    Ok(noise::NoiseHandshake::Success {
+                        cipher: _,
+                        remote_peer_id,
+                    }) => {
+                        // The handshake has succeeded and we will transition into "established"
+                        // mode.
+                        // However the rest of the body of this function still needs to deal with
+                        // the substream used for the handshake.
+                        // We close the writing side. If the reading side is closed, we indicate
+                        // that the substream is dead. If the reading side is still open, we
+                        // indicate that it's not dead and store it in the state machine while
+                        // waiting for it to be closed by the remote.
+                        read_write.close_write();
+                        let handshake_substream_still_open = read_write.incoming_buffer.is_some();
+
+                        self.connection = MultiStreamConnectionTaskInner::Established {
+                            established: established.take().unwrap(),
+                            handshake_finished_message_to_send: Some(remote_peer_id),
+                            handshake_substream: if handshake_substream_still_open {
+                                Some(opened_substream.take().unwrap())
+                            } else {
+                                None
+                            },
+                            outbound_substreams_map: hashbrown::HashMap::with_capacity_and_hasher(
+                                0,
+                                Default::default(),
+                            ),
+                            outbound_substreams_reverse:
+                                hashbrown::HashMap::with_capacity_and_hasher(0, Default::default()),
+                        };
+
+                        !handshake_substream_still_open
+                    }
+                }
+            }
+            MultiStreamConnectionTaskInner::Established {
+                handshake_substream,
+                ..
+            } if handshake_substream
+                .as_ref()
+                .map_or(false, |s| s == substream_id) =>
+            {
+                // Close the writing side. If the reading side is closed, we indicate that the
+                // substream is dead. If the reading side is still open, we indicate that it's not
+                // dead and simply wait for the remote to close it.
+                // TODO: kill the connection if the remote sends more data?
+                read_write.close_write();
+                if read_write.incoming_buffer.is_none() {
+                    *handshake_substream = None;
+                    true
+                } else {
+                    false
+                }
+            }
             MultiStreamConnectionTaskInner::Established { established, .. } => {
                 established.substream_read_write(substream_id, read_write)
             }
-            _ => {
+            MultiStreamConnectionTaskInner::Handshake { .. }
+            | MultiStreamConnectionTaskInner::ShutdownAcked { .. }
+            | MultiStreamConnectionTaskInner::ShutdownWaitingAck { .. } => {
                 // TODO: panic if substream id invalid?
                 true
             }

--- a/src/libp2p/connection/noise.rs
+++ b/src/libp2p/connection/noise.rs
@@ -626,6 +626,12 @@ impl HandshakeInProgress {
         }
     }
 
+    /// Returns `true` if the Noise handshake is waiting to write out data. Returns `false` if
+    /// instead it is blocked on incoming data.
+    pub fn ready_to_write(&self) -> bool {
+        !self.tx_buffer_encrypted.is_empty()
+    }
+
     /// Feeds data coming from a socket and outputs data to write to the socket.
     ///
     /// On success, returns the new state of the negotiation.

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -1044,34 +1044,26 @@ where
     ///
     /// See also [`ChainNetwork::pending_outcome_err`].
     ///
-    /// No [`Event::Connected`] will be generated. Calling this function implicitly acts as if
-    /// this event was generated.
-    ///
     /// # Panic
     ///
     /// Panics if the [`PendingId`] is invalid.
     ///
-    // TODO: not generating the Connected event is tricky, as the user needs to do an extra effort to know if there was already a connection to that peer
     pub fn pending_outcome_ok_multi_stream<TSubId>(
         &mut self,
         id: PendingId,
-        now: TNow,
-        peer_id: &PeerId,
     ) -> (ConnectionId, MultiStreamConnectionTask<TNow, TSubId>)
     where
         TSubId: Clone + PartialEq + Eq + Hash,
     {
         // Don't remove the value in `pending_ids` yet, so that the state remains consistent if
         // the user cancels the future returned by `add_outgoing_connection`.
-        let (expected_peer_id, multiaddr, _when_connected) = self.pending_ids.get(id.0).unwrap();
+        let (expected_peer_id, multiaddr, when_connected) = self.pending_ids.get(id.0).unwrap();
 
-        if expected_peer_id != peer_id {
-            todo!() // TODO: return an error or something
-        }
-
-        let (connection_id, connection_task) =
-            self.inner
-                .add_multi_stream_outgoing_connection(now, peer_id, multiaddr.clone());
+        let (connection_id, connection_task) = self.inner.add_multi_stream_outgoing_connection(
+            when_connected.clone(),
+            expected_peer_id,
+            multiaddr.clone(),
+        );
 
         // Update `self.peers`.
         {


### PR DESCRIPTION
cc https://github.com/paritytech/smoldot/issues/2754

In terms of API, this removes the necessity to pass a `PeerId` when creating a "multi-stream connection". The inner implementation now performs the substream opening and Noise negotiation internally.
