### PR TITLE
Implement WebRTC messages framing

### DIFF
--- a/bin/light-base/src/json_rpc_service.rs
+++ b/bin/light-base/src/json_rpc_service.rs
@@ -1289,7 +1289,7 @@ impl<TPlat: Platform> Background<TPlat> {
 
     async fn storage_query(
         &self,
-        keys: impl Iterator<Item = impl AsRef<[u8]>> + Clone,
+        keys: impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone,
         hash: &[u8; 32],
         total_attempts: u32,
         timeout_per_request: Duration,

--- a/bin/light-base/src/network_service.rs
+++ b/bin/light-base/src/network_service.rs
@@ -585,7 +585,7 @@ impl<TPlat: Platform> NetworkService<TPlat> {
         self: Arc<Self>,
         chain_index: usize,
         target: PeerId, // TODO: takes by value because of futures longevity issue
-        config: protocol::StorageProofRequestConfig<impl Iterator<Item = impl AsRef<[u8]>>>,
+        config: protocol::StorageProofRequestConfig<impl Iterator<Item = impl AsRef<[u8]> + Clone>>,
         timeout: Duration,
     ) -> Result<service::EncodedMerkleProof, StorageProofRequestError> {
         let rx = {

--- a/bin/light-base/src/network_service/tasks.rs
+++ b/bin/light-base/src/network_service/tasks.rs
@@ -382,7 +382,7 @@ async fn multi_stream_connection_task<TPlat: Platform>(
     // from this slice the data to send. Consequently, the write buffer is held locally. This is
     // suboptimal compared to writing to a write buffer provided by the platform, but it is easier
     // to implement it this way.
-    let mut write_buffer = vec![0; 4096];
+    let mut write_buffer = vec![0; 16384]; // TODO: the write buffer must not exceed 16kiB due to the libp2p WebRTC spec; this should ideally be enforced through the connection task API
 
     // When reading/writing substreams, the substream can ask to be woken up after a certain time.
     // This variable stores the earliest time when we should be waking up.

--- a/bin/light-base/src/sync_service.rs
+++ b/bin/light-base/src/sync_service.rs
@@ -398,7 +398,7 @@ impl<TPlat: Platform> SyncService<TPlat> {
         block_number: u64,
         block_hash: &[u8; 32],
         storage_trie_root: &[u8; 32],
-        requested_keys: impl Iterator<Item = impl AsRef<[u8]>> + Clone,
+        requested_keys: impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone,
         total_attempts: u32,
         timeout_per_request: Duration,
         _max_parallel: NonZeroU32,

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- The WebRTC protocol implementation is now up to date with the specification. While the specification hasn't been finalized yet and could still evolve, the current version is believed to be likely to be final. ([#2896](https://github.com/paritytech/smoldot/pull/2896))
+
 ### Fixed
 
 - Fix timeout not being checked when opening a notifications substream. ([#2323](https://github.com/paritytech/smoldot/pull/2323))

--- a/bin/wasm-node/javascript/src/index-browser.ts
+++ b/bin/wasm-node/javascript/src/index-browser.ts
@@ -256,17 +256,17 @@ export function start(options?: ClientOptions): Client {
               "v=0" + "\n" +
               // Identifies the creator of the SDP document. We are allowed to use dummy values
               // (`-` and `0.0.0.0`) to remain anonymous, which we do. Note that "IN" means
-              // "Internet". (RFC8866)
+              // "Internet" (and not "input"). (RFC8866)
               "o=- 0 0 IN IP" + ipVersion  + " " + targetIp + "\n" +
               // Name for the session. We are allowed to pass a dummy `-`. (RFC8866)
               "s=-" + "\n" +
               // Start and end of the validity of the session. `0 0` means that the session never
               // expires. (RFC8866)
               "t=0 0" + "\n" +
-              // A lite implementation is only appropriate for devices that will
-              // *always* be connected to the public Internet and have a public
+              // A non-lite implementation is only appropriate for devices that will
+              // always be connected to the public Internet and have a public
               // IP address at which it can receive packets from any
-              // correspondent.  ICE will not function when a lite implementation
+              // correspondent.  ICE will not function when a non-lite implementation
               // is placed behind a NAT (RFC8445).
               "a=ice-lite" + "\n" +
               // A `m=` line describes a request to establish a certain protocol.
@@ -278,7 +278,7 @@ export function start(options?: ClientOptions): Client {
               // RFCs: 8839, 8866, 8841
               "m=application " + targetPort + " " + "UDP/DTLS/SCTP webrtc-datachannel" + "\n" +
               // Indicates the IP address of the remote.
-              // Note that "IN" means "Internet".
+              // Note that "IN" means "Internet" (and not "input").
               "c=IN IP" + ipVersion + " " + targetIp + "\n" +
               // Media ID - uniquely identifies this media stream (RFC9143).
               "a=mid:0" + "\n" +

--- a/bin/wasm-node/javascript/src/index-browser.ts
+++ b/bin/wasm-node/javascript/src/index-browser.ts
@@ -303,7 +303,7 @@ export function start(options?: ClientOptions): Client {
               // (UDP or TCP)
               "a=sctp-port:5000" + "\n" +
               // The maximum SCTP user message size (in bytes) (RFC8841)
-              "a=max-message-size:100000" + "\n" +
+              "a=max-message-size:16384" + "\n" +  // TODO: should this be part of the spec?
               // A transport address for a candidate that can be used for connectivity checks (RFC8839).
               "a=candidate:1 1 UDP 1 " + targetIp + " " + targetPort + " typ host" + "\n";
 

--- a/bin/wasm-node/javascript/src/index-browser.ts
+++ b/bin/wasm-node/javascript/src/index-browser.ts
@@ -263,10 +263,10 @@ export function start(options?: ClientOptions): Client {
               // Start and end of the validity of the session. `0 0` means that the session never
               // expires. (RFC8866)
               "t=0 0" + "\n" +
-              // A non-lite implementation is only appropriate for devices that will
+              // A lite implementation is only appropriate for devices that will
               // always be connected to the public Internet and have a public
               // IP address at which it can receive packets from any
-              // correspondent.  ICE will not function when a non-lite implementation
+              // correspondent.  ICE will not function when a lite implementation
               // is placed behind a NAT (RFC8445).
               "a=ice-lite" + "\n" +
               // A `m=` line describes a request to establish a certain protocol.

--- a/bin/wasm-node/javascript/src/index-browser.ts
+++ b/bin/wasm-node/javascript/src/index-browser.ts
@@ -273,7 +273,7 @@ export function start(options?: ClientOptions): Client {
               // The protocol in this line (i.e. `TCP/DTLS/SCTP` or `UDP/DTLS/SCTP`) must always be
               // the same as the one in the offer. We know that this is true because we tweak the
               // offer to match the protocol.
-              // The `<fmt>` component must always be `pc-datachannel` for WebRTC.
+              // The `<fmt>` component must always be `webrtc-datachannel` for WebRTC.
               // The rest of the SDP payload adds attributes to this specific media stream.
               // RFCs: 8839, 8866, 8841
               "m=application " + targetPort + " " + "UDP/DTLS/SCTP webrtc-datachannel" + "\n" +
@@ -287,6 +287,7 @@ export function start(options?: ClientOptions): Client {
               // ICE username and password, which are used for establishing and
               // maintaining the ICE connection. (RFC8839)
               // MUST match ones used by the answerer (server).
+              // These values are set according to the libp2p WebRTC specification.
               "a=ice-ufrag:" + remoteCertMultibase + "\n" +
               "a=ice-pwd:" + remoteCertMultibase + "\n" +
               // Fingerprint of the certificate that the server will use during the TLS
@@ -304,7 +305,8 @@ export function start(options?: ClientOptions): Client {
               "a=sctp-port:5000" + "\n" +
               // The maximum SCTP user message size (in bytes) (RFC8841)
               "a=max-message-size:16384" + "\n" +  // TODO: should this be part of the spec?
-              // A transport address for a candidate that can be used for connectivity checks (RFC8839).
+              // A transport address for a candidate that can be used for connectivity
+              // checks (RFC8839).
               "a=candidate:1 1 UDP 1 " + targetIp + " " + targetPort + " typ host" + "\n";
 
           await pc!.setRemoteDescription({ type: "answer", sdp: remoteSdp });

--- a/src/libp2p/collection/multi_stream.rs
+++ b/src/libp2p/collection/multi_stream.rs
@@ -814,7 +814,7 @@ where
                     let mut parser =
                         nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(
                             nom::combinator::complete(nom::combinator::map_parser(
-                                nom::multi::length_data(crate::util::nom_scale_compact_usize),
+                                nom::multi::length_data(crate::util::leb128::nom_leb128_usize),
                                 protobuf::message_decode! {
                                     #[optional] flags = 1 => protobuf::enum_tag_decode,
                                     #[optional] message = 2 => protobuf::bytes_tag_decode,

--- a/src/libp2p/collection/multi_stream.rs
+++ b/src/libp2p/collection/multi_stream.rs
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::util::{self, protobuf};
+
 use super::{
     super::{
         connection::{established, noise},
@@ -25,8 +27,9 @@ use super::{
     NotificationsOutErr, OverlayNetwork, PeerId, ShutdownCause, SubstreamId,
 };
 
-use alloc::{collections::VecDeque, string::ToString as _, sync::Arc, vec::Vec};
+use alloc::{collections::VecDeque, string::ToString as _, sync::Arc, vec, vec::Vec};
 use core::{
+    cmp,
     hash::Hash,
     ops::{Add, Sub},
     time::Duration,
@@ -44,6 +47,12 @@ enum MultiStreamConnectionTaskInner<TNow, TSubId> {
 
         /// Noise handshake in progress. Always `Some`, except to be temporarily extracted.
         handshake: Option<noise::HandshakeInProgress>,
+
+        /// All incoming data for the handshake substream is first transferred to this buffer.
+        // TODO: this is very suboptimal code, instead the parsing should be done in a streaming way
+        handshake_read_buffer: Vec<u8>,
+
+        handshake_read_buffer_partial_read: usize,
 
         /// Other substreams, besides [`MultiStreamConnectionTaskInner::Handshake::opened_substream`],
         /// that have been opened. For each substream, contains a boolean indicating whether the
@@ -171,6 +180,8 @@ where
                     prologue: &noise_prologue,
                 })),
                 opened_substream: None,
+                handshake_read_buffer: Vec::new(),
+                handshake_read_buffer_partial_read: 0,
                 extra_open_substreams: hashbrown::HashMap::with_capacity_and_hasher(
                     0,
                     Default::default(),
@@ -730,9 +741,11 @@ where
             }
             MultiStreamConnectionTaskInner::Handshake {
                 opened_substream: Some(opened_substream),
+                handshake_read_buffer,
                 ..
             } if opened_substream == substream_id => {
                 // TODO: the handshake has failed, kill the connection?
+                handshake_read_buffer.clear();
             }
             MultiStreamConnectionTaskInner::Handshake {
                 extra_open_substreams,
@@ -768,6 +781,8 @@ where
             MultiStreamConnectionTaskInner::Handshake {
                 handshake,
                 opened_substream,
+                handshake_read_buffer,
+                handshake_read_buffer_partial_read,
                 established,
                 extra_open_substreams,
             } if opened_substream
@@ -775,12 +790,147 @@ where
                 .map_or(false, |s| s == substream_id) =>
             {
                 // TODO: check the handshake timeout
-                match handshake.take().unwrap().read_write(read_write) {
+
+                // The Noise data is not directly the data of the substream. Instead, everything
+                // is wrapped within a Protobuf frame. For this reason, we first transfer the data
+                // to a buffer.
+                //
+                // According to the libp2p WebRTC spec, a frame and its length prefix must not be
+                // larger than 16kiB, meaning that the read buffer never has to exceed this size.
+                // TODO: this is very suboptimal; improve
+                if let Some(incoming_buffer) = read_write.incoming_buffer {
+                    // TODO: reset the substream if `remote_writing_side_closed`
+                    let max_to_transfer =
+                        cmp::min(incoming_buffer.len(), 16384 - handshake_read_buffer.len());
+                    handshake_read_buffer.extend_from_slice(&incoming_buffer[..max_to_transfer]);
+                    debug_assert!(handshake_read_buffer.len() <= 16384);
+                    read_write.advance_read(max_to_transfer);
+                }
+
+                // Try to parse the content of `handshake_read_buffer`.
+                // If the content of `handshake_read_buffer` is an incomplete frame, the flags
+                // will be `None` and the message will be `&[]`.
+                let (protobuf_frame_size, flags, message_within_frame) = {
+                    let mut parser =
+                        nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(
+                            nom::combinator::complete(nom::combinator::map_parser(
+                                nom::multi::length_data(crate::util::nom_scale_compact_usize),
+                                protobuf::message_decode! {
+                                    #[optional] flags = 1 => protobuf::enum_tag_decode,
+                                    #[optional] message = 2 => protobuf::bytes_tag_decode,
+                                },
+                            )),
+                        );
+
+                    match nom::Finish::finish(parser(&handshake_read_buffer)) {
+                        Ok((rest, framed_message)) => {
+                            let protobuf_frame_size = handshake_read_buffer.len() - rest.len();
+                            (
+                                protobuf_frame_size,
+                                framed_message.flags,
+                                framed_message.message.unwrap_or(&[][..]),
+                            )
+                        }
+                        Err(err) if err.code == nom::error::ErrorKind::Eof => {
+                            // TODO: reset the substream if incoming_buffer is full, as it means that the frame is too large, and remove the debug_assert below
+                            debug_assert!(handshake_read_buffer.len() < 16384);
+                            (0, None, &[][..])
+                        }
+                        Err(_) => {
+                            // Message decoding error.
+                            // TODO: no, handshake failed
+                            return true;
+                        }
+                    }
+                };
+
+                // We allocate a buffer where the Noise state machine will temporarily write out
+                // its data. The size of the buffer is capped in order to prevent the substream
+                // from generating data that wouldn't fit in a single protobuf frame.
+                let mut intermediary_write_buffer =
+                    vec![
+                        0;
+                        cmp::min(read_write.outgoing_buffer_available(), 16384).saturating_sub(10)
+                    ]; // TODO: this -10 calculation is hacky because we need to account for the variable length prefixes everywhere
+
+                let mut sub_read_write = ReadWrite {
+                    now: read_write.now.clone(),
+                    incoming_buffer: Some(
+                        &message_within_frame[*handshake_read_buffer_partial_read..],
+                    ),
+                    outgoing_buffer: Some((&mut intermediary_write_buffer, &mut [])),
+                    read_bytes: 0,
+                    written_bytes: 0,
+                    wake_up_after: None,
+                };
+
+                let handshake_outcome = handshake.take().unwrap().read_write(&mut sub_read_write);
+                *handshake_read_buffer_partial_read += sub_read_write.read_bytes;
+                if let Some(wake_up_after) = &sub_read_write.wake_up_after {
+                    read_write.wake_up_after(wake_up_after)
+                }
+
+                // Send out the message that the Noise handshake has written
+                // into `intermediary_write_buffer`.
+                if sub_read_write.written_bytes != 0 {
+                    let written_bytes = sub_read_write.written_bytes;
+                    drop(sub_read_write);
+
+                    debug_assert!(written_bytes <= intermediary_write_buffer.len());
+
+                    let protobuf_frame =
+                        protobuf::bytes_tag_encode(2, &intermediary_write_buffer[..written_bytes]);
+                    let protobuf_frame_len = protobuf_frame.clone().fold(0, |mut l, b| {
+                        l += AsRef::<[u8]>::as_ref(&b).len();
+                        l
+                    });
+
+                    // The spec mentions that a frame plus its length prefix shouldn't exceed
+                    // 16kiB. This is normally ensured by forbidding the substream from writing
+                    // more data than would fit in 16kiB.
+                    debug_assert!(protobuf_frame_len <= 16384);
+                    debug_assert!(
+                        util::encode_scale_compact_usize(protobuf_frame_len)
+                            .as_ref()
+                            .len()
+                            + protobuf_frame_len
+                            <= 16384
+                    );
+                    read_write
+                        .write_out(util::encode_scale_compact_usize(protobuf_frame_len).as_ref());
+                    for buffer in protobuf_frame {
+                        read_write.write_out(AsRef::<[u8]>::as_ref(&buffer));
+                    }
+                }
+
+                if protobuf_frame_size != 0
+                    && message_within_frame.len() <= *handshake_read_buffer_partial_read
+                {
+                    // If the substream state machine has processed all the data within
+                    // `read_buffer`, process the flags of the current protobuf frame and
+                    // discard that protobuf frame so that at the next iteration we pick
+                    // up the rest.
+
+                    // Discard the data.
+                    *handshake_read_buffer_partial_read = 0;
+                    *handshake_read_buffer = handshake_read_buffer
+                        .split_at(protobuf_frame_size)
+                        .1
+                        .to_vec();
+
+                    // Process the flags.
+                    // TODO: ignore FIN and treat any other flag as error
+                    if flags.map_or(false, |f| f != 0) {
+                        todo!()
+                    }
+                }
+
+                match handshake_outcome {
                     Ok(noise::NoiseHandshake::InProgress(handshake_update)) => {
                         *handshake = Some(handshake_update);
                         false
                     }
-                    Err(_err) => todo!(), // TODO: /!\
+                    Err(_err) => todo!("{:?}", _err), // TODO: /!\
                     Ok(noise::NoiseHandshake::Success {
                         cipher: _,
                         remote_peer_id,

--- a/src/libp2p/collection/multi_stream.rs
+++ b/src/libp2p/collection/multi_stream.rs
@@ -889,14 +889,12 @@ where
                     // more data than would fit in 16kiB.
                     debug_assert!(protobuf_frame_len <= 16384);
                     debug_assert!(
-                        util::encode_scale_compact_usize(protobuf_frame_len)
-                            .as_ref()
-                            .len()
-                            + protobuf_frame_len
+                        util::leb128::encode_usize(protobuf_frame_len).count() + protobuf_frame_len
                             <= 16384
                     );
-                    read_write
-                        .write_out(util::encode_scale_compact_usize(protobuf_frame_len).as_ref());
+                    for byte in util::leb128::encode_usize(protobuf_frame_len) {
+                        read_write.write_out(&[byte]);
+                    }
                     for buffer in protobuf_frame {
                         read_write.write_out(AsRef::<[u8]>::as_ref(&buffer));
                     }

--- a/src/libp2p/collection/multi_stream.rs
+++ b/src/libp2p/collection/multi_stream.rs
@@ -811,16 +811,15 @@ where
                 // If the content of `handshake_read_buffer` is an incomplete frame, the flags
                 // will be `None` and the message will be `&[]`.
                 let (protobuf_frame_size, flags, message_within_frame) = {
-                    let mut parser =
-                        nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(
-                            nom::combinator::complete(nom::combinator::map_parser(
-                                nom::multi::length_data(crate::util::leb128::nom_leb128_usize),
-                                protobuf::message_decode! {
-                                    #[optional] flags = 1 => protobuf::enum_tag_decode,
-                                    #[optional] message = 2 => protobuf::bytes_tag_decode,
-                                },
-                            )),
-                        );
+                    let mut parser = nom::combinator::complete::<_, _, nom::error::Error<&[u8]>, _>(
+                        nom::combinator::map_parser(
+                            nom::multi::length_data(crate::util::leb128::nom_leb128_usize),
+                            protobuf::message_decode! {
+                                #[optional] flags = 1 => protobuf::enum_tag_decode,
+                                #[optional] message = 2 => protobuf::bytes_tag_decode,
+                            },
+                        ),
+                    );
 
                     match nom::Finish::finish(parser(&handshake_read_buffer)) {
                         Ok((rest, framed_message)) => {

--- a/src/libp2p/collection/multi_stream.rs
+++ b/src/libp2p/collection/multi_stream.rs
@@ -176,7 +176,7 @@ where
             connection: MultiStreamConnectionTaskInner::Handshake {
                 handshake: Some(noise::HandshakeInProgress::new(noise::Config {
                     key: &noise_key,
-                    is_initiator: true, // TODO: is_initiator?
+                    is_initiator: false, // TODO: is_initiator?
                     prologue: &noise_prologue,
                 })),
                 opened_substream: None,

--- a/src/libp2p/connection/established/multi_stream.rs
+++ b/src/libp2p/connection/established/multi_stream.rs
@@ -351,7 +351,7 @@ where
             let (protobuf_frame_size, flags, message_within_frame) = {
                 let mut parser = nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(
                     nom::combinator::complete(nom::combinator::map_parser(
-                        nom::multi::length_data(crate::util::nom_scale_compact_usize),
+                        nom::multi::length_data(crate::util::leb128::nom_leb128_usize),
                         protobuf::message_decode! {
                             #[optional] flags = 1 => protobuf::enum_tag_decode,
                             #[optional] message = 2 => protobuf::bytes_tag_decode,

--- a/src/libp2p/connection/established/multi_stream.rs
+++ b/src/libp2p/connection/established/multi_stream.rs
@@ -381,6 +381,8 @@ where
                 // If the substream state machine has already processed all the data within
                 // `read_buffer`, process the flags of the current protobuf frame, discard that
                 // protobuf frame, and loop again.
+                continue_looping = true;
+
                 // Discard the data.
                 debug_assert_ne!(protobuf_frame_size, 0);
                 substream.read_buffer_partial_read = 0;

--- a/src/libp2p/connection/established/multi_stream.rs
+++ b/src/libp2p/connection/established/multi_stream.rs
@@ -349,14 +349,14 @@ where
             // If the content of `self.read_buffer` is an incomplete frame, the flags will be
             // `None` and the message will be `&[]`.
             let (protobuf_frame_size, flags, message_within_frame) = {
-                let mut parser = nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(
-                    nom::combinator::complete(nom::combinator::map_parser(
+                let mut parser = nom::combinator::complete::<_, _, nom::error::Error<&[u8]>, _>(
+                    nom::combinator::map_parser(
                         nom::multi::length_data(crate::util::leb128::nom_leb128_usize),
                         protobuf::message_decode! {
                             #[optional] flags = 1 => protobuf::enum_tag_decode,
                             #[optional] message = 2 => protobuf::bytes_tag_decode,
                         },
-                    )),
+                    ),
                 );
 
                 match nom::Finish::finish(parser(&substream.read_buffer)) {

--- a/src/libp2p/connection/established/multi_stream.rs
+++ b/src/libp2p/connection/established/multi_stream.rs
@@ -381,14 +381,15 @@ where
                 }
             };
 
-            let event = if message_within_frame.len() <= substream.read_buffer_partial_read {
+            let event = if protobuf_frame_size != 0
+                && message_within_frame.len() <= substream.read_buffer_partial_read
+            {
                 // If the substream state machine has already processed all the data within
                 // `read_buffer`, process the flags of the current protobuf frame, discard that
                 // protobuf frame, and loop again.
                 continue_looping = true;
 
                 // Discard the data.
-                debug_assert_ne!(protobuf_frame_size, 0);
                 substream.read_buffer_partial_read = 0;
                 substream.read_buffer = substream
                     .read_buffer

--- a/src/libp2p/connection/established/multi_stream.rs
+++ b/src/libp2p/connection/established/multi_stream.rs
@@ -23,7 +23,7 @@ use super::{
 };
 use crate::util::{self, protobuf};
 
-use alloc::{collections::VecDeque, string::String, vec::Vec};
+use alloc::{collections::VecDeque, string::String, vec, vec::Vec};
 use core::{
     cmp, fmt,
     hash::Hash,

--- a/src/libp2p/connection/established/multi_stream.rs
+++ b/src/libp2p/connection/established/multi_stream.rs
@@ -509,14 +509,12 @@ where
                     // more data than would fit in 16kiB.
                     debug_assert!(protobuf_frame_len <= 16384);
                     debug_assert!(
-                        util::encode_scale_compact_usize(protobuf_frame_len)
-                            .as_ref()
-                            .len()
-                            + protobuf_frame_len
+                        util::leb128::encode_usize(protobuf_frame_len).count() + protobuf_frame_len
                             <= 16384
                     );
-                    read_write
-                        .write_out(util::encode_scale_compact_usize(protobuf_frame_len).as_ref());
+                    for byte in util::leb128::encode_usize(protobuf_frame_len) {
+                        read_write.write_out(&[byte]);
+                    }
                     for buffer in protobuf_frame {
                         read_write.write_out(AsRef::<[u8]>::as_ref(&buffer));
                     }

--- a/src/libp2p/connection/established/multi_stream.rs
+++ b/src/libp2p/connection/established/multi_stream.rs
@@ -237,6 +237,9 @@ where
             todo!()
         };
 
+        let _prev_val = self.out_in_substreams_map.insert(substream.id, id.clone());
+        debug_assert!(_prev_val.is_none());
+
         let previous_value = self.in_substreams.insert(id, substream);
         if previous_value.is_some() {
             // There is already a substream with that identifier. This is forbidden by the API of
@@ -255,6 +258,8 @@ where
     ///
     pub fn reset_substream(&mut self, substream_id: &TSubId) {
         let substream = self.in_substreams.remove(substream_id).unwrap();
+        let _was_in = self.out_in_substreams_map.remove(&substream.id);
+        debug_assert!(!_was_in.is_some());
 
         if Some(substream_id) == self.ping_substream.as_ref() {
             self.ping_substream = None;

--- a/src/libp2p/connection/established/multi_stream.rs
+++ b/src/libp2p/connection/established/multi_stream.rs
@@ -585,17 +585,15 @@ where
                 }
             }
 
-            if !continue_looping {
-                break if substream.inner.is_some() {
-                    false
-                } else {
-                    if Some(substream_id) == self.ping_substream.as_ref() {
-                        self.ping_substream = None;
-                    }
-                    self.out_in_substreams_map.remove(&substream.id);
-                    self.in_substreams.remove(&substream_id);
-                    true
-                };
+            if substream.inner.is_none() {
+                if Some(substream_id) == self.ping_substream.as_ref() {
+                    self.ping_substream = None;
+                }
+                self.out_in_substreams_map.remove(&substream.id);
+                self.in_substreams.remove(&substream_id);
+                break true;
+            } else if !continue_looping {
+                break false;
             }
         }
     }

--- a/src/network/protocol/storage_call_proof.rs
+++ b/src/network/protocol/storage_call_proof.rs
@@ -33,7 +33,7 @@ pub struct StorageProofRequestConfig<TKeysIter> {
 
 /// Builds the bytes corresponding to a storage proof request.
 pub fn build_storage_proof_request<'a>(
-    config: StorageProofRequestConfig<impl Iterator<Item = impl AsRef<[u8]> + 'a> + 'a>,
+    config: StorageProofRequestConfig<impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + 'a>,
 ) -> impl Iterator<Item = impl AsRef<[u8]> + 'a> + 'a {
     protobuf::message_tag_encode(
         2,

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -735,7 +735,7 @@ where
         now: TNow,
         target: &PeerId,
         chain_index: usize,
-        config: protocol::StorageProofRequestConfig<impl Iterator<Item = impl AsRef<[u8]>>>,
+        config: protocol::StorageProofRequestConfig<impl Iterator<Item = impl AsRef<[u8]> + Clone>>,
         timeout: Duration,
     ) -> OutRequestId {
         let request_data =

--- a/src/util/protobuf.rs
+++ b/src/util/protobuf.rs
@@ -66,8 +66,8 @@ pub(crate) fn message_tag_encode<'a>(
 
 pub(crate) fn bytes_tag_encode<'a>(
     field: u64,
-    data: impl AsRef<[u8]> + 'a,
-) -> impl Iterator<Item = impl AsRef<[u8]> + 'a> + 'a {
+    data: impl AsRef<[u8]> + Clone + 'a,
+) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
     // Protobuf only allows 2 GiB of data.
     debug_assert!(data.as_ref().len() <= 2 * 1024 * 1024 * 1024);
     delimited_tag_encode(field, data)
@@ -75,8 +75,9 @@ pub(crate) fn bytes_tag_encode<'a>(
 
 pub(crate) fn string_tag_encode<'a>(
     field: u64,
-    data: impl AsRef<str> + 'a,
-) -> impl Iterator<Item = impl AsRef<[u8]> + 'a> + 'a {
+    data: impl AsRef<str> + Clone + 'a,
+) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    #[derive(Clone)]
     struct Wrapper<T>(T);
     impl<T: AsRef<str>> AsRef<[u8]> for Wrapper<T> {
         fn as_ref(&self) -> &[u8] {
@@ -97,8 +98,8 @@ pub(crate) fn varint_zigzag_tag_encode(field: u64, value: u64) -> impl Iterator<
 
 pub(crate) fn delimited_tag_encode<'a>(
     field: u64,
-    data: impl AsRef<[u8]> + 'a,
-) -> impl Iterator<Item = impl AsRef<[u8]> + 'a> + 'a {
+    data: impl AsRef<[u8]> + Clone + 'a,
+) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
     tag_encode(field, 2)
         .chain(leb128::encode_usize(data.as_ref().len()))
         .map(|v| either::Right([v]))


### PR DESCRIPTION
cc https://github.com/libp2p/specs/pull/412
cc https://github.com/paritytech/smoldot/issues/1712

This PR finishes implementing the WebRTC spec by adding the last remaining item: the messages framing.

Implementing this messages framing while minimizing the amount of data copies is rather challenging.
Instead of going for the complicated solution, I went for the more easy solution of having an intermediate read buffer where data is first copied.
Going for the simple solution decreases the chances of bugs and increases the ease of debugging, so it's preferable at the moment.

In the future, once WebRTC is fully working, we can rewrite this messages framing code in a more optimized way.
