### PR TITLE
Remove concept of ready substreams from multi_stream code

### DIFF
--- a/bin/light-base/src/network_service/tasks.rs
+++ b/bin/light-base/src/network_service/tasks.rs
@@ -434,13 +434,9 @@ async fn multi_stream_connection_task<TPlat: Platform>(
             wake_up_after = None;
         }
 
-        // Perform a read-write on all substreams that are ready.
-        // TODO: what is a ready substream is a bit of a clusterfuck, figure out
-        for substream_id in connection_task
-            .ready_substreams()
-            .copied()
-            .collect::<Vec<_>>()
-        {
+        // Perform a read-write on all substreams.
+        // TODO: trying to read/write every single substream every single time is suboptimal, but making this not suboptimal is very complicated
+        for substream_id in open_substreams.iter().map(|(id, _)| id).collect::<Vec<_>>() {
             let substream = &mut open_substreams[substream_id];
 
             let mut read_write = ReadWrite {

--- a/src/libp2p/collection/multi_stream.rs
+++ b/src/libp2p/collection/multi_stream.rs
@@ -220,12 +220,9 @@ where
     /// [`MultiStreamConnectionTask::add_substream`], or [`MultiStreamConnectionTask::reset`]
     /// has been called. Multiple messages can happen in a row.
     ///
-    /// Because this function frees space in a buffer, calling
-    /// [`MultiStreamConnectionTask::ready_substreams`] and processing substreams again after it
+    /// Because this function frees space in a buffer, processing substreams again after it
     /// has returned might read/write more data and generate an event again. In other words,
-    /// the API user should call
-    ///  [`MultiStreamConnectionTask::ready_substreams`] and
-    /// [`MultiStreamConnectionTask::substream_read_write`], and
+    /// the API user should call [`MultiStreamConnectionTask::substream_read_write`] and
     /// [`MultiStreamConnectionTask::pull_message_to_coordinator`] repeatedly in a loop until no
     /// more message is generated.
     pub fn pull_message_to_coordinator(
@@ -375,7 +372,7 @@ where
     ///
     /// Calling this function might generate data to send to the connection. You should call
     /// [`MultiStreamConnectionTask::desired_outbound_substreams`] and
-    /// [`MultiStreamConnectionTask::ready_substreams`] after this function has returned.
+    /// [`MultiStreamConnectionTask::substream_read_write`] after this function has returned.
     pub fn inject_coordinator_message(&mut self, message: CoordinatorToConnection<TNow>) {
         match (message.inner, &mut self.connection) {
             (

--- a/src/libp2p/connection/established/multi_stream.rs
+++ b/src/libp2p/connection/established/multi_stream.rs
@@ -285,8 +285,6 @@ where
                 read_write.wake_up_after(&self.next_ping);
             }
 
-            let written_bytes_before = read_write.written_bytes;
-
             let (mut substream_update, event) = substream.read_write(read_write);
 
             match (event, substream_update.as_mut()) {


### PR DESCRIPTION
Right now the state machine of a multi-stream (i.e. WebRTC) connection has a function returning a list of substreams that have data ready to be written out.

The objective of this function is simply to allow optimizing the code that effectively reads/writes, in order to not try to read/write for nothing.

However this function is currently not properly implemented.
One way to easily implement it better would be to iterate over all substreams and check which ones are ready. But this is pointless, because the code that effectively reads/writes can already do that by trying to read each one one by one.
The best way to implement this function would require a lot of changes in the lower level substream code, which are quite complicated and I don't have the motivation to make right now.

This PR simply removes the concept of ready substreams at the moment. The code simply tries to read/write every single open substream, not trying to skip the ones that aren't ready.
