### PR TITLE
Make Yamux return an event on stream reset

### DIFF
--- a/src/libp2p/connection/yamux.rs
+++ b/src/libp2p/connection/yamux.rs
@@ -897,9 +897,15 @@ impl<T> Yamux<T> {
                                     }
                                     _ => {}
                                 }
-                            }
 
-                            // TODO: should return an event
+                                return Ok(IncomingDataOutcome {
+                                    yamux: self,
+                                    bytes_read: total_read,
+                                    detail: Some(IncomingDataDetail::StreamReset {
+                                        substream_id: SubstreamId(stream_id),
+                                    }),
+                                });
+                            }
                         }
 
                         // Remote has sent a SYN flag. A new substream is to be opened.


### PR DESCRIPTION
Fixes a TODO in the Yamux code.

This change has absolutely no influence, as `StreamReset` events are simply ignored by the higher level code, but in principle higher level code could use it.
