### PR TITLE
Fail if wasm-opt isn't installed when passing `--release`

### DIFF
--- a/bin/wasm-node/javascript/prepare.mjs
+++ b/bin/wasm-node/javascript/prepare.mjs
@@ -87,19 +87,13 @@ try {
     const rustOutput = "../../../target/wasm32-wasi/" + buildProfile + "/smoldot_light_wasm.wasm";
     let optimisationStageOutput = path.join(tmpDir, 'tmp.wasm');
 
-    try {
-        if (buildProfile == 'min-size-release') {
-            child_process.execSync(
-                "wasm-opt -o " + optimisationStageOutput + " -Oz --strip-debug --vacuum --dce "
-                + "../../../target/wasm32-wasi/" + buildProfile + "/smoldot_light_wasm.wasm",
-                { 'stdio': 'inherit' }
-            );
-        } else {
-            optimisationStageOutput = rustOutput;
-        }
-    } catch (error) {
-        console.warn("Failed to run `wasm-opt`. Using the direct Rust output instead.");
-        console.warn(error);
+    if (buildProfile == 'min-size-release') {
+        child_process.execSync(
+            "wasm-opt -o " + optimisationStageOutput + " -Oz --strip-debug --vacuum --dce "
+            + "../../../target/wasm32-wasi/" + buildProfile + "/smoldot_light_wasm.wasm",
+            { 'stdio': 'inherit' }
+        );
+    } else {
         optimisationStageOutput = rustOutput;
     }
 


### PR DESCRIPTION
When building the Wasm file to embed in the browser, and `--release` is provided, we try to run `wasm-opt` on it.
If `--debug` is provided, we don't do it.

Because we used to do it with `--debug` as well, there exists a fallback if `wasm-opt` isn't installed that will simply not run `wasm-opt`.

This PR removes this fallback, so that the release build fails if `wasm-opt` isn't installed. `--debug` will still work even if it's not installed.
