### PR TITLE
Several clean ups and refactors of peers.rs

### DIFF
--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -514,11 +514,13 @@ where
                         Connection {
                             peer_index: None,
                             user_data,
+                            outbound,
                             ..
                         },
                     ..
                 } => {
                     // Connection was incoming but its handshake wasn't finished yet.
+                    debug_assert!(!outbound);
                     return Some(Event::Shutdown {
                         connection_id,
                         peer: ShutdownPeer::IngoingHandshake,

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -1285,21 +1285,22 @@ where
         )
     }
 
-    /// Open a new outgoing substream to the given peer. A non-shutting-down connection must exist
-    /// with the current peer.
+    /// Open a new outgoing substream to the given peer. The peer-protocol combination must have
+    /// been marked as desired, and a non-shutting-down connection must exist with the current
+    /// peer.
     ///
     /// Must be passed the current moment in time in order to determine when the operation of
     /// opening the substream times out.
     ///
     /// Use [`Peers::unfulfilled_desired_outbound_substream`] in order to determine which
-    /// substreams should be opened. Note, however, that the parameters do not need to match an
-    /// item returned by [`Peers::unfulfilled_desired_outbound_substream`].
+    /// substreams should be opened.
     ///
     /// This function might generate a message destined to a connection. Use
     /// [`Peers::pull_message_to_connection`] to process these messages after it has returned.
     ///
     /// # Panic
     ///
+    /// Panics if this combination of peer-protocol isn't desired.
     /// Panics if there is no established non-shutting-down connection with the given peer.
     /// Panics if there is already an outgoing substream with this peer-protocol combination.
     ///
@@ -1321,6 +1322,7 @@ where
                 open: NotificationsOutOpenState::NotOpen,
             });
 
+        assert!(notif_state.desired);
         assert!(matches!(
             notif_state.open,
             NotificationsOutOpenState::NotOpen | NotificationsOutOpenState::ClosedByRemote

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -326,8 +326,6 @@ where
                                     .insert((actual_peer_index, connection_id));
                                 debug_assert!(_inserted);
                                 self.inner[connection_id].peer_index = Some(actual_peer_index);
-
-                                // TODO: report some kind of error on the outer API layers?
                             }
 
                             Some(self.peers[actual_peer_index].peer_id.clone())

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -1412,18 +1412,6 @@ where
         self.inner.respond_in_request(id.0, response)
     }
 
-    /// Returns `true` if there exists an established connection with the given peer.
-    // TODO: revisit this API as it's a duplicate of established_peer_connections
-    pub fn has_established_connection(&self, peer_id: &PeerId) -> bool {
-        // Connections that are shutting down are still counted, as we report the disconnected
-        // event only at the end of the shutdown.
-        match self.connection_id_for_peer(peer_id) {
-            ConnectionIdForPeer::Connected(_)
-            | ConnectionIdForPeer::ConnectedButShuttingDown(_) => true,
-            ConnectionIdForPeer::NotConnected => false,
-        }
-    }
-
     /// Returns an iterator to the list of [`PeerId`]s that we have an established connection
     /// with.
     pub fn peers_list(&self) -> impl Iterator<Item = &PeerId> {

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -1301,6 +1301,7 @@ where
     /// # Panic
     ///
     /// Panics if there is no established non-shutting-down connection with the given peer.
+    /// Panics if there is already an outgoing substream with this peer-protocol combination.
     ///
     pub fn open_out_notification(
         &mut self,
@@ -1319,6 +1320,11 @@ where
                 desired: true,
                 open: NotificationsOutOpenState::NotOpen,
             });
+
+        assert!(matches!(
+            notif_state.open,
+            NotificationsOutOpenState::NotOpen | NotificationsOutOpenState::ClosedByRemote
+        ));
 
         let substream_id = self.inner.open_out_notifications(
             connection_id,

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -493,6 +493,7 @@ where
                     self.try_clean_up_peer(expected_peer_index);
 
                     return Some(Event::Shutdown {
+                        connection_id,
                         peer: if was_established {
                             ShutdownPeer::Established {
                                 num_healthy_peer_connections,
@@ -508,6 +509,7 @@ where
                 }
 
                 collection::Event::Shutdown {
+                    id: connection_id,
                     user_data:
                         Connection {
                             peer_index: None,
@@ -518,6 +520,7 @@ where
                 } => {
                     // Connection was incoming but its handshake wasn't finished yet.
                     return Some(Event::Shutdown {
+                        connection_id,
                         peer: ShutdownPeer::IngoingHandshake,
                         user_data,
                     });
@@ -1655,11 +1658,11 @@ pub enum Event<TConn> {
 
     /// A connection has stopped.
     Shutdown {
+        /// Identifier of the connection that has started shutting down.
+        connection_id: ConnectionId,
         /// State of the connection and identity of the remote.
         peer: ShutdownPeer,
-
         /// User data that was associated to this connection.
-        // TODO: ?!
         user_data: TConn,
     },
 

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -1245,6 +1245,7 @@ where
     pub fn unfulfilled_desired_outbound_substream(
         &'_ self,
     ) -> impl Iterator<Item = (&'_ PeerId, usize)> + '_ {
+        // TODO: this is O(n), maybe add a cache
         self.peers_notifications_out.iter().filter_map(
             |((peer_index, notifications_protocol_index), state)| {
                 if !state.desired {

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -1678,7 +1678,7 @@ pub enum Event<TConn> {
 
     /// Outcome of a request started using [`Peers::start_request`].
     ///
-    /// *All* requests always lead to an outcome, even if the connection has been closed while the
+    /// All requests always lead to an outcome, even if the connection has been closed while the
     /// request was in progress.
     Response {
         /// Identifier for this request. Was returned by [`Peers::start_request`].

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -155,6 +155,7 @@ pub struct Peers<TConn, TNow> {
     /// Each [`DesiredInNotificationId`] points to this slab. Contains the connection and
     /// substream id to accept or refuse. Items are always initially set to `Some`, but they can
     /// be set to `None` if the remote cancels its request.
+    // TODO: we should just pass through the events from the collection/established
     desired_in_notifications: slab::Slab<Option<(collection::SubstreamId, usize, usize)>>,
 }
 

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -2059,7 +2059,7 @@ where
         loop {
             // Note: we can't use a `while let` due to borrow checker errors.
             let (peer_id, notifications_protocol_index) =
-                match self.inner.unfulfilled_desired_outbound_substream().next() {
+                match self.inner.unfulfilled_desired_outbound_substream(false).next() {
                     Some((peer_id, idx)) => (peer_id.clone(), idx),
                     None => break,
                 };

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -1116,7 +1116,13 @@ where
             != 1;
 
         // If the peer is completely unreachable, unassign all of its slots.
-        if !has_any_attempt_left && !self.inner.has_established_connection(expected_peer_id) {
+        if !has_any_attempt_left
+            && self
+                .inner
+                .established_peer_connections(expected_peer_id)
+                .count()
+                == 0
+        {
             let expected_peer_id = expected_peer_id.clone(); // Necessary for borrowck reasons.
 
             for chain_index in 0..self.chains.len() {
@@ -2277,7 +2283,7 @@ where
     /// Returns `true` if there exists an established connection with the given peer.
     // TODO: revisit this API w.r.t. shutdowns
     pub fn has_established_connection(&self, peer_id: &PeerId) -> bool {
-        self.inner.has_established_connection(peer_id)
+        self.inner.established_peer_connections(peer_id).count() != 0
     }
 
     /// Returns an iterator to the list of [`PeerId`]s that we have an established connection

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -2058,9 +2058,9 @@ where
         // to open.
         loop {
             // Note: we can't use a `while let` due to borrow checker errors.
-            let (id, _, notifications_protocol_index) =
-                match self.inner.next_unfulfilled_desired_outbound_substream() {
-                    Some(v) => v,
+            let (peer_id, notifications_protocol_index) =
+                match self.inner.unfulfilled_desired_outbound_substream().next() {
+                    Some((peer_id, idx)) => (peer_id.clone(), idx),
                     None => break,
                 };
 
@@ -2091,7 +2091,12 @@ where
                 unreachable!()
             };
 
-            self.inner.open_out_notification(id, now.clone(), handshake);
+            self.inner.open_out_notification(
+                &peer_id,
+                notifications_protocol_index,
+                now.clone(),
+                handshake,
+            );
         }
 
         event_to_return


### PR DESCRIPTION
This PR does a major clean-up pass on `peers.rs` and cleans up the remnants of the old times when it was asynchronous.

In details:

- Completely remove the `DesiredOutNotificationId` system where you first allocated a "desired outbound request" and then send the handshake with a different function.
- Add a `unfulfilled_desired_peers` field so that we simply return the content of the field in the `unfulfilled_desired_peers()` function instead of iterating through everything.
- When a substream is marked as "not desired" and it is currently opening, we no longer immediately cancel the opening and instead we generate an event about the opening having failed. This makes it possible for API users to track which substreams are currently being open.
- A couple of minor changes: remove a redundant function, add documentation, etc.

I have other changes in mind, which I'll do later as they also touch files other than `peers.rs`.
