### PR TITLE
Fix directory where git push is run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,7 +82,7 @@ jobs:
         working-directory: ./repo
       - run: git push -f origin gh-pages:gh-pages
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        working-directory: ./upload
+        working-directory: ./repo
 
   npm-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
cc https://github.com/paritytech/smoldot/issues/2856

It's amazing. The CI tests everything during a PR except a single line (`git push`, for obvious reasons), yet this single line causes tons of problems.
