### PR TITLE
Set the ufrag/pwd according to the spec

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - The parameter of `chainHead_unstable_finalizedDatabase` has been renamed from `max_size_bytes` to `maxSizeBytes`. ([#2923](https://github.com/paritytech/smoldot/pull/2923))
 
+### Fixed
+
+- When opening a WebRTC connection, the ufrag and password of SDP requests are now properly set according to the WebRTC libp2p specification.
+
 ## 0.7.3 - 2022-10-19
 
 ### Changed

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- When opening a WebRTC connection, the ufrag and password of SDP requests are now properly set according to the WebRTC libp2p specification.
+- When opening a WebRTC connection, the ufrag and password of SDP requests are now properly set according to the WebRTC libp2p specification. ([#2924](https://github.com/paritytech/smoldot/pull/2924))
 
 ## 0.7.3 - 2022-10-19
 

--- a/bin/wasm-node/javascript/src/index-browser.ts
+++ b/bin/wasm-node/javascript/src/index-browser.ts
@@ -351,7 +351,7 @@ export function start(options?: ClientOptions): Client {
           if (browserGeneratedPwd === undefined) {
             console.error("Failed to set ufrag to pwd. WebRTC connections will likely fail. Please report this issue.");
           }
-          const ufragPwd = "libp2p-webrtc-v1:" + browserGeneratedPwd;
+          const ufragPwd = "libp2p+webrtc+v1/" + browserGeneratedPwd;
           sdpOffer = sdpOffer.replace(/^a=ice-ufrag.*$/m, 'a=ice-ufrag:' + ufragPwd);
           sdpOffer = sdpOffer.replace(/^a=ice-pwd.*$/m, 'a=ice-pwd:' + ufragPwd);
           await pc!.setLocalDescription({ type: 'offer', sdp: sdpOffer });

--- a/bin/wasm-node/javascript/src/index-browser.ts
+++ b/bin/wasm-node/javascript/src/index-browser.ts
@@ -272,12 +272,12 @@ export function start(options?: ClientOptions): Client {
           // While we could randomly generate a new string, we just grab the one that the
           // browser has generated, in order to make sure that it respects the constraints
           // of the ICE protocol.
-          const ufrag_pwd = "libp2p-webrtc-v1:" + sdpOffer.match(/^a=ice-pwd:(.+)$/m)?.at(1);
-          if (ufrag_pwd === undefined) {
+          const ufragPwd = "libp2p-webrtc-v1:" + sdpOffer.match(/^a=ice-pwd:(.+)$/m)?.at(1);
+          if (ufragPwd === undefined) {
             console.error("Failed to set ufrag to pwd. WebRTC connections will likely fail. Please report this issue.");
           }
-          sdpOffer = sdpOffer.replace(/^a=ice-ufrag.*$/m, 'a=ice-ufrag:' + ufrag_pwd);
-          sdpOffer = sdpOffer.replace(/^a=ice-pwd.*$/m, 'a=ice-pwd:' + ufrag_pwd);
+          sdpOffer = sdpOffer.replace(/^a=ice-ufrag.*$/m, 'a=ice-ufrag:' + ufragPwd);
+          sdpOffer = sdpOffer.replace(/^a=ice-pwd.*$/m, 'a=ice-pwd:' + ufragPwd);
           await pc!.setLocalDescription({ type: 'offer', sdp: sdpOffer });
 
           // Transform certificate hash into fingerprint (upper-hex; each byte separated by ":").
@@ -320,8 +320,8 @@ export function start(options?: ClientOptions): Client {
               // ICE username and password, which are used for establishing and
               // maintaining the ICE connection. (RFC8839)
               // These values are set according to the libp2p WebRTC specification.
-              "a=ice-ufrag:" + ufrag_pwd + "\n" +
-              "a=ice-pwd:" + ufrag_pwd + "\n" +
+              "a=ice-ufrag:" + ufragPwd + "\n" +
+              "a=ice-pwd:" + ufragPwd + "\n" +
               // Fingerprint of the certificate that the server will use during the TLS
               // handshake. (RFC8122)
               // MUST be derived from the certificate used by the answerer (server).

--- a/bin/wasm-node/javascript/src/index-browser.ts
+++ b/bin/wasm-node/javascript/src/index-browser.ts
@@ -347,10 +347,11 @@ export function start(options?: ClientOptions): Client {
           // While we could randomly generate a new string, we just grab the one that the
           // browser has generated, in order to make sure that it respects the constraints
           // of the ICE protocol.
-          const ufragPwd = "libp2p-webrtc-v1:" + sdpOffer.match(/^a=ice-pwd:(.+)$/m)?.at(1);
-          if (ufragPwd === undefined) {
+          const browserGeneratedPwd = sdpOffer.match(/^a=ice-pwd:(.+)$/m)?.at(1);
+          if (browserGeneratedPwd === undefined) {
             console.error("Failed to set ufrag to pwd. WebRTC connections will likely fail. Please report this issue.");
           }
+          const ufragPwd = "libp2p-webrtc-v1:" + browserGeneratedPwd;
           sdpOffer = sdpOffer.replace(/^a=ice-ufrag.*$/m, 'a=ice-ufrag:' + ufragPwd);
           sdpOffer = sdpOffer.replace(/^a=ice-pwd.*$/m, 'a=ice-pwd:' + ufragPwd);
           await pc!.setLocalDescription({ type: 'offer', sdp: sdpOffer });

--- a/bin/wasm-node/javascript/src/index-browser.ts
+++ b/bin/wasm-node/javascript/src/index-browser.ts
@@ -267,13 +267,17 @@ export function start(options?: ClientOptions): Client {
             console.error("Local offer doesn't contain UDP data channel. WebRTC connections will likely fail. Please report this issue.");
           }
           // According to the libp2p WebRTC spec, the ufrag and pwd are the same
-          // randomly-generated string. We modify the local description to ensure that.
-          const pwd = sdpOffer.match(/^a=ice-pwd:(.+)$/m);
-          if (pwd != null) {
-            sdpOffer = sdpOffer.replace(/^a=ice-ufrag.*$/m, 'a=ice-ufrag:' + pwd[1]);
-          } else {
+          // randomly-generated string on both sides, and must be prefixed with
+          // `libp2p-webrtc-v1:`. We modify the local description to ensure that.
+          // While we could randomly generate a new string, we just grab the one that the
+          // browser has generated, in order to make sure that it respects the constraints
+          // of the ICE protocol.
+          const ufrag_pwd = "libp2p-webrtc-v1:" + sdpOffer.match(/^a=ice-pwd:(.+)$/m)?.at(1);
+          if (ufrag_pwd === undefined) {
             console.error("Failed to set ufrag to pwd. WebRTC connections will likely fail. Please report this issue.");
           }
+          sdpOffer = sdpOffer.replace(/^a=ice-ufrag.*$/m, 'a=ice-ufrag:' + ufrag_pwd);
+          sdpOffer = sdpOffer.replace(/^a=ice-pwd.*$/m, 'a=ice-pwd:' + ufrag_pwd);
           await pc!.setLocalDescription({ type: 'offer', sdp: sdpOffer });
 
           // Transform certificate hash into fingerprint (upper-hex; each byte separated by ":").
@@ -315,10 +319,9 @@ export function start(options?: ClientOptions): Client {
               "a=ice-options:ice2" + "\n" +
               // ICE username and password, which are used for establishing and
               // maintaining the ICE connection. (RFC8839)
-              // MUST match ones used by the answerer (server).
               // These values are set according to the libp2p WebRTC specification.
-              "a=ice-ufrag:" + remoteCertMultibase + "\n" +
-              "a=ice-pwd:" + remoteCertMultibase + "\n" +
+              "a=ice-ufrag:" + ufrag_pwd + "\n" +
+              "a=ice-pwd:" + ufrag_pwd + "\n" +
               // Fingerprint of the certificate that the server will use during the TLS
               // handshake. (RFC8122)
               // MUST be derived from the certificate used by the answerer (server).


### PR DESCRIPTION
Seeing the small discussion in the WebRTC implementation PR, I realized that smoldot doesn't actually say what is in the spec now. This PR changes it.