### PR TITLE
Fix close_write() being called too eagerly

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fix the responses to libp2p identify requests being wrongly empty.
 - Fix some Merkle proofs and SCALE-encoded structures being accepted as correct when they are actually invalid. This is a very minor fix that can presumably not be used as an attack vector. ([#2819](https://github.com/paritytech/smoldot/pull/2819))
 
 ## 0.7.1 - 2022-10-04

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix the responses to libp2p identify requests being wrongly empty.
+- Fix the responses to libp2p identify requests being wrongly empty. ([#2840](https://github.com/paritytech/smoldot/pull/2840))
 - Fix some Merkle proofs and SCALE-encoded structures being accepted as correct when they are actually invalid. This is a very minor fix that can presumably not be used as an attack vector. ([#2819](https://github.com/paritytech/smoldot/pull/2819))
 
 ## 0.7.1 - 2022-10-04

--- a/src/libp2p/collection/multi_stream.rs
+++ b/src/libp2p/collection/multi_stream.rs
@@ -818,7 +818,7 @@ where
                         // that the substream is dead. If the reading side is still open, we
                         // indicate that it's not dead and store it in the state machine while
                         // waiting for it to be closed by the remote.
-                        read_write.close_write();
+                        read_write.close_write_if_empty();
                         let handshake_substream_still_open = read_write.incoming_buffer.is_some();
 
                         let mut established = established.take().unwrap();
@@ -860,7 +860,7 @@ where
                 // substream is dead. If the reading side is still open, we indicate that it's not
                 // dead and simply wait for the remote to close it.
                 // TODO: kill the connection if the remote sends more data?
-                read_write.close_write();
+                read_write.close_write_if_empty();
                 if read_write.incoming_buffer.is_none() {
                     *handshake_substream = None;
                     true

--- a/src/libp2p/collection/single_stream.rs
+++ b/src/libp2p/collection/single_stream.rs
@@ -803,7 +803,7 @@ where
 
                 // This might have been done already during the shutdown process, but we do it
                 // again just in case.
-                read_write.close_write();
+                read_write.close_write_if_empty();
             }
 
             SingleStreamConnectionTaskInner::ShutdownWaitingAck {

--- a/src/libp2p/connection/established/single_stream.rs
+++ b/src/libp2p/connection/established/single_stream.rs
@@ -222,7 +222,7 @@ where
                 && self.inner.yamux.goaway_sent()
                 && self.inner.yamux.received_goaway().is_some()
             {
-                read_write.close_write();
+                read_write.close_write_if_empty();
             }
 
             // Any meaningful activity within this loop can set this value to `true`. If this

--- a/src/libp2p/connection/established/substream.rs
+++ b/src/libp2p/connection/established/substream.rs
@@ -683,9 +683,10 @@ where
 
                 read_write.wake_up_after(&timeout);
 
-                read_write.write_from_vec_deque(&mut request);
                 if request.is_empty() {
                     read_write.close_write();
+                } else {
+                    read_write.write_from_vec_deque(&mut request);
                 }
 
                 let incoming_buffer = match read_write.incoming_buffer {
@@ -786,11 +787,11 @@ where
             ),
             SubstreamInner::RequestInApiWait => (Some(SubstreamInner::RequestInApiWait), None),
             SubstreamInner::RequestInRespond { mut response } => {
-                read_write.write_from_vec_deque(&mut response);
                 if response.is_empty() {
                     read_write.close_write();
                     (None, None)
                 } else {
+                    read_write.write_from_vec_deque(&mut response);
                     (Some(SubstreamInner::RequestInRespond { response }), None)
                 }
             }

--- a/src/libp2p/read_write.rs
+++ b/src/libp2p/read_write.rs
@@ -96,13 +96,6 @@ impl<'a, TNow> ReadWrite<'a, TNow> {
 
     /// Sets the writing side of the connection to closed.
     ///
-    /// This is simply a shortcut for setting [`ReadWrite::outgoing_buffer`] to `None`.
-    pub fn close_write(&mut self) {
-        self.outgoing_buffer = None;
-    }
-
-    /// Sets the writing side of the connection to closed.
-    ///
     /// This is simply a shortcut for setting [`ReadWrite::outgoing_buffer`] to `None` if it
     /// doesn't contain any data.
     pub fn close_write_if_empty(&mut self) {

--- a/src/libp2p/read_write.rs
+++ b/src/libp2p/read_write.rs
@@ -101,6 +101,20 @@ impl<'a, TNow> ReadWrite<'a, TNow> {
         self.outgoing_buffer = None;
     }
 
+    /// Sets the writing side of the connection to closed.
+    ///
+    /// This is simply a shortcut for setting [`ReadWrite::outgoing_buffer`] to `None` if it
+    /// doesn't contain any data.
+    pub fn close_write_if_empty(&mut self) {
+        if self
+            .outgoing_buffer
+            .as_ref()
+            .map_or(false, |b| b.0.is_empty() && b.1.is_empty())
+        {
+            self.outgoing_buffer = None;
+        }
+    }
+
     /// Returns the size of the data available in the incoming buffer.
     pub fn incoming_buffer_available(&self) -> usize {
         self.incoming_buffer.as_ref().map_or(0, |buf| buf.len())


### PR DESCRIPTION
Fix #2831 

The problem turned out to be very stupid:
Calling `close_write()` is just a shortcut for `outgoing_buffer = None`.
So you're supposed to call `close_write()` when you have nothing more to write.

The problem is that we're calling `write_from_vec_deque(data)`, which transfers data from `data` to `outgoing_buffer`. Then we realize that `data` is empty (because it's been entirely copied to `outgoing_buffer`), and call `close_write()`. This sets `outgoing_buffer` to `None` and thus erases the data that we've just copied.

Instead, we now call `close_write` at the next iteration (when the data will have been extracted out), which is what you're supposed to do.

Additionally, as a safety measure, I've replaced `close_write` with `close_write_if_empty`. I think that `close_write` is too dangerous. There's never a situation where you would want to cancel sending data that you've already queued for writing.
