### PR TITLE
Make it mandatory to specify `#[required]`

### DIFF
--- a/src/libp2p/connection/noise.rs
+++ b/src/libp2p/connection/noise.rs
@@ -768,8 +768,8 @@ impl HandshakeInProgress {
                     let mut parser =
                         nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(
                             nom::combinator::complete(protobuf::message_decode! {
-                                key = 1 => protobuf::bytes_tag_decode,
-                                sig = 2 => protobuf::bytes_tag_decode,
+                                #[required] key = 1 => protobuf::bytes_tag_decode,
+                                #[required] sig = 2 => protobuf::bytes_tag_decode,
                             }),
                         );
                     match nom::Finish::finish(parser(&decoded_payload)) {

--- a/src/network/protocol/block_request.rs
+++ b/src/network/protocol/block_request.rs
@@ -278,7 +278,7 @@ pub fn decode_block_response(
         nom::combinator::complete(protobuf::message_decode! {
             #[repeated(max = 32768)] blocks = 1 => protobuf::message_tag_decode(protobuf::message_decode!{
                 #[required] hash = 1 => protobuf::bytes_tag_decode,
-                #[required] header = 2 => protobuf::bytes_tag_decode,
+                #[optional] header = 2 => protobuf::bytes_tag_decode,
                 #[repeated(max = usize::max_value())] body = 3 => protobuf::bytes_tag_decode,
                 #[optional] justifications = 8 => protobuf::bytes_tag_decode,
             }),
@@ -298,8 +298,8 @@ pub fn decode_block_response(
 
         blocks_out.push(BlockData {
             hash: <[u8; 32]>::try_from(block.hash).unwrap(),
-            header: if !block.header.is_empty() {
-                Some(block.header.to_vec())
+            header: if let Some(header) = block.header {
+                Some(header.to_vec())
             } else {
                 None
             },

--- a/src/network/protocol/block_request.rs
+++ b/src/network/protocol/block_request.rs
@@ -139,7 +139,7 @@ pub fn decode_block_request(
 ) -> Result<BlocksRequestConfig, DecodeBlockRequestError> {
     let mut parser = nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(
         nom::combinator::complete(protobuf::message_decode! {
-            fields = 1 => protobuf::uint32_tag_decode,
+            #[required] fields = 1 => protobuf::uint32_tag_decode,
             #[optional] hash = 2 => protobuf::bytes_tag_decode,
             #[optional] number = 3 => protobuf::bytes_tag_decode,
             #[optional] direction = 5 => protobuf::enum_tag_decode,
@@ -277,8 +277,8 @@ pub fn decode_block_response(
     let mut parser = nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(
         nom::combinator::complete(protobuf::message_decode! {
             #[repeated(max = 32768)] blocks = 1 => protobuf::message_tag_decode(protobuf::message_decode!{
-                hash = 1 => protobuf::bytes_tag_decode,
-                header = 2 => protobuf::bytes_tag_decode,
+                #[required] hash = 1 => protobuf::bytes_tag_decode,
+                #[required] header = 2 => protobuf::bytes_tag_decode,
                 #[repeated(max = usize::max_value())] body = 3 => protobuf::bytes_tag_decode,
                 #[optional] justifications = 8 => protobuf::bytes_tag_decode,
             }),

--- a/src/network/protocol/kademlia.rs
+++ b/src/network/protocol/kademlia.rs
@@ -46,7 +46,7 @@ pub fn decode_find_node_response(
 ) -> Result<Vec<(peer_id::PeerId, Vec<multiaddr::Multiaddr>)>, DecodeFindNodeResponseError> {
     let mut parser = nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(
         nom::combinator::complete(protobuf::message_decode! {
-            #[required] response_ty = 1 => protobuf::enum_tag_decode,
+            #[optional] response_ty = 1 => protobuf::enum_tag_decode,
             #[repeated(max = 1024)] peers = 8 => protobuf::message_tag_decode(protobuf::message_decode!{
                 #[required] peer_id = 1 => protobuf::bytes_tag_decode,
                 #[repeated(max = 1024)] addrs = 2 => protobuf::bytes_tag_decode,
@@ -55,7 +55,7 @@ pub fn decode_find_node_response(
     );
 
     let closer_peers = match nom::Finish::finish(parser(response_bytes)) {
-        Ok((_, out)) if out.response_ty == 4 => out.peers,
+        Ok((_, out)) if out.response_ty.unwrap_or(0) == 4 => out.peers,
         Ok((_, _)) => return Err(DecodeFindNodeResponseError::BadResponseTy),
         Err(_) => {
             return Err(DecodeFindNodeResponseError::ProtobufDecode(

--- a/src/network/protocol/kademlia.rs
+++ b/src/network/protocol/kademlia.rs
@@ -46,9 +46,9 @@ pub fn decode_find_node_response(
 ) -> Result<Vec<(peer_id::PeerId, Vec<multiaddr::Multiaddr>)>, DecodeFindNodeResponseError> {
     let mut parser = nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(
         nom::combinator::complete(protobuf::message_decode! {
-            response_ty = 1 => protobuf::enum_tag_decode,
+            #[required] response_ty = 1 => protobuf::enum_tag_decode,
             #[repeated(max = 1024)] peers = 8 => protobuf::message_tag_decode(protobuf::message_decode!{
-                peer_id = 1 => protobuf::bytes_tag_decode,
+                #[required] peer_id = 1 => protobuf::bytes_tag_decode,
                 #[repeated(max = 1024)] addrs = 2 => protobuf::bytes_tag_decode,
             }),
         }),

--- a/src/network/protocol/state_request.rs
+++ b/src/network/protocol/state_request.rs
@@ -60,12 +60,12 @@ pub fn decode_state_response(
     let mut parser = nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(
         nom::combinator::complete(protobuf::message_decode! {
             #[repeated(max = 1)] entries = 1 => protobuf::message_decode!{
-                _state_root = 1 => protobuf::bytes_tag_decode,
+                #[required] _state_root = 1 => protobuf::bytes_tag_decode,
                 #[repeated(max = 4 * 1024 * 1024)] entries = 2 => protobuf::message_tag_decode(protobuf::message_decode!{
-                    key = 1 => protobuf::bytes_tag_decode,
-                    value = 2 => protobuf::bytes_tag_decode,
+                    #[required] key = 1 => protobuf::bytes_tag_decode,
+                    #[required] value = 2 => protobuf::bytes_tag_decode,
                 }),
-                _complete = 3 => protobuf::bool_tag_decode,
+                #[required] _complete = 3 => protobuf::bool_tag_decode,
             }
         }),
     );

--- a/src/network/protocol/storage_call_proof.rs
+++ b/src/network/protocol/storage_call_proof.rs
@@ -106,8 +106,8 @@ pub fn decode_storage_or_call_proof_response(
 
     let mut parser = nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(
         nom::combinator::complete(protobuf::message_decode! {
-            response = field_num => protobuf::message_tag_decode(protobuf::message_decode!{
-                proof = 2 => protobuf::bytes_tag_decode
+            #[required] response = field_num => protobuf::message_tag_decode(protobuf::message_decode!{
+                #[required] proof = 2 => protobuf::bytes_tag_decode
             }),
         }),
     );

--- a/src/util/protobuf.rs
+++ b/src/util/protobuf.rs
@@ -244,14 +244,14 @@ pub(crate) fn tag_value_skip_decode<'a, E: nom::error::ParseError<&'a [u8]>>(
 ///
 /// # About `optional` fields
 ///
-/// A field can be either "required" (if marked with ̀`#[required]`) or "optional" (if marked
+/// A field can be either "required" (if marked with `#[required]`) or "optional" (if marked
 /// with `#[optional]` or `#[repeated]`).
 ///
 /// When translating Protobuf definitions into a decoder using this macro, it can be tricky to
 /// know whether to mark fields as `#[optional]`. If the definition uses `proto2`, then all fields
 /// of the definition are always serialized, meaning that they will always be found in the encoded
 /// message. If the definition uses `proto3`, however, then fields that contain their default value
-/// (typically `0` or an empty string/bytes) are intentionally ommitted unless they are marked as
+/// (typically `0` or an empty string/bytes) are intentionally omitted unless they are marked as
 /// `optional`.
 ///
 /// In general, you probably want to mark as `#[optional]` all the fields where `0` or an empty

--- a/src/util/protobuf.rs
+++ b/src/util/protobuf.rs
@@ -224,9 +224,9 @@ pub(crate) fn tag_value_skip_decode<'a, E: nom::error::ParseError<&'a [u8]>>(
 /// This macro expects a list of fields, each field has one of the three following formats:
 ///
 /// ```ignore
-/// field_name = num => parser
+/// #[required] field_name = num => parser
 /// #[optional] field_name = num => parser
-/// #[repeated] field_name = num => parser
+/// #[repeated(max = expr)] field_name = num => parser
 /// ```
 ///
 /// `field_name` must be an identifier, `num` the field number according to the Protobuf
@@ -242,16 +242,33 @@ pub(crate) fn tag_value_skip_decode<'a, E: nom::error::ParseError<&'a [u8]>>(
 /// The macro produces a `nom` parser that outputs an anonymous struct whose field correspond
 /// to the provided field names.
 ///
+/// # About `optional` fields
+///
+/// A field can be either "required" (if marked with ̀`#[required]`) or "optional" (if marked
+/// with `#[optional]` or `#[repeated]`).
+///
+/// When translating Protobuf definitions into a decoder using this macro, it can be tricky to
+/// know whether to mark fields as `#[optional]`. If the definition uses `proto2`, then all fields
+/// of the definition are always serialized, meaning that they will always be found in the encoded
+/// message. If the definition uses `proto3`, however, then fields that contain their default value
+/// (typically `0` or an empty string/bytes) are intentionally ommitted unless they are marked as
+/// `optional`.
+///
+/// In general, you probably want to mark as `#[optional]` all the fields where `0` or an empty
+/// string/bytes is a valid value.
+///
+/// See also <https://github.com/protocolbuffers/protobuf/blob/main/docs/field_presence.md>.
+///
 /// # Example
 ///
 /// ```ignore
 /// let _parser = nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(
 ///     nom::combinator::complete(protobuf::message_decode! {
 ///         #[repeated(max = 4)] entries = 1 => protobuf::message_decode!{
-///             state_root = 1 => protobuf::bytes_tag_decode(1),
+///             #[required] state_root = 1 => protobuf::bytes_tag_decode(1),
 ///             #[repeated(max = 10)] entries = 2 => protobuf::message_tag_decode(2, protobuf::message_decode!{
-///                 key = 1 => protobuf::bytes_tag_decode(1),
-///                 value = 2 => protobuf::bytes_tag_decode(2),
+///                 #[required] key = 1 => protobuf::bytes_tag_decode(1),
+///                 #[required] value = 2 => protobuf::bytes_tag_decode(2),
 ///             }),
 ///             #[optional] complete = 3 => protobuf::bool_tag_decode(3),
 ///         }
@@ -259,7 +276,6 @@ pub(crate) fn tag_value_skip_decode<'a, E: nom::error::ParseError<&'a [u8]>>(
 /// );
 /// ```
 ///
-// TODO: maybe optional should be default?
 macro_rules! message_decode {
     ($($(#[$($attrs:tt)*])* $field_name:ident = $field_num:expr => $parser:expr),*,) => {
         $crate::util::protobuf::message_decode!($($(#[$($attrs)*])* $field_name = $field_num => $parser),*)
@@ -324,13 +340,13 @@ macro_rules! message_decode {
 }
 
 macro_rules! message_decode_helper_ty {
-    ($ty:ty;) => { Option<$ty> };
+    ($ty:ty; required) => { Option<$ty> };
     ($ty:ty; optional) => { Option<$ty> };
     ($ty:ty; repeated(max = $max:expr)) => { Vec<$ty> };
 }
 
 macro_rules! message_decode_helper_store {
-    ($input_data:expr, $value:expr => $dest:expr;) => {
+    ($input_data:expr, $value:expr => $dest:expr; required) => {
         if $dest.is_some() {
             // Make sure that the field is only found once in the message.
             return core::result::Result::Err(nom::Err::Error(
@@ -368,7 +384,7 @@ macro_rules! message_decode_helper_store {
 }
 
 macro_rules! message_decode_helper_unwrap {
-    ($value:expr;) => {
+    ($value:expr; required) => {
         $value.ok_or_else(|| {
             nom::Err::Error(nom::error::ParseError::<&[u8]>::from_error_kind(
                 &[][..],


### PR DESCRIPTION
Whether a field is required or optional when decoding protobuf can be a bit tricky. I wrote a small paragraph about this and made it mandatory to specify `#[required]` instead of it being the default.