### PR TITLE
Stay in the same repository in docs-publish to benefit from the actions/checkout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,7 @@ jobs:
           git config user.name "GitHub Action"
           git config user.password ${{ secrets.GITHUB_TOKEN }}
           git checkout --orphan gh-pages
+          git rm -rf .
           git clean -d --force
           mv ../upload/* .
           git add --all

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,15 +70,15 @@ jobs:
           mv ./repo/target/doc/* ./upload/doc-rust
           mv ./repo/bin/wasm-node/javascript/dist/doc/* ./upload/doc-javascript
       - run: |
-          git init
           git config user.email "github-action@users.noreply.github.com"
           git config user.name "GitHub Action"
           git config user.password ${{ secrets.GITHUB_TOKEN }}
-          git checkout -b gh-pages
+          git checkout --orphan gh-pages
+          git reset --hard
+          mv ../upload .
           git add --all
           git commit -m "Documentation"
-          git remote add origin ${{ github.repositoryUrl }}
-        working-directory: ./upload
+        working-directory: ./repo
       - run: git push -f origin gh-pages:gh-pages
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         working-directory: ./upload

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
           git config user.name "GitHub Action"
           git config user.password ${{ secrets.GITHUB_TOKEN }}
           git checkout --orphan gh-pages
-          git reset --hard
+          git rm -rf .
           mv ../upload .
           git add --all
           git commit -m "Documentation"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,8 +74,8 @@ jobs:
           git config user.name "GitHub Action"
           git config user.password ${{ secrets.GITHUB_TOKEN }}
           git checkout --orphan gh-pages
-          git rm -rf .
-          mv ../upload .
+          git clean -d --force
+          mv ../upload/* .
           git add --all
           git commit -m "Documentation"
         working-directory: ./repo


### PR DESCRIPTION
https://github.com/paritytech/smoldot/pull/2855 wasn't actually working because the `actions/checkout` configures only the local git repository.

This PR does it hopefully better.
