### PR TITLE
Reduce the allocations when emitting logs

### DIFF
--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -2434,7 +2434,7 @@ enum LogEmitInner {
         data_size: u32,
     },
     Log {
-        /// Log level. Arbitrary number indicated by runtime, but typically in the 1..=5 range.
+        /// Log level. Arbitrary number indicated by runtime, but typically in the `1..=5` range.
         _log_level: u32,
         /// Pointer to the string of the log target. Guaranteed to be in range and to be UTF-8.
         _target_str_ptr: u32,

--- a/src/executor/read_only_runtime_host.rs
+++ b/src/executor/read_only_runtime_host.rs
@@ -21,10 +21,7 @@
 
 use crate::executor::{self, host, vm};
 
-use alloc::{
-    string::{String, ToString as _},
-    vec::Vec,
-};
+use alloc::{string::String, vec::Vec};
 use core::{fmt, iter};
 
 /// Configuration for [`run`].
@@ -334,16 +331,32 @@ impl Inner {
                     // rarely log more than a few hundred bytes. This limit is hardcoded rather
                     // than configurable because it is not expected to be reachable unless
                     // something is very wrong.
-                    // TODO: optimize somehow? don't create an intermediary String?
-                    let message = req.to_string();
-                    if self.logs.len().saturating_add(message.len()) >= 1024 * 1024 {
-                        return RuntimeHostVm::Finished(Err(Error {
-                            detail: ErrorDetail::LogsTooLong,
-                            prototype: host::HostVm::LogEmit(req).into_prototype(),
-                        }));
+                    struct WriterWithMax<'a>(&'a mut String);
+                    impl<'a> fmt::Write for WriterWithMax<'a> {
+                        fn write_str(&mut self, s: &str) -> fmt::Result {
+                            if self.0.len().saturating_add(s.len()) >= 1024 * 1024 {
+                                return Err(fmt::Error);
+                            }
+                            self.0.push_str(s);
+                            Ok(())
+                        }
+                        fn write_char(&mut self, c: char) -> fmt::Result {
+                            if self.0.len().saturating_add(1) >= 1024 * 1024 {
+                                return Err(fmt::Error);
+                            }
+                            self.0.push(c);
+                            Ok(())
+                        }
                     }
-
-                    self.logs.push_str(&message);
+                    match fmt::write(&mut WriterWithMax(&mut self.logs), format_args!("{}", req)) {
+                        Ok(()) => {}
+                        Err(fmt::Error) => {
+                            return RuntimeHostVm::Finished(Err(Error {
+                                detail: ErrorDetail::LogsTooLong,
+                                prototype: host::HostVm::LogEmit(req).into_prototype(),
+                            }));
+                        }
+                    }
                     self.vm = req.resume();
                 }
 


### PR DESCRIPTION
Instead of turning things immediately into a string, we instead put the values provided to the host function into the `LogEmit` struct, and do the formatting and turning into string later.

This unlocks a potential future change where the API user can format the runtime logs the way they want.
