### PR TITLE
Remove weird sentence from CHANGELOG

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 - `Chain.sendJsonRpc` now throws a `MalformedJsonRpcError` exception if the JSON-RPC request is too large or malformed, or a `QueueFullError` if the queue of JSON-RPC requests of the chain is full. ([#2778](https://github.com/paritytech/smoldot/pull/2778))
 - Removed `AddChainOptions.jsonRpcCallback`. Use the new `Chain.nextJsonRpcResponse` asynchronous function to pull JSON-RPC responses instead of registering a callback. A `AddChainOptions.disableJsonRpc` flag is now supported in order to bring the same effects as not passing any `jsonRpcCallback`. ([#2778](https://github.com/paritytech/smoldot/pull/2778))
-- Removed the `version` field of the struct returned by the `rpc_methods` function. This is technically a breaking change, but it has been introduced in a minor version bump because it is very insubstantial. ([#2756](https://github.com/paritytech/smoldot/pull/2756))
+- Removed the `version` field of the struct returned by the `rpc_methods` function. ([#2756](https://github.com/paritytech/smoldot/pull/2756))
 
 ### Fixed
 


### PR DESCRIPTION
I expected this change to `rpc_methods` to land in a minor version, but it ended up landing in a major version. Thus the sentence in the CHANGELOG is now incorrect. This PR removes it.