### PR TITLE
Fix panic when sending block announces to disconnected peers

### DIFF
--- a/bin/light-base/src/network_service.rs
+++ b/bin/light-base/src/network_service.rs
@@ -771,7 +771,10 @@ impl<TPlat: Platform> NetworkService<TPlat> {
         let mut guarded = self.shared.guarded.lock().await;
 
         // The call to `send_block_announce` below panics if we have no active substream.
-        if !guarded.network.can_send_block_announces(target, chain_index) {
+        if !guarded
+            .network
+            .can_send_block_announces(target, chain_index)
+        {
             return Err(QueueNotificationError::NoConnection);
         }
 

--- a/bin/light-base/src/network_service.rs
+++ b/bin/light-base/src/network_service.rs
@@ -770,9 +770,8 @@ impl<TPlat: Platform> NetworkService<TPlat> {
     ) -> Result<(), QueueNotificationError> {
         let mut guarded = self.shared.guarded.lock().await;
 
-        // The call to `send_block_announce` below panics if we have no active connection.
-        // TODO: not the correct check; must make sure that we have a substream open
-        if !guarded.network.can_start_requests(target) {
+        // The call to `send_block_announce` below panics if we have no active substream.
+        if !guarded.network.can_send_block_announces(target, chain_index) {
             return Err(QueueNotificationError::NoConnection);
         }
 

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -1286,7 +1286,8 @@ where
     ///
     /// # Panics
     ///
-    /// Panics if [`SubstreamId`] is not a fully open outbound notifications substream.
+    /// Panics if there is no fully-open outbound substream with that peer-protocol combination.
+    /// This can be checked using [`Peers::can_queue_notification`].
     ///
     pub fn queue_notification(
         &mut self,
@@ -1319,6 +1320,35 @@ where
             Err(collection::QueueNotificationError::QueueFull) => {
                 Err(QueueNotificationError::QueueFull)
             }
+        }
+    }
+
+    /// Returns `true` if it is allowed to call [`Peers::queue_notification`], in other words if
+    /// there is an outbound notifications substream currently open with the target.
+    ///
+    /// If this function returns `false`, calling [`Peers::queue_notification`] will panic.
+    pub fn can_queue_notification(
+        &self,
+        target: &PeerId,
+        notifications_protocol_index: usize,
+    ) -> bool {
+        let peer_index = match self.peer_indices.get(target) {
+            Some(idx) => *idx,
+            None => return false,
+        };
+
+        match self
+            .peers_notifications_out
+            .get(&(peer_index, notifications_protocol_index))
+            .map(|state| &state.open)
+        {
+            Some(NotificationsOutOpenState::Open(_)) => true,
+            None
+            | Some(
+                NotificationsOutOpenState::Opening(_)
+                | NotificationsOutOpenState::NotOpen
+                | NotificationsOutOpenState::ClosedByRemote,
+            ) => false,
         }
     }
 

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -834,12 +834,9 @@ where
     ///
     /// If this function returns `false`, calling [`ChainNetwork::send_block_announce`] will
     /// panic.
-    pub fn can_send_block_announces(
-        &self,
-        target: &PeerId,
-        chain_index: usize,
-    ) -> bool {
-        self.inner.can_queue_notification(target, chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN)
+    pub fn can_send_block_announces(&self, target: &PeerId, chain_index: usize) -> bool {
+        self.inner
+            .can_queue_notification(target, chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN)
     }
 
     /// Returns the list of peers for which we have a fully established notifications protocol of

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -829,6 +829,19 @@ where
         )
     }
 
+    /// Returns `true` if it is allowed to call [`ChainNetwork::send_block_announce`], in other
+    /// words if there is an outbound block announces substream currently open with the target.
+    ///
+    /// If this function returns `false`, calling [`ChainNetwork::send_block_announce`] will
+    /// panic.
+    pub fn can_send_block_announces(
+        &self,
+        target: &PeerId,
+        chain_index: usize,
+    ) -> bool {
+        self.inner.can_queue_notification(target, chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN)
+    }
+
     /// Returns the list of peers for which we have a fully established notifications protocol of
     /// the given protocol.
     pub fn opened_transactions_substream(


### PR DESCRIPTION
Doesn't warrant a CHANGELOG entry because this relates to the full node only.