### PR TITLE
Remove persist-credentials: false when checking out

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          persist-credentials: false
           path: repo
       - uses: actions/setup-node@v3.5.0
         with:


### PR DESCRIPTION
It seems that the checkout action does a ton of dark magic which is useful when later you want to `git push` again.

See https://github.com/actions/checkout#push-a-commit-using-the-built-in-token