### PR TITLE
Remove AddChainOptions.jsonRpcCallback in favor of Chain.nextJsonRpcResponse

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Chain.sendJsonRpc` now throws a `MalformedJsonRpcError` exception if the JSON-RPC request is too large or malformed, or a `QueueFullError` if the queue of JSON-RPC requests of the chain is full.
+- Removed `AddChainOptions.jsonRpcCallback`. Use the new `Chain.nextJsonRpcResponse` asynchronous function to pull JSON-RPC responses instead of registering a callback. A `AddChainOptions.disableJsonRpc` flag is now supported in order to bring the same effects as not passing any `jsonRpcCallback`.
 - Removed the `version` field of the struct returned by the `rpc_methods` function. This is technically a breaking change, but it has been introduced in a minor version bump because it is very insubstantial. ([#2756](https://github.com/paritytech/smoldot/pull/2756))
 
 ## 0.6.34 - 2022-09-20

--- a/bin/wasm-node/javascript/README.md
+++ b/bin/wasm-node/javascript/README.md
@@ -19,16 +19,13 @@ const chainSpec = fs.readFileSync('./westend.json', 'utf8');
 // A single client can be used to initialize multiple chains.
 const client = smoldot.start();
 
-const chain = await client.addChain({
-  chainSpec,
-  jsonRpcCallback: (jsonRpcResponse) => {
-      // Called whenever the client emits a response to a JSON-RPC request,
-      // or an incoming JSON-RPC notification.
-      console.log(jsonRpcResponse)
-  }
-});
+const chain = await client.addChain({ chainSpec });
 
 chain.sendJsonRpc('{"jsonrpc":"2.0","id":1,"method":"system_name","params":[]}');
+
+// Wait for a JSON-RPC response to come back. This is typically done in a loop in the background.
+const jsonRpcResponse = await chain.nextJsonRpcResponse();
+console.log(jsonRpcResponse)
 
 // Later:
 // chain.remove();
@@ -58,15 +55,12 @@ and [the list of requests that smoldot is capable of serving](https://polkadot.j
 Smoldot also has experimental support for an extra (still experimental at the time of writing of
 this comment) set of JSON-RPC functions [found here](https://github.com/paritytech/json-rpc-interface-spec/).
 
-If the request is well formatted, the client will send a response using the `jsonRpcCallback`
-callback that was passed to `addChain`. This callback takes as parameter the string JSON-RPC
-response.
+If the request is well formatted, the client will generate a response. This response can be pulled
+using the `nextJsonRpcResponse` asynchronous function. Calling this function waits until a response
+is available and returns it.
 
-If the request is a subscription, the notifications will also be sent back using the same
-`jsonRpcCallback`.
-
-If no `jsonRpcCallback` was passed to `addChain`, then this chain won't be capable of serving
-any JSON-RPC request at all. This can be used to save resources.
+If the request is a subscription, the notifications will also be sent back using the same mechanism
+and can be pulled using `nextJsonRpcResponse`.
 
 If the chain specification passed to `addChain` is a parachain, then the list of potential relay
 chains must be passed as parameter to `addChain` as well. In situations where the chain

--- a/bin/wasm-node/javascript/demo/demo-deno.ts
+++ b/bin/wasm-node/javascript/demo/demo-deno.ts
@@ -65,10 +65,16 @@ while(true) {
 
     const { socket, response } = Deno.upgradeWebSocket(event.request);
 
-    const chain = await client.addChain({
-        chainSpec,
-        jsonRpcCallback: (response) => socket.send(response)
-    });
+    const chain = await client.addChain({ chainSpec });
+
+    (async () => {
+        try {
+            while(true) {
+                const response = await chain.nextJsonRpcResponse();
+                socket.send(response);
+            }
+        } catch(_error) {}
+    })()
 
     socket.onclose = () => {
         console.log("(demo) JSON-RPC client disconnected.");

--- a/bin/wasm-node/javascript/demo/demo-deno.ts
+++ b/bin/wasm-node/javascript/demo/demo-deno.ts
@@ -47,7 +47,7 @@ const client = smoldot.start({
 // We add the chain ahead of time in order to preload it.
 // Once a client connects, the chain is added again, but smoldot is smart enough to not connect
 // a second time.
-client.addChain({ chainSpec });
+client.addChain({ chainSpec, disableJsonRpc: true });
 
 // Now spawn a WebSocket server in order to handle JSON-RPC clients.
 console.log('JSON-RPC server now listening on port 9944');

--- a/bin/wasm-node/javascript/demo/demo.mjs
+++ b/bin/wasm-node/javascript/demo/demo.mjs
@@ -120,21 +120,35 @@ wsServer.on('connection', function (connection, request) {
 
             const para = await client.addChain({
                 chainSpec: chainCfg.chainSpec,
-                jsonRpcCallback: (resp) => {
-                    connection.send(resp);
-                },
                 potentialRelayChains: [relay]
             });
 
+            (async () => {
+                try {
+                    while(true) {
+                        const response = await para.nextJsonRpcResponse();
+                        connection.send(response);
+                    }
+                } catch(_error) {}
+            })()
+
             return { relay, para };
         } else {
+            const relay = await client.addChain({
+                chainSpec: chainCfg.chainSpec,
+            });
+
+            (async () => {
+                try {
+                    while(true) {
+                        const response = await relay.nextJsonRpcResponse();
+                        connection.send(response);
+                    }
+                } catch(_error) {}
+            })()
+
             return {
-                relay: await client.addChain({
-                    chainSpec: chainCfg.chainSpec,
-                    jsonRpcCallback: (resp) => {
-                        connection.send(resp);
-                    },
-                })
+                relay,
             };
         }
     })().catch((error) => {

--- a/bin/wasm-node/javascript/demo/demo.mjs
+++ b/bin/wasm-node/javascript/demo/demo.mjs
@@ -116,6 +116,7 @@ wsServer.on('connection', function (connection, request) {
 
             const relay = await client.addChain({
                 chainSpec: chainSpecsById[chainCfg.relayChain].chainSpec,
+                disableJsonRpc: true
             });
 
             const para = await client.addChain({

--- a/bin/wasm-node/javascript/src/client.ts
+++ b/bin/wasm-node/javascript/src/client.ts
@@ -323,7 +323,7 @@ export interface AddChainOptions {
    */
   potentialRelayChains?: Chain[];
 
-  disableJsonRpc: boolean,
+  disableJsonRpc?: boolean,
 }
 
 // This function is similar to the `start` function found in `index.ts`, except with an extra
@@ -390,7 +390,7 @@ export function start(options: ClientOptions, platformBindings: PlatformBindings
         }
       }
 
-      const outcome = await instance.addChain(options.chainSpec, typeof options.databaseContent === 'string' ? options.databaseContent : "", potentialRelayChainsIds, options.disableJsonRpc);
+      const outcome = await instance.addChain(options.chainSpec, typeof options.databaseContent === 'string' ? options.databaseContent : "", potentialRelayChainsIds, !!options.disableJsonRpc);
 
       if (!outcome.success)
         throw new AddChainError(outcome.error);

--- a/bin/wasm-node/javascript/src/client.ts
+++ b/bin/wasm-node/javascript/src/client.ts
@@ -117,11 +117,26 @@ export interface Chain {
    * @param rpc JSON-encoded RPC request.
    *
    * @throws {AlreadyDestroyedError} If the chain has been removed or the client has been terminated.
-   * @throws {JsonRpcDisabledError} If no JSON-RPC callback was passed in the options of the chain.
+   * @throws {JsonRpcDisabledError} If the JSON-RPC system was disabled in the options of the chain.
    * @throws {CrashError} If the background client has crashed.
    */
   sendJsonRpc(rpc: string): void;
 
+  /**
+   * Waits for a JSON-RPC response or notification to be generated.
+   *
+   * If this function is called multiple times "simultaneously" (generating multiple different
+   * `Promise`s), each `Promise` will return a different JSON-RPC response or notification.
+   *
+   * Each chain contains a buffer of the responses waiting to be sent out. Calling this function
+   * pulls one element from the buffer. If this function is called at a slower rate than responses
+   * are generated, then buffer will eventually become full, at which point calling
+   * {Chain.sendJsonRpc} will throw an exception.
+   *
+   * @throws {AlreadyDestroyedError} If the chain has been removed or the client has been terminated.
+   * @throws {JsonRpcDisabledError} If the JSON-RPC system was disabled in the options of the chain.
+   * @throws {CrashError} If the background client has crashed.
+   */
   nextJsonRpcResponse(): Promise<string>;
 
   /**
@@ -323,6 +338,14 @@ export interface AddChainOptions {
    */
   potentialRelayChains?: Chain[];
 
+  /**
+   * Disables the JSON-RPC system of the chain.
+   *
+   * This option can be used in order to save up some resources.
+   *
+   * It will be illegal to call {Chain.sendJsonRpc} and {Chain.nextJsonRpcResponse} on this
+   * chain.
+   */
   disableJsonRpc?: boolean,
 }
 

--- a/bin/wasm-node/javascript/src/index-browser.ts
+++ b/bin/wasm-node/javascript/src/index-browser.ts
@@ -30,7 +30,6 @@ export {
   Client,
   ClientOptions,
   CrashError,
-  JsonRpcCallback,
   JsonRpcDisabledError,
   LogCallback
 } from './client.js';

--- a/bin/wasm-node/javascript/src/index-browser.ts
+++ b/bin/wasm-node/javascript/src/index-browser.ts
@@ -31,6 +31,8 @@ export {
   ClientOptions,
   CrashError,
   JsonRpcDisabledError,
+  MalformedJsonRpcError,
+  QueueFullError,
   LogCallback
 } from './client.js';
 

--- a/bin/wasm-node/javascript/src/index-deno.ts
+++ b/bin/wasm-node/javascript/src/index-deno.ts
@@ -26,6 +26,8 @@ export {
     Client,
     ClientOptions,
     CrashError,
+    MalformedJsonRpcError,
+    QueueFullError,
     JsonRpcDisabledError,
     LogCallback
 } from './client.js';

--- a/bin/wasm-node/javascript/src/index-deno.ts
+++ b/bin/wasm-node/javascript/src/index-deno.ts
@@ -26,7 +26,6 @@ export {
     Client,
     ClientOptions,
     CrashError,
-    JsonRpcCallback,
     JsonRpcDisabledError,
     LogCallback
 } from './client.js';

--- a/bin/wasm-node/javascript/src/index-nodejs.ts
+++ b/bin/wasm-node/javascript/src/index-nodejs.ts
@@ -38,6 +38,8 @@ export {
   Client,
   ClientOptions,
   CrashError,
+  MalformedJsonRpcError,
+  QueueFullError,
   JsonRpcDisabledError,
   LogCallback
 } from './client.js';

--- a/bin/wasm-node/javascript/src/index-nodejs.ts
+++ b/bin/wasm-node/javascript/src/index-nodejs.ts
@@ -38,7 +38,6 @@ export {
   Client,
   ClientOptions,
   CrashError,
-  JsonRpcCallback,
   JsonRpcDisabledError,
   LogCallback
 } from './client.js';

--- a/bin/wasm-node/javascript/src/instance/bindings.ts
+++ b/bin/wasm-node/javascript/src/instance/bindings.ts
@@ -32,6 +32,8 @@ export interface SmoldotWasmExports extends WebAssembly.Exports {
     chain_error_len: (chainId: number) => number,
     chain_error_ptr: (chainId: number) => number,
     json_rpc_send: (textPtr: number, textLen: number, chainId: number) => void,
+    json_rpc_responses_peek: (chainId: number) => number,
+    json_rpc_responses_pop: (chainId: number) => void,
     database_content: (chainId: number, maxSize: number) => void,
     timer_finished: (timerId: number) => void,
     connection_open_single_stream: (connectionId: number, handshakeTy: number) => void,

--- a/bin/wasm-node/javascript/src/instance/bindings.ts
+++ b/bin/wasm-node/javascript/src/instance/bindings.ts
@@ -31,7 +31,7 @@ export interface SmoldotWasmExports extends WebAssembly.Exports {
     chain_is_ok: (chainId: number) => number,
     chain_error_len: (chainId: number) => number,
     chain_error_ptr: (chainId: number) => number,
-    json_rpc_send: (textPtr: number, textLen: number, chainId: number) => void,
+    json_rpc_send: (textPtr: number, textLen: number, chainId: number) => number,
     json_rpc_responses_peek: (chainId: number) => number,
     json_rpc_responses_pop: (chainId: number) => void,
     database_content: (chainId: number, maxSize: number) => void,

--- a/bin/wasm-node/javascript/src/instance/instance.ts
+++ b/bin/wasm-node/javascript/src/instance/instance.ts
@@ -34,6 +34,24 @@ export { PlatformBindings, ConnectionError, ConnectionConfig, Connection } from 
 }
 
 /**
+ * Thrown in case a malformed JSON-RPC request is sent.
+ */
+export class MalformedJsonRpcError extends Error {
+  constructor() {
+    super("JSON-RPC request is malformed");
+  }
+}
+
+/**
+ * Thrown in case the buffer of JSON-RPC requests is full and cannot accept any more request.
+ */
+export class QueueFullError extends Error {
+  constructor() {
+    super("JSON-RPC requests queue is full");
+  }
+}
+
+/**
  * Contains the configuration of the instance.
  */
 export interface Config {
@@ -199,9 +217,9 @@ export function start(configMessage: Config, platformBindings: instance.Platform
 
       switch (retVal) {
         case 0: break;
-        case 1: throw new Error("Couldn't parse JSON-RPC request");  // TODO: document this and use a proper error type
-        case 2: throw new Error("Client currently overloaded");  // TODO: document this and use a proper error type
-        default: throw new Error("Unknown json_rpc_send error code: " + retVal)
+        case 1: throw new MalformedJsonRpcError();
+        case 2: throw new QueueFullError();
+        default: throw new Error("Internal error: unknown json_rpc_send error code: " + retVal)
       }
     },
 

--- a/bin/wasm-node/javascript/src/instance/instance.ts
+++ b/bin/wasm-node/javascript/src/instance/instance.ts
@@ -18,6 +18,7 @@
 import * as buffer from './buffer.js';
 import * as instance from './raw-instance.js';
 import { SmoldotWasmInstance } from './bindings.js';
+import { AlreadyDestroyedError } from '../client.js';
 
 export { PlatformBindings, ConnectionError, ConnectionConfig, Connection } from './raw-instance.js';
 
@@ -44,7 +45,8 @@ export interface Config {
 
 export interface Instance {
   request: (request: string, chainId: number) => void
-  addChain: (chainSpec: string, databaseContent: string, potentialRelayChains: number[], jsonRpcCallback?: (response: string) => void) => Promise<{ success: true, chainId: number } | { success: false, error: string }>
+  nextJsonRpcResponse: (chainId: number, resolve: (response: string) => void, reject: (error: Error) => void) => void
+  addChain: (chainSpec: string, databaseContent: string, potentialRelayChains: number[], disableJsonRpc: boolean) => Promise<{ success: true, chainId: number } | { success: false, error: string }>
   removeChain: (chainId: number) => void
   databaseContent: (chainId: number, maxUtf8BytesSize?: number) => Promise<string>
   startShutdown: () => void
@@ -67,7 +69,7 @@ export function start(configMessage: Config, platformBindings: instance.Platform
 
   // Contains the information of each chain that is currently alive.
   let chains: Map<number, {
-    jsonRpcCallback?: (response: string) => void,
+    jsonRpcResponsesPromises: DatabasePromise[], // TODO: rename DatabasePromise?
     databasePromises: DatabasePromise[],
   }> = new Map();
 
@@ -89,9 +91,29 @@ export function start(configMessage: Config, platformBindings: instance.Platform
     logCallback: (level, target, message) => {
       configMessage.logCallback(level, target, message)
     },
-    jsonRpcCallback: (data, chainId) => {
-      const cb = chains.get(chainId)?.jsonRpcCallback;
-      if (cb) cb(data);
+    jsonRpcResponsesNonEmptyCallback: (chainId) => {
+      if (!state.initialized)
+        throw new Error("Internal error");
+
+      const promises = chains.get(chainId)!.jsonRpcResponsesPromises;
+      const mem = new Uint8Array(state.instance.exports.memory.buffer);
+
+      // Immediately read all the elements of the queue and remove them.
+      // `json_rpc_responses_non_empty` is only guaranteed to be called if the queue is
+      // empty.
+      while (promises.length !== 0) {
+          const responseInfo = state.instance.exports.json_rpc_responses_peek(chainId) >>> 0;
+          const ptr = buffer.readUInt32LE(mem, responseInfo) >>> 0;
+          const len = buffer.readUInt32LE(mem, responseInfo + 4) >>> 0;
+          // `len === 0` means "queue is empty" according to the API.
+          if (len === 0)
+              break;
+
+          const message = buffer.utf8BytesToString(mem, ptr, len);
+          promises.shift()!.resolve(message);
+
+          state.instance.exports.json_rpc_responses_pop(chainId);
+      }
     },
     databaseContentCallback: (data, chainId) => {
       const promises = chains.get(chainId)?.databasePromises!;
@@ -166,7 +188,39 @@ export function start(configMessage: Config, platformBindings: instance.Platform
       }
     },
 
-    addChain: (chainSpec: string, databaseContent: string, potentialRelayChains: number[], jsonRpcCallback?: (response: string) => void): Promise<{ success: true, chainId: number } | { success: false, error: string }> => {
+    nextJsonRpcResponse: (chainId: number, resolve: (response: string) => void, reject: (error: Error) => void) => {
+      // Because `nextJsonRpcResponse` is passed as parameter an identifier returned by `addChain`,
+      // it is always the case that the Wasm instance is already initialized. The only possibility
+      // for it to not be the case is if the user completely invented the `chainId`.
+      if (!state.initialized)
+        throw new Error("Internal error");
+      if (crashError.error)
+        throw crashError.error;
+
+      try {
+        const mem = new Uint8Array(state.instance.exports.memory.buffer);
+        const responseInfo = state.instance.exports.json_rpc_responses_peek(chainId) >>> 0;
+        const ptr = buffer.readUInt32LE(mem, responseInfo) >>> 0;
+        const len = buffer.readUInt32LE(mem, responseInfo + 4) >>> 0;
+
+        // `len === 0` means "queue is empty" according to the API.
+        // In that situation, queue the resolve/reject.
+        if (len === 0) {
+          chains.get(chainId)!.jsonRpcResponsesPromises.push({ resolve, reject })
+          return;
+        }
+
+        const message = buffer.utf8BytesToString(mem, ptr, len);
+        resolve(message);
+
+        state.instance.exports.json_rpc_responses_pop(chainId);
+      } catch (_error) {
+        console.assert(crashError.error);
+        throw crashError.error
+      }
+    },
+
+    addChain: (chainSpec: string, databaseContent: string, potentialRelayChains: number[], disableJsonRpc: boolean): Promise<{ success: true, chainId: number } | { success: false, error: string }> => {
       return queueOperation((instance) => {
         if (crashError.error)
           throw crashError.error;
@@ -196,14 +250,14 @@ export function start(configMessage: Config, platformBindings: instance.Platform
           const chainId = instance.exports.add_chain(
             chainSpecPtr, chainSpecEncoded.length,
             databaseContentPtr, databaseContentEncoded.length,
-            !!jsonRpcCallback ? 1 : 0,
+            disableJsonRpc ? 0 : 1,
             potentialRelayChainsPtr, potentialRelayChainsLen
           );
 
           if (instance.exports.chain_is_ok(chainId) != 0) {
             console.assert(!chains.has(chainId));
             chains.set(chainId, {
-              jsonRpcCallback,
+              jsonRpcResponsesPromises: new Array(),
               databasePromises: new Array()
             });
             return { success: true, chainId };
@@ -234,6 +288,9 @@ export function start(configMessage: Config, platformBindings: instance.Platform
       // JSON-RPC response corresponding to a chain that is going to be deleted but hasn't been yet.
       // These kind of race conditions are already delt with within smoldot.
       console.assert(chains.has(chainId));
+      for (const { reject } of chains.get(chainId)!.jsonRpcResponsesPromises) {
+        reject(new AlreadyDestroyedError());
+      }
       chains.delete(chainId);
       try {
         state.instance.exports.remove_chain(chainId);

--- a/bin/wasm-node/javascript/src/instance/instance.ts
+++ b/bin/wasm-node/javascript/src/instance/instance.ts
@@ -147,14 +147,22 @@ export function start(configMessage: Config, platformBindings: instance.Platform
       if (crashError.error)
         throw crashError.error;
 
+      let retVal;
       try {
         const encoded = new TextEncoder().encode(request)
         const ptr = state.instance.exports.alloc(encoded.length) >>> 0;
         new Uint8Array(state.instance.exports.memory.buffer).set(encoded, ptr);
-        state.instance.exports.json_rpc_send(ptr, encoded.length, chainId);
+        retVal = state.instance.exports.json_rpc_send(ptr, encoded.length, chainId) >>> 0;
       } catch (_error) {
         console.assert(crashError.error);
         throw crashError.error
+      }
+
+      switch (retVal) {
+        case 0: break;
+        case 1: throw new Error("Couldn't parse JSON-RPC request");  // TODO: document this and use a proper error type
+        case 2: throw new Error("Client currently overloaded");  // TODO: document this and use a proper error type
+        default: throw new Error("Unknown json_rpc_send error code: " + retVal)
       }
     },
 

--- a/bin/wasm-node/javascript/src/instance/raw-instance.ts
+++ b/bin/wasm-node/javascript/src/instance/raw-instance.ts
@@ -38,7 +38,7 @@ export interface Config {
      */
     onWasmPanic: (message: string) => void,
     logCallback: (level: number, target: string, message: string) => void,
-    jsonRpcCallback: (response: string, chainId: number) => void,
+    jsonRpcResponsesNonEmptyCallback: (chainId: number) => void,
     databaseContentCallback: (data: string, chainId: number) => void,
     currentTaskCallback?: (taskName: string | null) => void,
     cpuRateLimit: number,

--- a/bin/wasm-node/javascript/test/chainSpec.mjs
+++ b/bin/wasm-node/javascript/test/chainSpec.mjs
@@ -22,76 +22,58 @@ import { start } from "../dist/mjs/index-nodejs.js";
 const westendSpec = fs.readFileSync('./test/westend.json', 'utf8');
 
 test('chainSpec_chainName works', async t => {
-  let promiseResolve;
-  let promiseReject;
-  const promise = new Promise((resolve, reject) => { promiseResolve = resolve; promiseReject = reject; });
-
   const client = start({ logCallback: () => { } });
   await client
-    .addChain({
-      chainSpec: westendSpec,
-      jsonRpcCallback: (resp) => {
-        const parsed = JSON.parse(resp);
-        if (parsed.result == "Westend")
-          promiseResolve();
-        else
-          promiseReject(resp);
-      }
-    })
+    .addChain({ chainSpec: westendSpec })
     .then((chain) => {
-      chain.sendJsonRpc('{"jsonrpc":"2.0","id":1,"method":"chainSpec_unstable_chainName","params":[]}', 0, 0);
+      chain.sendJsonRpc('{"jsonrpc":"2.0","id":1,"method":"chainSpec_unstable_chainName","params":[]}');
+      return chain;
     })
-    .then(() => promise)
-    .then(() => t.pass())
+    .then(async (chain) => {
+      const response = await chain.nextJsonRpcResponse();
+      const parsed = JSON.parse(response);
+      if (parsed.result == "Westend")
+        t.pass();
+      else
+        t.fail(response);
+    })
     .then(() => client.terminate());
 });
 
 test('chainSpec_unstable_genesisHash works', async t => {
-  let promiseResolve;
-  let promiseReject;
-  const promise = new Promise((resolve, reject) => { promiseResolve = resolve; promiseReject = reject; });
-
   const client = start({ logCallback: () => { } });
   await client
-    .addChain({
-      chainSpec: westendSpec,
-      jsonRpcCallback: (resp) => {
-        const parsed = JSON.parse(resp);
-        if (parsed.result.toLowerCase() == "0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e")
-          promiseResolve();
-        else
-          promiseReject(resp);
-      }
-    })
+    .addChain({ chainSpec: westendSpec })
     .then((chain) => {
-      chain.sendJsonRpc('{"jsonrpc":"2.0","id":1,"method":"chainSpec_unstable_genesisHash","params":[]}', 0, 0);
+      chain.sendJsonRpc('{"jsonrpc":"2.0","id":1,"method":"chainSpec_unstable_genesisHash","params":[]}');
+      return chain;
     })
-    .then(() => promise)
-    .then(() => t.pass())
+    .then(async (chain) => {
+      const response = await chain.nextJsonRpcResponse();
+      const parsed = JSON.parse(response);
+      if (parsed.result.toLowerCase() == "0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e")
+        t.pass();
+      else
+        t.fail(response);
+    })
     .then(() => client.terminate());
 });
 
 test('chainSpec_unstable_properties works', async t => {
-  let promiseResolve;
-  let promiseReject;
-  const promise = new Promise((resolve, reject) => { promiseResolve = resolve; promiseReject = reject; });
-
   const client = start({ logCallback: () => { } });
   await client
-    .addChain({
-      chainSpec: westendSpec,
-      jsonRpcCallback: (resp) => {
-        const parsed = JSON.parse(resp);
-        if (parsed.result.ss58Format == 42 && parsed.result.tokenDecimals == 12 && parsed.result.tokenSymbol == "WND")
-          promiseResolve();
-        else
-          promiseReject(resp);
-      }
-    })
+    .addChain({ chainSpec: westendSpec })
     .then((chain) => {
-      chain.sendJsonRpc('{"jsonrpc":"2.0","id":1,"method":"chainSpec_unstable_properties","params":[]}', 0, 0);
+      chain.sendJsonRpc('{"jsonrpc":"2.0","id":1,"method":"chainSpec_unstable_properties","params":[]}');
+      return chain;
     })
-    .then(() => promise)
-    .then(() => t.pass())
+    .then(async (chain) => {
+      const response = await chain.nextJsonRpcResponse();
+      const parsed = JSON.parse(response);
+      if (parsed.result.ss58Format == 42 && parsed.result.tokenDecimals == 12 && parsed.result.tokenSymbol == "WND")
+        t.pass();
+      else
+        t.fail(response);
+    })
     .then(() => client.terminate());
 });

--- a/bin/wasm-node/javascript/test/misc.mjs
+++ b/bin/wasm-node/javascript/test/misc.mjs
@@ -43,7 +43,7 @@ test('too large json-rpc requests rejected', async t => {
       // The test succeeds if a certain time passes without a response.
       setTimeout(() => promiseResolve(), 2000);
       // We use `JSON.stringify` in order to be certain that the request is valid JSON.
-      chain.sendJsonRpc(JSON.stringify({ "jsonrpc": "2.0", "id": 1, "method": "foo", "params": [veryLongString] }), 0, 0);
+      chain.sendJsonRpc(JSON.stringify({ "jsonrpc": "2.0", "id": 1, "method": "foo", "params": [veryLongString] }));
     })
     .then(() => promise)
     .then(() => t.pass())

--- a/bin/wasm-node/javascript/test/sudo.mjs
+++ b/bin/wasm-node/javascript/test/sudo.mjs
@@ -22,101 +22,77 @@ import { start } from "../dist/mjs/index-nodejs.js";
 const westendSpec = fs.readFileSync('./test/westend.json', 'utf8');
 
 test('sudo_unstable_p2pDiscover is available', async t => {
-  let promiseResolve;
-  let promiseReject;
-  const promise = new Promise((resolve, reject) => { promiseResolve = resolve; promiseReject = reject; });
-
   const client = start({ logCallback: () => { } });
   await client
-    .addChain({
-      chainSpec: westendSpec,
-      jsonRpcCallback: (resp) => {
-        const parsed = JSON.parse(resp);
-        if (parsed.id == 1 && parsed.result === null)
-          promiseResolve();
-        else
-          promiseReject(resp);
-      }
-    })
+    .addChain({ chainSpec: westendSpec })
     .then((chain) => {
-      chain.sendJsonRpc('{"jsonrpc":"2.0","id":1,"method":"sudo_unstable_p2pDiscover","params":["/ip4/1.2.3.4/tcp/30333/p2p/12D3KooWDmQPkBvQGg9wjBdFThtWj3QCDVQyHJ1apfWrHvjwbYS8"]}', 0, 0);
+      chain.sendJsonRpc('{"jsonrpc":"2.0","id":1,"method":"sudo_unstable_p2pDiscover","params":["/ip4/1.2.3.4/tcp/30333/p2p/12D3KooWDmQPkBvQGg9wjBdFThtWj3QCDVQyHJ1apfWrHvjwbYS8"]}');
+      return chain;
     })
-    .then(() => promise)
-    .then(() => t.pass())
+    .then(async (chain) => {
+      const response = await chain.nextJsonRpcResponse();
+      const parsed = JSON.parse(response);
+      if (parsed.id == 1 && parsed.result === null)
+        t.pass();
+      else
+        t.fail(response);
+    })
     .then(() => client.terminate());
 });
 
 test('sudo_unstable_p2pDiscover returns error on invalid multiaddr', async t => {
-  let promiseResolve;
-  let promiseReject;
-  const promise = new Promise((resolve, reject) => { promiseResolve = resolve; promiseReject = reject; });
-
   const client = start({ logCallback: () => { } });
   await client
-    .addChain({
-      chainSpec: westendSpec,
-      jsonRpcCallback: (resp) => {
-        const parsed = JSON.parse(resp);
-        if (parsed.id == 1 && !!parsed.error)
-          promiseResolve();
-        else
-          promiseReject(resp);
-      }
-    })
+    .addChain({ chainSpec: westendSpec })
     .then((chain) => {
-      chain.sendJsonRpc('{"jsonrpc":"2.0","id":1,"method":"sudo_unstable_p2pDiscover","params":["/hello/world"]}', 0, 0);
+      chain.sendJsonRpc('{"jsonrpc":"2.0","id":1,"method":"sudo_unstable_p2pDiscover","params":["/hello/world"]}');
+      return chain;
     })
-    .then(() => promise)
-    .then(() => t.pass())
+    .then(async (chain) => {
+      const response = await chain.nextJsonRpcResponse();
+      const parsed = JSON.parse(response);
+      if (parsed.id == 1 && !!parsed.error)
+        t.pass();
+      else
+        t.fail(response);
+    })
     .then(() => client.terminate());
 });
 
 test('sudo_unstable_p2pDiscover returns error if multiaddr doesn\'t end with /p2p', async t => {
-  let promiseResolve;
-  let promiseReject;
-  const promise = new Promise((resolve, reject) => { promiseResolve = resolve; promiseReject = reject; });
-
   const client = start({ logCallback: () => { } });
   await client
-    .addChain({
-      chainSpec: westendSpec,
-      jsonRpcCallback: (resp) => {
-        const parsed = JSON.parse(resp);
-        if (parsed.id == 1 && !!parsed.error)
-          promiseResolve();
-        else
-          promiseReject(resp);
-      }
-    })
+    .addChain({ chainSpec: westendSpec })
     .then((chain) => {
-      chain.sendJsonRpc('{"jsonrpc":"2.0","id":1,"method":"sudo_unstable_p2pDiscover","params":["/ip4/127.0.0.1/tcp/30333/ws"]}', 0, 0);
+      chain.sendJsonRpc('{"jsonrpc":"2.0","id":1,"method":"sudo_unstable_p2pDiscover","params":["/ip4/127.0.0.1/tcp/30333/ws"]}');
+      return chain;
     })
-    .then(() => promise)
-    .then(() => t.pass())
+    .then(async (chain) => {
+      const response = await chain.nextJsonRpcResponse();
+      const parsed = JSON.parse(response);
+      if (parsed.id == 1 && !!parsed.error)
+        t.pass();
+      else
+        t.fail(response);
+    })
     .then(() => client.terminate());
 });
 
 test('sudo_unstable_version works', async t => {
-  let promiseResolve;
-  let promiseReject;
-  const promise = new Promise((resolve, reject) => { promiseResolve = resolve; promiseReject = reject; });
-
   const client = start({ logCallback: () => { } });
   await client
-    .addChain({
-      chainSpec: westendSpec,
-      jsonRpcCallback: (resp) => {
-        const parsed = JSON.parse(resp);
-        if (parsed.result.includes("smoldot"))
-          promiseResolve();
-        else
-          promiseReject(resp);
-      }
-    })
+    .addChain({ chainSpec: westendSpec })
     .then((chain) => {
-      chain.sendJsonRpc('{"jsonrpc":"2.0","id":1,"method":"sudo_unstable_version","params":[]}', 0, 0);
+      chain.sendJsonRpc('{"jsonrpc":"2.0","id":1,"method":"sudo_unstable_version","params":[]}');
+      return chain;
     })
-    .then(() => promise)
-    .then(() => t.pass())
+    .then(async (chain) => {
+      const response = await chain.nextJsonRpcResponse();
+      const parsed = JSON.parse(response);
+      if (parsed.result.includes("smoldot"))
+        t.pass();
+      else
+        t.fail(response);
+    })
     .then(() => client.terminate());
 });

--- a/bin/wasm-node/javascript/test/test.mjs
+++ b/bin/wasm-node/javascript/test/test.mjs
@@ -33,23 +33,17 @@ test('invalid chain spec throws error', async t => {
 });
 
 test('system_name works', async t => {
-  let promiseResolve;
-  const promise = new Promise((resolve, reject) => promiseResolve = resolve);
-
   const client = start({ logCallback: () => { } });
   await client
-    .addChain({
-      chainSpec: westendSpec,
-      jsonRpcCallback: (resp) => {
-        if (resp == '{"jsonrpc":"2.0","id":1,"result":"smoldot-light-wasm"}') {
-          promiseResolve();
-        }
-      }
-    })
+    .addChain({ chainSpec: westendSpec })
     .then((chain) => {
-      chain.sendJsonRpc('{"jsonrpc":"2.0","id":1,"method":"system_name","params":[]}', 0, 0);
+      chain.sendJsonRpc('{"jsonrpc":"2.0","id":1,"method":"system_name","params":[]}');
+      return chain;
     })
-    .then(() => promise)
-    .then(() => t.pass())
+    .then(async (chain) => {
+      const response = await chain.nextJsonRpcResponse();
+      t.assert(response === '{"jsonrpc":"2.0","id":1,"result":"smoldot-light-wasm"}');
+      t.pass();
+    })
     .then(() => client.terminate());
 });

--- a/bin/wasm-node/rust/src/bindings.rs
+++ b/bin/wasm-node/rust/src/bindings.rs
@@ -86,13 +86,15 @@ extern "C" {
     /// behave like `abort` and prevent any further execution.
     pub fn panic(message_ptr: u32, message_len: u32);
 
-    /// Client is emitting a response to a previous JSON-RPC request sent using [`json_rpc_send`].
-    /// Also used to send subscriptions notifications.
+    /// The queue of JSON-RPC responses of the given chain is no longer empty.
     ///
-    /// The response or notification is a UTF-8 string found in the memory of the WebAssembly
-    /// virtual machine at offset `ptr` and with length `len`. `chain_id` is the chain
-    /// that the request was made to.
-    pub fn json_rpc_respond(ptr: u32, len: u32, chain_id: u32);
+    /// Use [`json_rpc_responses_peek`] in order to obtain information about the responses in the
+    /// queue.
+    ///
+    /// This function might be called even when the queue wasn't empty before, however this
+    /// behavior must not be relied upon. The queue must be emptied by calling
+    /// [`json_rpc_responses_pop`] in order to have the guarantee that this function gets called.
+    pub fn json_rpc_responses_non_empty(chain_id: u32);
 
     /// This function is called by the client is response to calling [`database_content`].
     ///
@@ -413,6 +415,47 @@ pub extern "C" fn chain_error_ptr(chain_id: u32) -> u32 {
 #[no_mangle]
 pub extern "C" fn json_rpc_send(text_ptr: u32, text_len: u32, chain_id: u32) {
     super::json_rpc_send(text_ptr, text_len, chain_id)
+}
+
+/// Obtains information about the first response in the queue of JSON-RPC responses.
+///
+/// This function returns a pointer within the memory of the WebAssembly virtual machine where is
+/// stored a struct of type [`JsonRpcResponseInfo`]. This pointer remains valid until
+/// [`json_rpc_responses_pop`] or [`remove_chain`] is called with the same `chain_id`.
+///
+/// The response or notification is a UTF-8 string found in the memory of the WebAssembly
+/// virtual machine at offset `ptr` and with length `len`, where `ptr` and `len` are found in the
+/// [`JsonRpcResponseInfo`].
+///
+/// If `len` is equal to 0, this indicates that the queue of JSON-RPC responses is empty.
+///
+/// After having read the response or notification, use [`json_rpc_responses_pop`] to remove it
+/// from the queue. You can then call [`json_rpc_responses_peek`] again to read the next response.
+#[no_mangle]
+pub extern "C" fn json_rpc_responses_peek(chain_id: u32) -> u32 {
+    super::json_rpc_responses_peek(chain_id)
+}
+
+/// See [`json_rpc_responses_peek`].
+#[repr(C)]
+pub struct JsonRpcResponseInfo {
+    /// Pointer in memory where the JSON-RPC response can be found.
+    pub ptr: u32,
+    /// Length of the JSON-RPC response in bytes. If 0, indicates that the queue is empty.
+    pub len: u32,
+}
+
+/// Removes the first response from the queue of JSON-RPC responses. This is the response whose
+/// information can be retrieved using [`json_rpc_responses_peek`].
+///
+/// Calling this function invalidates the pointer previously returned by a call to
+/// [`json_rpc_responses_peek`] with the same `chain_id`.
+///
+/// It is forbidden to call this function on an erroneous chain or a chain that was created with
+/// `json_rpc_running` equal to 0.
+#[no_mangle]
+pub extern "C" fn json_rpc_responses_pop(chain_id: u32) {
+    super::json_rpc_responses_pop(chain_id)
 }
 
 /// Starts generating the content of the database of the chain.

--- a/bin/wasm-node/rust/src/bindings.rs
+++ b/bin/wasm-node/rust/src/bindings.rs
@@ -403,7 +403,6 @@ pub extern "C" fn chain_error_ptr(chain_id: u32) -> u32 {
 /// A buffer containing a UTF-8 JSON-RPC request or notification must be passed as parameter. The
 /// format of the JSON-RPC requests and notifications is described in
 /// [the standard JSON-RPC 2.0 specification](https://www.jsonrpc.org/specification).
-/// Requests that are not valid JSON-RPC are silently ignored.
 ///
 /// The buffer passed as parameter **must** have been allocated with [`alloc`]. It is freed when
 /// this function is called.
@@ -412,8 +411,15 @@ pub extern "C" fn chain_error_ptr(chain_id: u32) -> u32 {
 ///
 /// It is forbidden to call this function on an erroneous chain or a chain that was created with
 /// `json_rpc_running` equal to 0.
+///
+/// This function returns:
+/// - 0 if everything went ok.
+/// - 1 if the request couldn't be parsed as a valid JSON-RPC request.
+/// - 2 if the chain is currently overloaded with JSON-RPC requests and refuses to queue another
+/// one.
+///
 #[no_mangle]
-pub extern "C" fn json_rpc_send(text_ptr: u32, text_len: u32, chain_id: u32) {
+pub extern "C" fn json_rpc_send(text_ptr: u32, text_len: u32, chain_id: u32) -> u32 {
     super::json_rpc_send(text_ptr, text_len, chain_id)
 }
 

--- a/bin/wasm-node/rust/src/init.rs
+++ b/bin/wasm-node/rust/src/init.rs
@@ -44,8 +44,23 @@ pub(crate) struct Client<TPlat: smoldot_light::platform::Platform, TChain> {
 }
 
 pub(crate) enum Chain {
-    Healthy(smoldot_light::ChainId),
-    Erroneous { error: String },
+    Healthy {
+        smoldot_chain_id: smoldot_light::ChainId,
+
+        /// JSON-RPC responses that is at the front of the queue according to the API. If `Some`,
+        /// a pointer to the string is referenced to within
+        /// [`Chain::Healthy::json_rpc_response_info`].
+        json_rpc_response: Option<String>,
+        /// Information about [`json_rpc_response`]. A pointer to this struct is sent over the FFI
+        /// layer to the JavaScript. As such, the pointer must never be invalidated.
+        json_rpc_response_info: Box<bindings::JsonRpcResponseInfo>,
+        /// Receiver for JSON-RPC responses sent by the client. `None` if JSON-RPC requests are
+        /// disabled on this chain.
+        json_rpc_responses_rx: Option<mpsc::Receiver<String>>,
+    },
+    Erroneous {
+        error: String,
+    },
 }
 
 pub(crate) fn init<TPlat: smoldot_light::platform::Platform, TChain>(


### PR DESCRIPTION
Close https://github.com/paritytech/smoldot/issues/2528

This PR is a major change in the public API of the JS library, as such I will bump to 0.7.0 at the next release.

Instead of passing a callback when adding a chain where the JSON-RPC responses are sent, you are now supposed to call `nextJsonRpcResponse` on the chain.
This asynchronous function waits (if necessary) for a JSON-RPC response to be available then returns it.

In addition to this, `sendJsonRpc` now returns an error if the request is malformed or if the queue is full.

This change in API has several major advantages:

- It removes an ambiguity about what to do if the `jsonRpcCallback` throws an exception.
- It is now possible to back-pressure the client by not calling `nextJsonRpcResponse`. This will cause the responses to pile up in the buffer, until a point where `sendJsonRpc` will return an error.
- It is overall easier to use the API because you no longer have to create things ahead of time (before the chain is even created) in order to pass them to the callback. See the tests that this PR rewrites for example.

## Migration

It is always possible to migrate to the new API.

If your code looks like this:

```js
const chain = await client.addChain({ jsonRpcCallback, /* other options */ ... });
```

You can rewrite it like this:

```js
const chain = await client.addChain({ /* other options */ ... });

(async () => {
    try {
        while(true) {
            const response = await chain.nextJsonRpcResponse();
            /* do whatever you want here */
        }
    } catch(_error) {
        // Will happen when the chain is removed or the client terminated.
    }
})()
```
