### PR TITLE
Make a few WebRTC-related assumptions more explicit

### DIFF
--- a/bin/light-base/src/network_service/tasks.rs
+++ b/bin/light-base/src/network_service/tasks.rs
@@ -356,7 +356,8 @@ async fn single_stream_connection_task<TPlat: Platform>(
 /// Asynchronous task managing a specific multi-stream connection after it's been open.
 ///
 /// > **Note**: This function is specific to WebRTC in the sense that it checks whether the reading
-/// >           and writing sides of substreams never close. It can easily be made more
+/// >           and writing sides of substreams never close, and adjusts the size of the write
+/// >           buffer to not go over the frame size limit of WebRTC. It can easily be made more
 /// >           general-purpose.
 // TODO: a lot of logging disappeared
 async fn webrtc_multi_stream_connection_task<TPlat: Platform>(
@@ -388,7 +389,9 @@ async fn webrtc_multi_stream_connection_task<TPlat: Platform>(
     // from this slice the data to send. Consequently, the write buffer is held locally. This is
     // suboptimal compared to writing to a write buffer provided by the platform, but it is easier
     // to implement it this way.
-    let mut write_buffer = vec![0; 16384]; // TODO: the write buffer must not exceed 16kiB due to the libp2p WebRTC spec; this should ideally be enforced through the connection task API
+    // The write buffer is limited to 16kiB, as this is the maximum amount of data a single
+    // WebRTC frame can have.
+    let mut write_buffer = vec![0; 16384];
 
     loop {
         // Start opening new outbound substreams, if needed.

--- a/bin/light-base/src/platform.rs
+++ b/bin/light-base/src/platform.rs
@@ -109,8 +109,8 @@ pub trait Platform: Send + 'static {
     /// Gives access to the content of the read buffer of the given stream.
     ///
     /// Returns `None` if the remote has closed their sending side or if the stream has been
-    /// reset. Returning `None` is forbidden in the case of
-    /// [`PlatformConnection::MultiStreamWebRtc`].
+    /// reset. In the case of [`PlatformConnection::MultiStreamWebRtc`], only the stream having
+    /// been reset applies.
     fn read_buffer(stream: &mut Self::Stream) -> Option<&[u8]>;
 
     /// Discards the first `bytes` bytes of the read buffer of this stream. This makes it

--- a/bin/light-base/src/platform.rs
+++ b/bin/light-base/src/platform.rs
@@ -123,6 +123,12 @@ pub trait Platform: Send + 'static {
     fn advance_read_cursor(stream: &mut Self::Stream, bytes: usize);
 
     /// Queues the given bytes to be sent out on the given connection.
+    ///
+    /// > **Note**: In the case of [`PlatformConnection::MultiStreamWebRtc`], be aware that there
+    /// >           exists a limit to the amount of data to send at once. The `data` parameter
+    /// >           is guaranteed to fit within that limit. Due to the existence of this limit,
+    /// >           the implementation of this function shouldn't attempt to save function calls
+    /// >           by performing internal buffering and batching multiple calls into one.
     // TODO: back-pressure
     // TODO: allow closing sending side
     fn send(stream: &mut Self::Stream, data: &[u8]);

--- a/bin/light-base/src/platform.rs
+++ b/bin/light-base/src/platform.rs
@@ -109,7 +109,8 @@ pub trait Platform: Send + 'static {
     /// Gives access to the content of the read buffer of the given stream.
     ///
     /// Returns `None` if the remote has closed their sending side or if the stream has been
-    /// reset.
+    /// reset. Returning `None` is forbidden in the case of
+    /// [`PlatformConnection::MultiStreamWebRtc`].
     fn read_buffer(stream: &mut Self::Stream) -> Option<&[u8]>;
 
     /// Discards the first `bytes` bytes of the read buffer of this stream. This makes it
@@ -134,7 +135,8 @@ pub enum PlatformConnection<TStream, TConnection> {
     /// should be negotiated. The division in multiple substreams is handled internally.
     SingleStreamMultistreamSelectNoiseYamux(TStream),
     /// The connection is made of multiple substreams. The encryption and multiplexing are handled
-    /// externally.
+    /// externally. The reading and writing sides of substreams must never close, and substreams
+    /// can only be abruptly closed by either side.
     MultiStreamWebRtc {
         /// Object representing the WebRTC connection.
         connection: TConnection,

--- a/src/libp2p/collection.rs
+++ b/src/libp2p/collection.rs
@@ -85,6 +85,9 @@ pub enum MultiStreamHandshakeKind {
     /// The connection is a WebRTC connection.
     ///
     /// See <https://github.com/libp2p/specs/pull/412> for details.
+    ///
+    /// The reading and writing side of substreams must never be closed. Substreams can only be
+    /// abruptly destroyed by either side.
     WebRtc {
         /// Multihash encoding of the TLS certificate used by the local node at the DTLS layer.
         local_tls_certificate_multihash: Vec<u8>,

--- a/src/libp2p/collection/multi_stream.rs
+++ b/src/libp2p/collection/multi_stream.rs
@@ -186,7 +186,7 @@ where
                     0,
                     Default::default(),
                 ),
-                established: Some(established::MultiStream::new(established::Config {
+                established: Some(established::MultiStream::webrtc(established::Config {
                     notifications_protocols: notification_protocols
                         .iter()
                         .map(|net| established::ConfigNotifications {

--- a/src/libp2p/connection/established/multi_stream.rs
+++ b/src/libp2p/connection/established/multi_stream.rs
@@ -280,17 +280,23 @@ where
     /// This method will refuse to accept data if too many events are already queued. Use
     /// [`MultiStream::pull_event`] to empty the queue of events between calls to this method.
     ///
+    /// In the case of a WebRTC connection, the [`ReadWrite::incoming_buffer`] and
+    /// [`ReadWrite::outgoing_buffer`] must always be `Some`.
+    ///
     /// # Panic
     ///
     /// Panics if there is no substream with that identifier.
+    /// Panics if this is a WebRTC connection, and the reading or writing side is closed.
     ///
-    // TODO: clarify docs to explain that in the case of WebRTC the reading and writing sides never close, and substream can only ever reset
     pub fn substream_read_write(
         &mut self,
         substream_id: &TSubId,
         read_write: &'_ mut ReadWrite<'_, TNow>,
     ) -> bool {
         let mut substream = self.in_substreams.get_mut(substream_id).unwrap();
+
+        // In WebRTC, the reading and writing side is never closed.
+        assert!(read_write.incoming_buffer.is_some() && read_write.outgoing_buffer.is_some());
 
         // Reading/writing the ping substream is used to queue new outgoing pings.
         if Some(substream_id) == self.ping_substream.as_ref() {
@@ -582,6 +588,9 @@ where
                     Self::on_substream_event(&mut self.pending_events, substream.id, other)
                 }
             }
+
+            // WebRTC never closes the writing side.
+            debug_assert!(read_write.outgoing_buffer.is_some());
 
             if substream.inner.is_none() {
                 if Some(substream_id) == self.ping_substream.as_ref() {

--- a/src/libp2p/connection/established/multi_stream.rs
+++ b/src/libp2p/connection/established/multi_stream.rs
@@ -114,7 +114,7 @@ where
     TSubId: Clone + PartialEq + Eq + Hash,
 {
     /// Creates a new connection from the given configuration.
-    pub fn new(config: Config<TNow>) -> MultiStream<TNow, TSubId, TRqUd, TNotifUd> {
+    pub fn webrtc(config: Config<TNow>) -> MultiStream<TNow, TSubId, TRqUd, TNotifUd> {
         // TODO: check conflicts between protocol names?
 
         // We expect at maximum one parallel request per protocol, plus one substream per direction
@@ -308,8 +308,6 @@ where
 
             read_write.wake_up_after(&self.next_ping);
         }
-
-        // TODO: make it explicit in the API that this is indeed the WebRTC protocol, as almost everything below is WebRTC-specific
 
         loop {
             // Don't process any more data before events are pulled.


### PR DESCRIPTION
WebRTC has a few assumptions, most notably the fact that the reading and writing side of substreams must never close (in other words: the browser can't control the individual closing of the reading and writing, so the code within smoldot expects them to remain always open).

Since this is a property of WebRTC specifically and not of multi-stream connections in general, I've opted to keeping an API that allows closing the reading/writing and simply documenting that this is not allowed.

An alternative could have been for the internals of smoldot to accept in its API that the reading/writing was closed, and if that actually happens consider this as a protocol violation and reset the substream. I've however opted to not do that because of the "external" nature of multi-stream connections. The encryption and multiplexing are already ensured by the JS code, and thus it makes sense to include as part of the responsibilities of the JS code to never report the substream being closed.

As part of this PR, I've found the cause for https://github.com/paritytech/smoldot/issues/2782
Because the fix I have in mind would conflict with this PR, I'll do it afterwards.
