### PR TITLE
Properly handle data channel opening failures

### DIFF
--- a/bin/light-base/src/platform.rs
+++ b/bin/light-base/src/platform.rs
@@ -80,6 +80,11 @@ pub trait Platform: Send + 'static {
     /// Queues the opening of an additional outbound substream.
     ///
     /// The substream, once opened, must be yielded by [`Platform::next_substream`].
+    ///
+    /// > **Note**: No mechanism exists in this API to handle the situation where a substream fails
+    /// >           to open, as this is not supposed to happen. If you need to handle such a
+    /// >           situation, either try again opening a substream again or reset the entire
+    /// >           connection.
     fn open_out_substream(connection: &mut Self::Connection);
 
     /// Waits until a new incoming substream arrives on the connection.

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Fix errors showing in the browser's console about WebSockets being already in the CLOSING or CLOSED state. ([#2925](https://github.com/paritytech/smoldot/pull/2925))
+- No longer panic when a WebRTC connection fails to open due to the browser calling callbacks in an unexpected order. ([#2936](https://github.com/paritytech/smoldot/pull/2936))
 
 ## 0.7.3 - 2022-10-19
 

--- a/bin/wasm-node/javascript/src/index-browser.ts
+++ b/bin/wasm-node/javascript/src/index-browser.ts
@@ -460,8 +460,8 @@ export function start(options?: ClientOptions): Client {
         // As explained above, we open a data channel ahead of time. If this data channel is still
         // there, we report it.
         if (handshakeDataChannel) {
-          // Use `setTimeout` because calling callbacks within callbacks is error-prone.
-          setTimeout(() => {
+          // Do this asynchronously because calling callbacks within callbacks is error-prone.
+          (async () => {
             // We need to check again if `handshakeDataChannel` is still defined, as the
             // connection might have been closed.
             if (handshakeDataChannel) {
@@ -469,7 +469,7 @@ export function start(options?: ClientOptions): Client {
               dataChannels.set(handshakeDataChannel.id!, handshakeDataChannel)
               handshakeDataChannel = undefined
             }
-          }, 1)
+          })()
         } else {
           // Note that the label passed to `createDataChannel` is required to be empty as per the
           // libp2p WebRTC specification.

--- a/bin/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
+++ b/bin/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
@@ -107,6 +107,10 @@ export interface Config {
      * connections of type "multi-stream".
      *
      * The `onStreamOpened` callback must later be called with an outbound direction.
+     * 
+     * Note that no mechanism exists in this API to handle the situation where a substream fails
+     * to open, as this is not supposed to happen. If you need to handle such a situation, either
+     * try again opening a substream again or reset the entire connection.
      */
     openOutSubstream(): void;
 }

--- a/bin/wasm-node/rust/src/bindings.rs
+++ b/bin/wasm-node/rust/src/bindings.rs
@@ -209,6 +209,11 @@ extern "C" {
     ///
     /// This function will only be called for multi-stream connections. The connection must
     /// currently be in the `Open` state. See the documentation of [`connection_new`] for details.
+    ///
+    /// > **Note**: No mechanism exists in this API to handle the situation where a substream fails
+    /// >           to open, as this is not supposed to happen. If you need to handle such a
+    /// >           situation, either try again opening a substream again or reset the entire
+    /// >           connection.
     pub fn connection_stream_open(connection_id: u32);
 
     /// Abruptly closes an existing substream of a multi-stream connection. The substream must


### PR DESCRIPTION
Fix https://github.com/paritytech/smoldot/issues/2900

In order to open outbound substreams on a WebRTC connection, the mechanism that the API of smoldot uses is as follows: one function to ask the implementation to open a substream, and one callback that is later called in order to notify that a substream has been fully opened.

The API of smoldot doesn't provide a way to report that opening an outbound substream has failed. This is because this isn't really supposed to happen. If you have a connection, opening a substream is purely a "local side change": you allocate an ID, then send a message. It should maybe not even be asynchronous, but that's off-topic here.

The problem here is that this mental model doesn't really fit what the browser does. In particular, the browser does nothing until a data channel is first opened, plus the browser can call `onclose` or `onerror` on the data channel before `onopen`. To accomodate for that, the current code is a bit hacky in the sense that it reports the connection as immediately open.

This PR does it a bit more differently and more properly: we immediately open a data channel at the same time as we create the `RTCPeerConnection` in order for the browser to start connecting, even though smoldot didn't request a channel yet. We store this first data channel on the side, and when smoldot asks for a data channel we provide this one.
If a data channel closes while it is still opening (the handshake one or another), we just kill the entire connection.
