### PR TITLE
Remove Chain.databaseContent function

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Removed
 
-- Removed `Chain.databaseContent` function. Use the `chainHead_unstable_finalizedDatabase` JSON-RPC function to obtain the database content instead.
+- Removed `Chain.databaseContent` function. Use the `chainHead_unstable_finalizedDatabase` JSON-RPC function to obtain the database content instead. ([#2791](https://github.com/paritytech/smoldot/pull/2791))
 
 ### Changed
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Removed
+
+- Removed `Chain.databaseContent` function. Use the `chainHead_unstable_finalizedDatabase` JSON-RPC function to obtain the database content instead.
+
 ### Changed
 
 - `Chain.sendJsonRpc` now throws a `MalformedJsonRpcError` exception if the JSON-RPC request is too large or malformed, or a `QueueFullError` if the queue of JSON-RPC requests of the chain is full. ([#2778](https://github.com/paritytech/smoldot/pull/2778))

--- a/bin/wasm-node/javascript/src/client.ts
+++ b/bin/wasm-node/javascript/src/client.ts
@@ -141,22 +141,6 @@ export interface Chain {
   nextJsonRpcResponse(): Promise<string>;
 
   /**
-   * Serializes the important information about the state of the chain so that it can be provided
-   * back in the {AddChainOptions.databaseContent} when the chain is recreated.
-   *
-   * The content of the string is opaque and shouldn't be decoded.
-   *
-   * A parameter can be passed to indicate the maximum length of the returned value (in number
-   * of bytes this string would occupy in the UTF-8 encoding). The higher this limit is the more
-   * information can be included. This parameter is optional, and not passing any value means
-   * "unbounded".
-   *
-   * @throws {AlreadyDestroyedError} If the chain has been removed or the client has been terminated.
-   * @throws {CrashError} If the background client has crashed.
-   */
-  databaseContent(maxUtf8BytesSize?: number): Promise<string>;
-
-  /**
    * Disconnects from the blockchain.
    *
    * The JSON-RPC callback will no longer be called.
@@ -295,7 +279,8 @@ export interface AddChainOptions {
   chainSpec: string;
 
   /**
-   * Content of the database of this chain. Can be obtained with {Client.databaseContent}.
+   * Content of the database of this chain. Can be obtained by using the
+   * `chainHead_unstable_finalizedDatabase` JSON-RPC function.
    *
    * Smoldot reserves the right to change its database format, making previous databases
    * incompatible. For this reason, no error is generated if the content of the database is invalid
@@ -447,13 +432,6 @@ export function start(options: ClientOptions, platformBindings: PlatformBindings
           return new Promise((resolve, reject) => {
             instance.nextJsonRpcResponse(chainId, resolve, reject)
           });
-        },
-        databaseContent: (maxUtf8BytesSize) => {
-          if (alreadyDestroyedError)
-            return Promise.reject(alreadyDestroyedError);
-          if (wasDestroyed.destroyed)
-            return Promise.reject(new AlreadyDestroyedError);
-          return instance.databaseContent(chainId, maxUtf8BytesSize);
         },
         remove: () => {
           if (alreadyDestroyedError)

--- a/bin/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
+++ b/bin/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
@@ -48,7 +48,6 @@ export interface Config {
     
     logCallback: (level: number, target: string, message: string) => void,
     jsonRpcResponsesNonEmptyCallback: (chainId: number) => void,
-    databaseContentCallback: (data: string, chainId: number) => void,
     currentTaskCallback?: (taskName: string | null) => void,
 }
 
@@ -220,21 +219,6 @@ export default function (config: Config): { imports: WebAssembly.ModuleImports, 
         json_rpc_responses_non_empty: (chainId: number) => {
             if (killedTracked.killed) return;
             config.jsonRpcResponsesNonEmptyCallback(chainId);
-        },
-
-        // Used by the Rust side in response to asking for the database content of a chain.
-        database_content_ready: (ptr: number, len: number, chainId: number) => {
-            if (killedTracked.killed) return;
-
-            const instance = config.instance!;
-
-            ptr >>>= 0;
-            len >>>= 0;
-
-            let content = buffer.utf8BytesToString(new Uint8Array(instance.exports.memory.buffer), ptr, len);
-            if (config.databaseContentCallback) {
-                config.databaseContentCallback(content, chainId);
-            }
         },
 
         // Used by the Rust side to emit a log entry.

--- a/bin/wasm-node/javascript/src/instance/bindings.ts
+++ b/bin/wasm-node/javascript/src/instance/bindings.ts
@@ -34,7 +34,6 @@ export interface SmoldotWasmExports extends WebAssembly.Exports {
     json_rpc_send: (textPtr: number, textLen: number, chainId: number) => number,
     json_rpc_responses_peek: (chainId: number) => number,
     json_rpc_responses_pop: (chainId: number) => void,
-    database_content: (chainId: number, maxSize: number) => void,
     timer_finished: (timerId: number) => void,
     connection_open_single_stream: (connectionId: number, handshakeTy: number) => void,
     connection_open_multi_stream: (connectionId: number, handshakeTyPtr: number, handshakeTyLen: number) => void,

--- a/bin/wasm-node/javascript/src/instance/raw-instance.ts
+++ b/bin/wasm-node/javascript/src/instance/raw-instance.ts
@@ -39,7 +39,6 @@ export interface Config {
     onWasmPanic: (message: string) => void,
     logCallback: (level: number, target: string, message: string) => void,
     jsonRpcResponsesNonEmptyCallback: (chainId: number) => void,
-    databaseContentCallback: (data: string, chainId: number) => void,
     currentTaskCallback?: (taskName: string | null) => void,
     cpuRateLimit: number,
 }

--- a/bin/wasm-node/rust/src/init.rs
+++ b/bin/wasm-node/rust/src/init.rs
@@ -37,8 +37,6 @@ use std::{
 pub(crate) struct Client<TPlat: smoldot_light::platform::Platform, TChain> {
     pub(crate) smoldot: smoldot_light::Client<TPlat, TChain>,
 
-    pub(crate) new_tasks_spawner: mpsc::UnboundedSender<(String, future::BoxFuture<'static, ()>)>,
-
     /// List of all chains that have been added by the user.
     pub(crate) chains: slab::Slab<Chain>,
 }
@@ -197,17 +195,15 @@ pub(crate) fn init<TPlat: smoldot_light::platform::Platform, TChain>(
         .unwrap();
 
     let client = smoldot_light::Client::new(smoldot_light::ClientConfig {
-        tasks_spawner: {
-            let new_task_tx = new_task_tx.clone();
-            Box::new(move |name, task| new_task_tx.unbounded_send((name, task)).unwrap())
-        },
+        tasks_spawner: Box::new(move |name, task| {
+            new_task_tx.unbounded_send((name, task)).unwrap()
+        }),
         system_name: env!("CARGO_PKG_NAME").into(),
         system_version: env!("CARGO_PKG_VERSION").into(),
     });
 
     Client {
         smoldot: client,
-        new_tasks_spawner: new_task_tx,
         chains: slab::Slab::with_capacity(8),
     }
 }

--- a/bin/wasm-node/rust/src/lib.rs
+++ b/bin/wasm-node/rust/src/lib.rs
@@ -323,7 +323,7 @@ fn remove_chain(chain_id: u32) {
                 .smoldot
                 .remove_chain(smoldot_chain_id);
         }
-        init::Chain::Erroneous { .. } => {},
+        init::Chain::Erroneous { .. } => {}
     }
 }
 


### PR DESCRIPTION
Close https://github.com/paritytech/smoldot/issues/2456

This PR removes the `Chain.databaseContent` function from the public API. Users are supposed to use the `chainHead_unstable_finalizedDatabase` JSON-RPC function that was added in https://github.com/paritytech/smoldot/pull/2749 instead.

This is an API breaking change. Since https://github.com/paritytech/smoldot/pull/2778 has been merged and is a breaking change, let's do other breaking changes at the same time.

