### PR TITLE
Publish v0.6.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light-wasm"
-version = "0.6.33"
+version = "0.6.34"
 dependencies = [
  "event-listener",
  "fnv",

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,19 +2,21 @@
 
 ## Unreleased
 
-### Fixed
-
-- Fix potential infinite loop in networking connection task. ([#2751](https://github.com/paritytech/smoldot/pull/2751))
-- Fix panic when trying to perform a runtime call on an old block while having no networking connection. ([#2764](https://github.com/paritytech/smoldot/pull/2764))
-
-### Changed
-
-- No longer try to connect to a peer for 20 seconds after failing to connect to it. This prevents loops where we keep trying to connect to the same address(es) over and over again ([#2747](https://github.com/paritytech/smoldot/pull/2747)).
+## 0.6.34 - 2022-09-20
 
 ### Added
 
 - Add experimental support for WebRTC according to the in-progress specification for libp2p-webrtc. For now this feature must explicitly be enabled by passing `enableExperimentalWebRTC: true` as part of the ̀`ClientConfig`. The multiaddress format for WebRTC is `/ip4/.../udp/.../webrtc/certhash/...` (or `/ip6/...`), where the payload behind `/certhash` is a multibase-encoded multihash-encoded SHA256 of the DTLS certificate used by the remote. ([#2579](https://github.com/paritytech/smoldot/pull/2579))
 - Add support for the `chainHead_unstable_finalizedDatabase` JSON-RPC method. This JSON-RPC method aims to be a replacement for the `databaseContent` method of the `Chain` and is expected to remain a permanently unstable smoldot-specific function. ([#2749](https://github.com/paritytech/smoldot/pull/2749))
+
+### Changed
+
+- No longer try to connect to a peer for 20 seconds after failing to connect to it. This prevents loops where we keep trying to connect to the same address(es) over and over again ([#2747](https://github.com/paritytech/smoldot/pull/2747)).
+
+### Fixed
+
+- Fix potential infinite loop in networking connection task. ([#2751](https://github.com/paritytech/smoldot/pull/2751))
+- Fix panic when trying to perform a runtime call on an old block while having no networking connection. ([#2764](https://github.com/paritytech/smoldot/pull/2764))
 
 ## 0.6.33 - 2022-09-13
 

--- a/bin/wasm-node/javascript/package-lock.json
+++ b/bin/wasm-node/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@substrate/smoldot-light",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@substrate/smoldot-light",
-      "version": "0.6.33",
+      "version": "0.6.34",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "pako": "^2.0.4",

--- a/bin/wasm-node/javascript/package.json
+++ b/bin/wasm-node/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@substrate/smoldot-light",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "description": "Light client that connects to Polkadot and Substrate-based blockchains",
   "author": "Parity Technologies <admin@parity.io>",
   "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",

--- a/bin/wasm-node/rust/Cargo.toml
+++ b/bin/wasm-node/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light-wasm"
-version = "0.6.33"
+version = "0.6.34"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Browser bindings to a light client for Substrate-based blockchains"
 repository = "https://github.com/paritytech/smoldot"


### PR DESCRIPTION
I've taken the liberty to change the order of the sections in the CHANGELOG by order of importance: first "added", then "changed", then "fixed". Because of merge conflicts I ended up putting them in an awkward order.