### PR TITLE
Clarify platform reading API

### DIFF
--- a/bin/light-base/src/platform.rs
+++ b/bin/light-base/src/platform.rs
@@ -179,6 +179,6 @@ pub enum ReadBuffer<'a> {
     /// type [`PlatformConnection::MultiStreamWebRtc`].
     Closed,
 
-    /// The stream has been abprutly closed by the remote.
+    /// The stream has been abruptly closed by the remote.
     Reset,
 }

--- a/bin/light-base/src/platform.rs
+++ b/bin/light-base/src/platform.rs
@@ -107,11 +107,7 @@ pub trait Platform: Send + 'static {
     fn wait_more_data(stream: &mut Self::Stream) -> Self::StreamDataFuture;
 
     /// Gives access to the content of the read buffer of the given stream.
-    ///
-    /// Returns `None` if the remote has closed their sending side or if the stream has been
-    /// reset. In the case of [`PlatformConnection::MultiStreamWebRtc`], only the stream having
-    /// been reset applies.
-    fn read_buffer(stream: &mut Self::Stream) -> Option<&[u8]>;
+    fn read_buffer(stream: &mut Self::Stream) -> ReadBuffer;
 
     /// Discards the first `bytes` bytes of the read buffer of this stream. This makes it
     /// possible for the remote to send more data.
@@ -169,4 +165,20 @@ pub struct ConnectError {
 
     /// `true` if the error is caused by the address to connect to being forbidden or unsupported.
     pub is_bad_addr: bool,
+}
+
+/// State of the read buffer, as returned by [`Platform::read_buffer`].
+#[derive(Debug)]
+pub enum ReadBuffer<'a> {
+    /// Reading side of the stream is fully open. Contains the data waiting to be processed.
+    Open(&'a [u8]),
+    
+    /// The reading side of the stream has been closed by the remote.
+    ///
+    /// Note that this is forbidden for connections of
+    /// type [`PlatformConnection::MultiStreamWebRtc`].
+    Closed,
+
+    /// The stream has been abprutly closed by the remote.
+    Reset,
 }

--- a/bin/light-base/src/platform.rs
+++ b/bin/light-base/src/platform.rs
@@ -172,7 +172,7 @@ pub struct ConnectError {
 pub enum ReadBuffer<'a> {
     /// Reading side of the stream is fully open. Contains the data waiting to be processed.
     Open(&'a [u8]),
-    
+
     /// The reading side of the stream has been closed by the remote.
     ///
     /// Note that this is forbidden for connections of

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -7,6 +7,10 @@
 - The `payment_queryInfo` JSON-RPC function now works with runtimes that have defined the type of `Balance` to be less than 16 bytes. ([#2914](https://github.com/paritytech/smoldot/pull/2914))
 - The parameter of `chainHead_unstable_finalizedDatabase` has been renamed from `max_size_bytes` to `maxSizeBytes`. ([#2923](https://github.com/paritytech/smoldot/pull/2923))
 
+### Fixed
+
+- Fix errors showing in the browser's console about WebSockets being already in the CLOSED or CLOSED state.
+
 ## 0.7.3 - 2022-10-19
 
 ### Changed

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Fix errors showing in the browser's console about WebSockets being already in the CLOSED or CLOSED state. ([#2925](https://github.com/paritytech/smoldot/pull/2925))
+- Fix errors showing in the browser's console about WebSockets being already in the CLOSING or CLOSED state. ([#2925](https://github.com/paritytech/smoldot/pull/2925))
 
 ## 0.7.3 - 2022-10-19
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Fix errors showing in the browser's console about WebSockets being already in the CLOSED or CLOSED state.
+- Fix errors showing in the browser's console about WebSockets being already in the CLOSED or CLOSED state. ([#2925](https://github.com/paritytech/smoldot/pull/2925))
 
 ## 0.7.3 - 2022-10-19
 

--- a/bin/wasm-node/javascript/src/index-browser.ts
+++ b/bin/wasm-node/javascript/src/index-browser.ts
@@ -108,14 +108,14 @@ export function start(options?: ClientOptions): Client {
       };
       connection.onclose = (event) => {
           const message = "Error code " + event.code + (!!event.reason ? (": " + event.reason) : "");
-          config.onConnectionClose(message);
+          config.onConnectionReset(message);
       };
       connection.onmessage = (msg) => {
           config.onMessage(new Uint8Array(msg.data as ArrayBuffer));
       };
 
       return {
-        close: (): void => {
+        reset: (): void => {
             connection.onopen = null;
             connection.onclose = null;
             connection.onmessage = null;
@@ -167,11 +167,11 @@ export function start(options?: ClientOptions): Client {
       };
 
       dataChannel.onerror = (_error) => {
-          config.onStreamClose(dataChannelId);
+          config.onStreamReset(dataChannelId);
       };
 
       dataChannel.onclose = () => {
-          config.onStreamClose(dataChannelId);
+          config.onStreamReset(dataChannelId);
       };
 
       dataChannel.onmessage = (m) => {
@@ -226,7 +226,7 @@ export function start(options?: ClientOptions): Client {
       if (localTlsCertificateHex === undefined) {
         // Because we've already returned from the `connect` function at this point, we pretend
         // that the connection has failed to open.
-        config.onConnectionClose('Failed to obtain the browser certificate fingerprint');
+        config.onConnectionReset('Failed to obtain the browser certificate fingerprint');
         return;
       }
       const localTlsCertificateMultihash = new Uint8Array(34);
@@ -240,7 +240,7 @@ export function start(options?: ClientOptions): Client {
       // open.
       pc.onconnectionstatechange = (_event) => {
         if (pc!.connectionState == "closed" || pc!.connectionState == "disconnected" || pc!.connectionState == "failed") {
-          config.onConnectionClose("WebRTC state transitioned to " + pc!.connectionState);
+          config.onConnectionReset("WebRTC state transitioned to " + pc!.connectionState);
 
           pc!.onconnectionstatechange = null;
           pc!.onnegotiationneeded = null;
@@ -361,7 +361,7 @@ export function start(options?: ClientOptions): Client {
     });
 
     return {
-      close: (streamId: number | undefined): void => {
+      reset: (streamId: number | undefined): void => {
         // If `streamId` is undefined, then the whole connection must be destroyed.
         if (streamId === undefined) {
           // The `RTCPeerConnection` is created at the same time as we report the connection as

--- a/bin/wasm-node/javascript/src/index-deno.ts
+++ b/bin/wasm-node/javascript/src/index-deno.ts
@@ -141,7 +141,7 @@ function connect(config: ConnectionConfig, forbidTcp: boolean, forbidWs: boolean
         };
         connection.socket.onclose = (event) => {
             const message = "Error code " + event.code + (!!event.reason ? (": " + event.reason) : "");
-            config.onConnectionClose(message);
+            config.onConnectionReset(message);
         };
         connection.socket.onmessage = (msg) => {
             config.onMessage(new Uint8Array(msg.data as ArrayBuffer));
@@ -191,7 +191,7 @@ function connect(config: ConnectionConfig, forbidTcp: boolean, forbidWs: boolean
                     // The socket is reported closed, but `socket.destroyed` is still `false` (see
                     // check above). As such, we must inform the inner layers.
                     socket.destroyed = true;
-                    config.onConnectionClose(outcome === null ? "EOF when reading socket" : outcome);
+                    config.onConnectionReset(outcome === null ? "EOF when reading socket" : outcome);
                     return;
                 }
                 console.assert(outcome !== 0); // `read` guarantees to return a non-zero value.
@@ -208,7 +208,7 @@ function connect(config: ConnectionConfig, forbidTcp: boolean, forbidWs: boolean
     }
 
     return {
-        close: (): void => {
+        reset: (): void => {
             if (connection.ty == 'websocket') {
                 // WebSocket
                 // We can't set these fields to null because the TypeScript definitions don't
@@ -249,7 +249,7 @@ function connect(config: ConnectionConfig, forbidTcp: boolean, forbidWs: boolean
                             // The socket is reported closed, but `socket.destroyed` is still
                             // `false` (see check above). As such, we must inform the inner layers.
                             socket.destroyed = true;
-                            config.onConnectionClose(outcome);
+                            config.onConnectionReset(outcome);
                             return c;
                         }
                         // Note that, contrary to `read`, it is possible for `outcome` to be 0.

--- a/bin/wasm-node/javascript/src/index-nodejs.ts
+++ b/bin/wasm-node/javascript/src/index-nodejs.ts
@@ -108,14 +108,14 @@ function connect(config: ConnectionConfig, forbidTcp: boolean, forbidWs: boolean
         };
         socket.onclose = (event) => {
             const message = "Error code " + event.code + (!!event.reason ? (": " + event.reason) : "");
-            config.onConnectionClose(message);
+            config.onConnectionReset(message);
             socket.onopen = () => { };
             socket.onclose = () => { };
             socket.onmessage = () => { };
             socket.onerror = () => { };
         };
         socket.onerror = (event) => {
-            config.onConnectionClose(event.message);
+            config.onConnectionReset(event.message);
             socket.onopen = () => { };
             socket.onclose = () => { };
             socket.onmessage = () => { };
@@ -150,7 +150,7 @@ function connect(config: ConnectionConfig, forbidTcp: boolean, forbidWs: boolean
             // NodeJS doesn't provide a reason why the closing happened, but only
             // whether it was caused by an error.
             const message = hasError ? "Error" : "Closed gracefully";
-            config.onConnectionClose(message);
+            config.onConnectionReset(message);
         });
         connection.socket.on('error', () => { });
         connection.socket.on('data', (message) => {
@@ -163,7 +163,7 @@ function connect(config: ConnectionConfig, forbidTcp: boolean, forbidWs: boolean
     }
 
     return {
-        close: (): void => {
+        reset: (): void => {
             if (connection.ty == 'websocket') {
                 // WebSocket
                 // We can't set these fields to null because the TypeScript definitions don't

--- a/bin/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
+++ b/bin/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
@@ -58,11 +58,11 @@ export interface Config {
  *
  * - `Opening` (initial state)
  * - `Open`
- * - `Closed`
+ * - `Reset`
  *
- * When in the `Opening` or `Open` state, the connection can transition to the `Closed` state
+ * When in the `Opening` or `Open` state, the connection can transition to the `Reset` state
  * if the remote closes the connection or refuses the connection altogether. When that
- * happens, `config.onClosed` is called. Once in the `Closed` state, the connection cannot
+ * happens, `config.onReset` is called. Once in the `Reset` state, the connection cannot
  * transition back to another state.
  *
  * Initially in the `Opening` state, the connection can transition to the `Open` state if the
@@ -75,20 +75,20 @@ export interface Config {
  */
  export interface Connection {
     /**
-     * Transitions the connection or one of its substreams to the `Closed` state.
+     * Transitions the connection or one of its substreams to the `Reset` state.
      *
      * If the connection is of type "single-stream", the whole connection must be shut down.
      * If the connection is of type "multi-stream", a `streamId` can be provided, in which case
      * only the given substream is shut down.
      *
-     * The `config.onClose` or `config.onStreamClose` callbacks are **not** called.
+     * The `config.onReset` or `config.onStreamReset` callbacks are **not** called.
      *
      * The transition is performed in the background.
      * If the whole connection is to be shut down, none of the callbacks passed to the `Config`
-     * must be called again. If only a substream is shut down, the `onStreamClose` and `onMessage`
+     * must be called again. If only a substream is shut down, the `onStreamReset` and `onMessage`
      * callbacks must not be called again with that substream.
      */
-    close(streamId?: number): void;
+    reset(streamId?: number): void;
 
     /**
      * Queues data to be sent on the given connection.
@@ -139,11 +139,11 @@ export interface ConnectionConfig {
     ) => void;
 
     /**
-     * Callback called when the connection transitions to the `Closed` state.
+     * Callback called when the connection transitions to the `Reset` state.
      *
-     * It it **not** called if `Connection.close` is manually called by the API user.
+     * It it **not** called if `Connection.reset` is manually called by the API user.
      */
-    onConnectionClose: (message: string) => void;
+    onConnectionReset: (message: string) => void;
 
     /**
      * Callback called when a new substream has been opened.
@@ -153,13 +153,13 @@ export interface ConnectionConfig {
     onStreamOpened: (streamId: number, direction: 'inbound' | 'outbound') => void;
 
     /**
-     * Callback called when a stream transitions to the `Closed` state.
+     * Callback called when a stream transitions to the `Reset` state.
      *
-     * It it **not** called if `Connection.closeStream` is manually called by the API user.
+     * It it **not** called if `Connection.resetStream` is manually called by the API user.
      *
      * This function must only be called for connections of type "multi-stream".
      */
-    onStreamClose: (streamId: number) => void;
+    onStreamReset: (streamId: number) => void;
 
     /**
      * Callback called when a message sent by the remote has been received.
@@ -196,7 +196,7 @@ export default function (config: Config): { imports: WebAssembly.ModuleImports, 
         killedTracked.killed = true;
         // TODO: kill timers as well?
         for (const connection in connections) {
-            connections[connection]!.close()
+            connections[connection]!.reset()
             delete connections[connection]
         }
     };
@@ -322,13 +322,13 @@ export default function (config: Config): { imports: WebAssembly.ModuleImports, 
                             }
                         } catch(_error) {}
                     },
-                    onConnectionClose: (message: string) => {
+                    onConnectionReset: (message: string) => {
                         if (killedTracked.killed) return;
                         try {
                             const encoded = new TextEncoder().encode(message)
                             const ptr = instance.exports.alloc(encoded.length) >>> 0;
                             new Uint8Array(instance.exports.memory.buffer).set(encoded, ptr);
-                            instance.exports.connection_closed(connectionId, ptr, encoded.length);
+                            instance.exports.connection_reset(connectionId, ptr, encoded.length);
                         } catch(_error) {}
                     },
                     onMessage: (message: Uint8Array, streamId?: number) => {
@@ -349,10 +349,10 @@ export default function (config: Config): { imports: WebAssembly.ModuleImports, 
                             );
                         } catch(_error) {}
                     },
-                    onStreamClose: (streamId: number) => {
+                    onStreamReset: (streamId: number) => {
                         if (killedTracked.killed) return;
                         try {
-                            instance.exports.stream_closed(connectionId, streamId);
+                            instance.exports.stream_reset(connectionId, streamId);
                         } catch(_error) {}
                     }
                 
@@ -379,10 +379,10 @@ export default function (config: Config): { imports: WebAssembly.ModuleImports, 
         },
 
         // Must close and destroy the connection object.
-        connection_close: (connectionId: number) => {
+        reset_connection: (connectionId: number) => {
             if (killedTracked.killed) return;
             const connection = connections[connectionId]!;
-            connection.close();
+            connection.reset();
             delete connections[connectionId];
         },
 
@@ -393,9 +393,9 @@ export default function (config: Config): { imports: WebAssembly.ModuleImports, 
         },
 
         // Closes a substream on a multi-stream connection.
-        connection_stream_close: (connectionId: number, streamId: number) => {
+        connection_stream_reset: (connectionId: number, streamId: number) => {
             const connection = connections[connectionId]!;
-            connection.close(streamId)
+            connection.reset(streamId)
         },
 
         // Must queue the data found in the WebAssembly memory at the given pointer. It is assumed

--- a/bin/wasm-node/javascript/src/instance/bindings.ts
+++ b/bin/wasm-node/javascript/src/instance/bindings.ts
@@ -39,8 +39,8 @@ export interface SmoldotWasmExports extends WebAssembly.Exports {
     connection_open_multi_stream: (connectionId: number, handshakeTyPtr: number, handshakeTyLen: number) => void,
     stream_message: (connectionId: number, streamId: number, ptr: number, len: number) => void,
     connection_stream_opened: (connectionId: number, streamId: number, outbound: number) => void,
-    connection_closed: (connectionId: number, ptr: number, len: number) => void,
-    stream_closed: (connectionId: number, streamId: number) => void,
+    connection_reset: (connectionId: number, ptr: number, len: number) => void,
+    stream_reset: (connectionId: number, streamId: number) => void,
 }
 
 export interface SmoldotWasmInstance extends WebAssembly.Instance {

--- a/src/libp2p/collection/single_stream.rs
+++ b/src/libp2p/collection/single_stream.rs
@@ -482,6 +482,18 @@ where
         }
     }
 
+    /// Returns `true` if [`SingleStreamConnectionTask::reset`] has been called in the past.
+    pub fn is_reset_called(&self) -> bool {
+        matches!(
+            self.connection,
+            SingleStreamConnectionTaskInner::ShutdownWaitingAck {
+                initiator: ShutdownInitiator::Api,
+            } | SingleStreamConnectionTaskInner::ShutdownAcked {
+                initiator: ShutdownInitiator::Api,
+            }
+        )
+    }
+
     /// Reads data coming from the connection, updates the internal state machine, and writes data
     /// destined to the connection through the [`ReadWrite`].
     ///


### PR DESCRIPTION
At the moment, the `read_buffer` function of the `Platform` trait (representing how the light client binds to the environment) returns either `Some` in normal situations or `None` if the connection has been either closed or reset.

This PR turns this `Option` into an enum with three variants: `Open`, `Closed`, and `Reset`.
This lets the code properly differentiate between these two latter situations.

Additionally, I've renamed "closed" to "reset" in the entire Wasm<->JS code (all the functions and variables), for clarity. While the `Platform` trait lets you report that the reading side is closed but the writing side still open, the JS code can't represent that state. Instead, it's either "connection open" or "connection reset".

This PR fixes https://github.com/paritytech/smoldot/issues/2782. The issue was that we were treating `read_buffer()` returning `None` as meaning "reading side closed", but actually the entire connection was already reset. We would then call `send` on the already-reset connection, leading to the error. This kind of confusion is exactly why I've performed the rename.
