### PR TITLE
Missing custom Display implementation on error

### DIFF
--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -2129,6 +2129,7 @@ pub enum InboundError {
     Connection(collection::InboundError),
     /// Refused a notifications substream because we already have an existing substream of that
     /// protocol.
+    #[display(fmt = "Refused duplicate notifications substream")]
     DuplicateNotificationsSubstream {
         /// Notifications protocol the substream is about.
         notifications_protocol_index: usize,


### PR DESCRIPTION
Right now the `derive_more` library just prints the value of `notifications_protocol_index` (an integer) when displaying this error, which is kind of crappy.