### PR TITLE
Remove unwrap() in runtime_lock

### DIFF
--- a/bin/light-base/src/json_rpc_service/state_chain.rs
+++ b/bin/light-base/src/json_rpc_service/state_chain.rs
@@ -960,7 +960,7 @@ impl<TPlat: Platform> Background<TPlat> {
         // This is necessary to perform network storage queries.
         let (state_root, block_number) = match self.state_trie_root_hash(&hash).await {
             Ok(v) => v,
-            Err(()) => {
+            Err(err) => {
                 self.requests_subscriptions
                     .respond(
                         &state_machine_request_id,
@@ -968,7 +968,7 @@ impl<TPlat: Platform> Background<TPlat> {
                             request_id,
                             json_rpc::parse::ErrorResponse::ServerError(
                                 -32000,
-                                &"Failed to fetch block information",
+                                &format!("Failed to fetch block information: {}", err),
                             ),
                             None,
                         ),
@@ -1031,7 +1031,7 @@ impl<TPlat: Platform> Background<TPlat> {
         // This is necessary to perform network storage queries.
         let (state_root, block_number) = match self.state_trie_root_hash(&hash).await {
             Ok(v) => v,
-            Err(()) => {
+            Err(err) => {
                 self.requests_subscriptions
                     .respond(
                         &state_machine_request_id,
@@ -1039,7 +1039,7 @@ impl<TPlat: Platform> Background<TPlat> {
                             request_id,
                             json_rpc::parse::ErrorResponse::ServerError(
                                 -32000,
-                                &"Failed to fetch block information",
+                                &format!("Failed to fetch block information: {}", err),
                             ),
                             None,
                         ),

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix potential infinite loop in networking connection task. ([#2751](https://github.com/paritytech/smoldot/pull/2751))
+- Fix panic when trying to perform a runtime call on an old block while having no networking connection.
 
 ### Changed
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Fix potential infinite loop in networking connection task. ([#2751](https://github.com/paritytech/smoldot/pull/2751))
-- Fix panic when trying to perform a runtime call on an old block while having no networking connection.
+- Fix panic when trying to perform a runtime call on an old block while having no networking connection. ([#2764](https://github.com/paritytech/smoldot/pull/2764))
 
 ### Changed
 


### PR DESCRIPTION
Fix https://github.com/paritytech/smoldot/issues/2763

This PR gives a proper error type to the `state_trie_root_hash` function (which retrieves the state trie root hash of a block from the network), and makes `runtime_lock` properly propagates the error instead of unwrapping.