### PR TITLE
Add two caches to the `peers` state machine

### DIFF
--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -239,11 +239,11 @@ where
             ),
             peers_notifications_out: BTreeMap::new(),
             unfulfilled_desired_outbound_substreams: hashbrown::HashMap::with_capacity_and_hasher(
-                0, // TODO: capacity?
+                config.peers_capacity,
                 Default::default(),
             ),
             fulfilled_undesired_outbound_substreams: hashbrown::HashMap::with_capacity_and_hasher(
-                0, // TODO: capacity?
+                config.peers_capacity,
                 Default::default(),
             ),
             peers_notifications_in: BTreeSet::new(),

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -685,7 +685,6 @@ where
 
                     if result.is_ok() {
                         notification_out.open = NotificationsOutOpenState::Open(substream_id);
-                        // TODO: close if `!desired`
                     } else {
                         notification_out.open = NotificationsOutOpenState::ClosedByRemote;
                         self.inner_notification_substreams


### PR DESCRIPTION
The `Peers` state machine has two functions: `unfulfilled_desired_outbound_substreams` and `fulfilled_undesired_outbound_substreams`. They return a list of peer-substreams tuples.

These two functions are called very frequently (every time something happens on the networking), they are `O(n)` (they iterate over every single substream of every single peer), and most of the time they return nothing.

This PR adds two new fields to the `peers` state machine with the same names as these functions.
The functions now simply return the content of the field, and the field is updated pro-actively whenever something else changes.
