### PR TITLE
Remove `version` field from struct returned by `rpc_methods`

### DIFF
--- a/bin/light-base/src/json_rpc_service/getters.rs
+++ b/bin/light-base/src/json_rpc_service/getters.rs
@@ -127,7 +127,6 @@ impl<TPlat: Platform> Background<TPlat> {
             .respond(
                 state_machine_request_id,
                 methods::Response::rpc_methods(methods::RpcMethods {
-                    version: 1,
                     methods: methods::MethodCall::method_names()
                         .map(|n| n.into())
                         .collect(),

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - No longer try to connect to a peer for 20 seconds after failing to connect to it. This prevents loops where we keep trying to connect to the same address(es) over and over again ([#2747](https://github.com/paritytech/smoldot/pull/2747)).
+- Removed the `version` field of the struct returned by the `rpc_methods` function.
 
 ### Added
 

--- a/src/json_rpc/methods.rs
+++ b/src/json_rpc/methods.rs
@@ -889,7 +889,6 @@ pub struct NetworkConfig {
 
 #[derive(Debug, Clone)]
 pub struct RpcMethods {
-    pub version: u64,
     pub methods: Vec<String>,
 }
 
@@ -1054,12 +1053,10 @@ impl serde::Serialize for RpcMethods {
     {
         #[derive(serde::Serialize)]
         struct SerdeRpcMethods<'a> {
-            version: u64,
             methods: &'a [String],
         }
 
         SerdeRpcMethods {
-            version: self.version,
             methods: &self.methods,
         }
         .serialize(serializer)


### PR DESCRIPTION
Mimics the change done here: https://github.com/paritytech/substrate/pull/12261

Let's merge this PR only if https://github.com/paritytech/substrate/pull/12261 is approved and merged.