### PR TITLE
Make Grandpa warp sync protocol code more zero cost

### DIFF
--- a/bin/light-base/src/sync_service/standalone.rs
+++ b/bin/light-base/src/sync_service/standalone.rs
@@ -250,17 +250,18 @@ pub(super) async fn start_standalone_chain<TPlat: Platform>(
                 // machine.
                 match result {
                     Ok(Ok(result)) => {
-                        let fragments = result.fragments
+                        let decoded = result.decode();
+                        let fragments = decoded.fragments
                             .into_iter()
                             .map(|f| all::WarpSyncFragment {
-                                scale_encoded_header: f.scale_encoded_header,
-                                scale_encoded_justification: f.scale_encoded_justification,
+                                scale_encoded_header: f.scale_encoded_header.to_vec(),
+                                scale_encoded_justification: f.scale_encoded_justification.to_vec(),
                             })
                             .collect();
                         task.sync.grandpa_warp_sync_response_ok(
                             request_id,
                             fragments,
-                            result.is_finished,
+                            decoded.is_finished,
                         ).1
                     }
                     Ok(Err(_)) => {
@@ -412,7 +413,7 @@ struct Task<TPlat: Platform> {
                 all::RequestId,
                 Result<
                     Result<
-                        protocol::GrandpaWarpSyncResponse,
+                        network::service::EncodedGrandpaWarpSyncResponse,
                         network_service::GrandpaWarpSyncRequestError,
                     >,
                     future::Aborted,

--- a/src/sync/warp_sync.rs
+++ b/src/sync/warp_sync.rs
@@ -769,6 +769,7 @@ impl<TSrc, TRq> InProgressWarpSync<TSrc, TRq> {
     /// Panics if the [`RequestId`] is invalid.
     /// Panics if the [`RequestId`] doesn't correspond to a warp sync request.
     ///
+    // TODO: more zero cost API w.r.t. the fragments
     pub fn warp_sync_request_success(
         &mut self,
         request_id: RequestId,


### PR DESCRIPTION
We no longer copy the fragments when decoding a response sent by a peer, but return the message as a whole. This avoids copies.

Unfortunately, we have to do `to_vec()` at some point, so this doesn't actually save anything. However this is still progress towards a final zero-cost version.
