### PR TITLE
Add wasm-opt when checking wasm node size diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     container:
       image: rust:1.61
     steps:
-    - run: apt-get update && apt install -y cmake # TODO: remove; temporarily needed to build the `prost-build` library in the "before" comparison
+    - run: apt-get update && apt install -y binaryen cmake # TODO: remove cmake; temporarily needed to build the `prost-build` library in the "before" comparison
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0  # Necessary to fetch pull request base below

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     container:
       image: rust:1.61
     steps:
-    - run: apt-get update && apt install -y binaryen cmake # TODO: remove cmake; temporarily needed to build the `prost-build` library in the "before" comparison
+    - run: apt-get update && apt install -y binaryen # For `wasm-opt`
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0  # Necessary to fetch pull request base below


### PR DESCRIPTION
It turns out that it wasn't installed, completely skewing the results.

I've also removed `cmake`, which was still there from before we switched to our own protobuf codec, thereby fixing a TODO.
