### PR TITLE
Update Rust version to v1.64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         # Since build artifacts are specific to a nightly version, we pin the specific nightly
         # version to use in order to not invalidate the build cache every day. The exact version
         # is completely arbitrary.
-        toolchain: nightly-2022-06-05
+        toolchain: nightly-2022-10-16
         override: true
     - uses: baptiste0928/cargo-install@v1  # This action ensures that the compilation is cached.
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
   test-64bits:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.61
+      image: rust:1.64
     steps:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v1
@@ -36,7 +36,7 @@ jobs:
   test-32bits:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.61
+      image: rust:1.64
     steps:
     - run: apt-get update && apt install -y libc6-dev-i386
     - uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
   wasm-node-check:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.61
+      image: rust:1.64
     steps:
     - run: apt-get update && apt install -y binaryen # For `wasm-opt`
     - uses: actions/checkout@v3
@@ -63,7 +63,7 @@ jobs:
   wasm-node-size-diff:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.61
+      image: rust:1.64
     steps:
     - run: apt-get update && apt install -y cmake # TODO: remove; temporarily needed to build the `prost-build` library in the "before" comparison
     - uses: actions/checkout@v3
@@ -98,7 +98,7 @@ jobs:
   check-features:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.61
+      image: rust:1.64
     steps:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v1
@@ -141,7 +141,7 @@ jobs:
   check-rustdoc-links:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.61
+      image: rust:1.64
     steps:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,7 +87,7 @@ jobs:
   npm-publish:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.61
+      image: rust:1.64
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.5.0

--- a/bin/light-base/src/lib.rs
+++ b/bin/light-base/src/lib.rs
@@ -615,8 +615,7 @@ impl<TPlat: platform::Platform, TChain> Client<TPlat, TChain> {
                 // The chain to add always has a corresponding chain running. Simply grab the
                 // existing services and existing log name.
                 // The `log_name` created above is discarded in favour of the existing log name.
-                entry.get_mut().num_references =
-                    NonZeroU32::new(entry.get_mut().num_references.get() + 1).unwrap();
+                entry.get_mut().num_references = entry.get().num_references.checked_add(1).unwrap();
                 let entry = entry.into_mut();
                 (&mut entry.services, &entry.log_name)
             }

--- a/bin/light-base/src/util.rs
+++ b/bin/light-base/src/util.rs
@@ -32,7 +32,7 @@
 // TODO: this is a complete hack ^
 pub async fn yield_twice() {
     let mut num_pending_remain = 2;
-    futures::future::poll_fn(move |cx| {
+    core::future::poll_fn(move |cx| {
         if num_pending_remain > 0 {
             num_pending_remain -= 1;
             cx.waker().wake_by_ref();

--- a/bin/wasm-node/javascript/prepare.mjs
+++ b/bin/wasm-node/javascript/prepare.mjs
@@ -40,7 +40,7 @@ if (buildProfile != 'debug' && buildProfile != 'min-size-release')
 // The Rust version is pinned because the wasi target is still unstable. Without pinning, it is
 // possible for the wasm-js bindings to change between two Rust versions. Feel free to update
 // this version pin whenever you like, provided it continues to build.
-const rustVersion = '1.61.0';
+const rustVersion = '1.64.0';
 
 // Assume that the user has `rustup` installed and make sure that `rust_version` is available.
 // Because `rustup install` requires an Internet connection, check whether the toolchain is

--- a/src/libp2p/async_std_connection/with_buffers.rs
+++ b/src/libp2p/async_std_connection/with_buffers.rs
@@ -24,11 +24,8 @@
 
 // TODO: usage and example
 
-use core::{fmt, pin::Pin, task::Poll};
-use futures::{
-    io::{AsyncRead, AsyncWrite},
-    prelude::*,
-};
+use core::{fmt, future, pin::Pin, task::Poll};
+use futures::io::{AsyncRead, AsyncWrite};
 use std::io;
 
 /// Holds an implementation of `AsyncRead` and `AsyncWrite`, alongside with a read buffer and a

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -917,8 +917,7 @@ where
                         match self.kbuckets_peers.entry(peer_id) {
                             hashbrown::hash_map::Entry::Occupied(e) => {
                                 let e = e.into_mut();
-                                e.num_references =
-                                    NonZeroUsize::new(e.num_references.get() + 1).unwrap();
+                                e.num_references = e.num_references.checked_add(1).unwrap();
                                 e
                             }
                             hashbrown::hash_map::Entry::Vacant(e) => {


### PR DESCRIPTION
https://github.com/paritytech/smoldot/pull/2881 currently fails CI because it uses a function that wasn't stable yet in Rust 1.61.
While I could bypass the issue, it makes sense to just update the Rust version.