### PR TITLE
Interpret 0 maximum block as no maximum

### DIFF
--- a/src/network/protocol/block_request.rs
+++ b/src/network/protocol/block_request.rs
@@ -189,8 +189,11 @@ pub fn decode_block_request(
             (Some(_), Some(_)) => return Err(DecodeBlockRequestError::ProtobufDecode),
             (None, None) => return Err(DecodeBlockRequestError::MissingStartBlock),
         },
-        desired_count: NonZeroU32::new(max_blocks.unwrap_or(u32::max_value()))
-            .ok_or(DecodeBlockRequestError::ZeroBlocksRequested)?,
+        desired_count: {
+            // A missing field or a `0` field are both interpreted as "no limit".
+            NonZeroU32::new(max_blocks.unwrap_or(u32::max_value()))
+                .unwrap_or(NonZeroU32::new(u32::max_value()).unwrap())
+        },
         direction: match direction {
             0 => BlocksRequestDirection::Ascending,
             1 => BlocksRequestDirection::Descending,


### PR DESCRIPTION
Substrate can in principle send requests with `0` maximum blocks. This is meant to mean "no limit".

I've discovered this mismatch while investigating https://github.com/paritytech/smoldot/issues/2833, however this is not the same issue as https://github.com/paritytech/smoldot/issues/2833.
