### PR TITLE
Install clang before the spellcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: apt-get update && apt install -y clang  # LLVM required by cargo-spellcheck
+    - run: sudo apt-get update && apt install -y clang  # LLVM required by cargo-spellcheck
     - uses: baptiste0928/cargo-install@v1  # This action ensures that the compilation is cached.
       with:
         crate: cargo-spellcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: sudo apt-get update && apt install -y clang  # LLVM required by cargo-spellcheck
+    - run: sudo apt-get update && sudo apt install -y clang  # LLVM required by cargo-spellcheck
     - uses: baptiste0928/cargo-install@v1  # This action ensures that the compilation is cached.
       with:
         crate: cargo-spellcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: sudo apt-get update && sudo apt install -y clang  # LLVM required by cargo-spellcheck
+    - run: sudo apt-get update && sudo apt install -y libclang-dev  # Required by cargo-spellcheck
     - uses: baptiste0928/cargo-install@v1  # This action ensures that the compilation is cached.
       with:
         crate: cargo-spellcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - run: apt-get update && apt install -y clang  # LLVM required by cargo-spellcheck
     - uses: baptiste0928/cargo-install@v1  # This action ensures that the compilation is cached.
       with:
         crate: cargo-spellcheck


### PR DESCRIPTION
Our spellcheck CI job has started failing yesterday because compiling `clang-sys` can't find LLVM installed on the system.

I was curious why this suddenly happened. Unfortunately, we were caching the compiled version of `cargo-spellcheck`, and suddenly the cache expired, which means that we're now compiling it whereas we weren't compiling it before. I don't really have the motivation to find the CI run where we initially compiled it in order to compare it with the failing CI run, and even if I found it the logs are probably expired now.

A quick investigation of the cargo-spellcheck and clang-sys packages don't reveal anything abnormal.
