### PR TITLE
Fix prefix_proof misbehavior

### DIFF
--- a/bin/light-base/src/sync_service.rs
+++ b/bin/light-base/src/sync_service.rs
@@ -479,6 +479,7 @@ impl<TPlat: Platform> SyncService<TPlat> {
 
             // TODO: better peers selection ; don't just take the first
             // TODO: handle max_parallel
+            // TODO: is the number of keys is large, split into multiple requests
             for target in self
                 .peers_assumed_know_blocks(block_number, block_hash)
                 .await

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix the `state_getKeysPaged` JSON-RPC function returning incorrect results in some situations.
+- Fix the `state_getKeysPaged` JSON-RPC function returning incorrect results in some situations. ([#2947](https://github.com/paritytech/smoldot/pull/2947))
 
 ## 0.7.4 - 2022-10-27
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix the `state_getKeysPaged` JSON-RPC function returning incorrect results in some situations.
+
 ## 0.7.4 - 2022-10-27
 
 ### Changed

--- a/src/trie/proof_verify.rs
+++ b/src/trie/proof_verify.rs
@@ -306,6 +306,30 @@ impl Children {
             ),
         }
     }
+
+    /// Iterators over all the children of the node. Returns an iterator producing one element per
+    /// child, where the element is `key` plus the nibble of this child.
+    pub fn unfold_append_to_key(
+        &self,
+        mut key: Vec<nibble::Nibble>,
+    ) -> impl Iterator<Item = Vec<nibble::Nibble>> {
+        match *self {
+            Children::None => either::Left(None.into_iter()),
+            Children::One(nibble) => {
+                key.push(nibble);
+                either::Left(Some(key).into_iter())
+            }
+            Children::Multiple { children_bitmap } => either::Right(
+                nibble::all_nibbles()
+                    .filter(move |n| (children_bitmap & (1 << u8::from(*n)) != 0))
+                    .map(move |nibble| {
+                        let mut k = key.clone();
+                        k.push(nibble);
+                        k
+                    }),
+            ),
+        }
+    }
 }
 
 /// Possible error returned by [`verify_proof`]


### PR DESCRIPTION
Fix https://github.com/paritytech/smoldot/issues/2946

The behavior of `prefix_proof` is currently buggy. When a node isn't found in the proof that the remote sent us, we simply discard it instead of adding it to the list of keys to query at the next iteration.
The consequence is that `state_getKeysPaged` was wrong most the time.

In order to fix this, I had to reorganize the entire function.

There's still an issue because we're asking for too much data, which leads the remote to shutdown the connection, so queries still occasionally fail. But this other issue is not the fault of the `prefix_proof` module, and this PR is only about fixing `prefix_proof`.
