### PR TITLE
Fix WebRTC for Firefox

### DIFF
--- a/bin/wasm-node/javascript/src/index-browser.ts
+++ b/bin/wasm-node/javascript/src/index-browser.ts
@@ -146,6 +146,8 @@ export function start(options?: ClientOptions): Client {
     const remoteCertMultihash = multibaseBase64Decode(remoteCertMultibase);
     const remoteCertSha256Hash = multihashToSha256(remoteCertMultihash);
 
+    // TODO: detect localhost for Firefox? https://bugzilla.mozilla.org/show_bug.cgi?id=1659672
+
     let pc: RTCPeerConnection | null = null;
     const dataChannels = new Map<number, RTCDataChannel>();
     // TODO: this system is a complete hack
@@ -158,6 +160,7 @@ export function start(options?: ClientOptions): Client {
     // inbound and outbound substreams.
     const addChannel = (dataChannel: RTCDataChannel, direction: 'inbound' | 'outbound') => {
       const dataChannelId = dataChannel.id!;
+      dataChannel.binaryType = 'arraybuffer';
 
       dataChannel.onopen = () => {
           config.onStreamOpened(dataChannelId, direction);


### PR DESCRIPTION
In the `dataChannel.onmessage` callback, we expect the data to be an `ArrayBuffer`.
However, in order for that to be the case, one has to set the value of `binarytype`. See https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/binaryType.

The documentation says that the default is `blob`. The fact that Chrome is providing me with an `ArrayBuffer` seems to be a bug: https://bugs.chromium.org/p/webrtc/issues/detail?id=2276
