### PR TITLE
Rename chainHead_unstable_finalizedDatabase parameter

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- The parameter of `chainHead_unstable_finalizedDatabase` has been renamed from `max_size_bytes` to `maxSizeBytes`.
+
 ## 0.7.3 - 2022-10-19
 
 ### Changed

--- a/src/json_rpc/methods.rs
+++ b/src/json_rpc/methods.rs
@@ -460,7 +460,7 @@ define_methods! {
     // <https://github.com/paritytech/smoldot/issues/2456>.
     network_unstable_subscribeEvents() -> Cow<'a, str>,
     network_unstable_unsubscribeEvents(subscription: Cow<'a, str>) -> (),
-    chainHead_unstable_finalizedDatabase(max_size_bytes: Option<u64>) -> Cow<'a, str>,
+    chainHead_unstable_finalizedDatabase(#[rename = "maxSizeBytes"] max_size_bytes: Option<u64>) -> Cow<'a, str>,
 }
 
 define_methods! {


### PR DESCRIPTION
Every JSON-RPC parameter uses camelCase, so let's keep it consistent.