### PR TITLE
Fix Deno demo

### DIFF
--- a/bin/wasm-node/javascript/demo/demo-deno.ts
+++ b/bin/wasm-node/javascript/demo/demo-deno.ts
@@ -59,7 +59,7 @@ const httpConn = Deno.serveHttp(await conn.accept());
 while(true) {
     const event = await httpConn.nextRequest();
     if (!event)
-        continue;
+        break;
 
     console.log('(demo) New JSON-RPC client connected.');
 


### PR DESCRIPTION
I had to look at the source code of Deno because the doc is [non-existent](https://deno.land/api@v1.25.4?s=Deno.HttpConn#method_nextRequest_0).

When `null` is returned, it means the connection can no longer serve requests, and so if we `continue` we just get an infinite loop.
