### PR TITLE
Make signature verification customizable in the host module

### DIFF
--- a/bin/light-base/src/json_rpc_service.rs
+++ b/bin/light-base/src/json_rpc_service.rs
@@ -1588,6 +1588,9 @@ impl<TPlat: Platform> Background<TPlat> {
                 read_only_runtime_host::RuntimeHostVm::StorageRoot(storage_root) => {
                     runtime_call = storage_root.resume(runtime_call_lock.block_storage_root());
                 }
+                read_only_runtime_host::RuntimeHostVm::SignatureVerification(sig) => {
+                    runtime_call = sig.verify_and_resume();
+                }
             }
         }
     }

--- a/bin/light-base/src/json_rpc_service/chain_head.rs
+++ b/bin/light-base/src/json_rpc_service/chain_head.rs
@@ -274,6 +274,9 @@ impl<TPlat: Platform> Background<TPlat> {
                                                 }
                                                 .to_json_call_object_parameters(None);
                                         }
+                                        runtime_host::RuntimeHostVm::SignatureVerification(sig) => {
+                                            runtime_call = sig.verify_and_resume();
+                                        }
                                     }
                                 }
                             }

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -1162,6 +1162,9 @@ async fn parahead<TPlat: Platform>(
             read_only_runtime_host::RuntimeHostVm::StorageRoot(storage_root) => {
                 runtime_call = storage_root.resume(runtime_call_lock.block_storage_root());
             }
+            read_only_runtime_host::RuntimeHostVm::SignatureVerification(sig) => {
+                runtime_call = sig.verify_and_resume();
+            }
         }
     };
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix the `ext_crypto_ecdsa_verify_version_1` host function mixing its parameters and thus always failing.
+- Fix the `ext_crypto_ecdsa_verify_version_1` host function mixing its parameters and thus always failing. ([#2955](https://github.com/paritytech/smoldot/pull/2955))
 
 ## 0.7.5 - 2022-10-31
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix the `ext_crypto_ecdsa_verify_version_1` host function mixing its parameters and thus always failing.
+
 ## 0.7.5 - 2022-10-31
 
 ### Fixed

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix the `ext_crypto_ecdsa_verify_version_1` host function mixing its parameters and thus always failing. ([#2955](https://github.com/paritytech/smoldot/pull/2955))
+- Fix the `ext_crypto_ecdsa_verify_version_1` and `ext_crypto_ecdsa_verify_prehashed_version_1` host functions mixing their parameters and thus always failing. ([#2955](https://github.com/paritytech/smoldot/pull/2955))
 
 ## 0.7.5 - 2022-10-31
 

--- a/src/chain/chain_information/build.rs
+++ b/src/chain/chain_information/build.rs
@@ -694,6 +694,9 @@ impl ChainInformationBuild {
                         call, inner,
                     )))
                 }
+                read_only_runtime_host::RuntimeHostVm::SignatureVerification(sig) => {
+                    call = sig.verify_and_resume();
+                }
             }
         }
     }

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -2427,16 +2427,18 @@ impl SignatureVerification {
 
     /// Resume the execution assuming that the signature is valid.
     ///
-    /// > **Note**: You are strongly encouraged to call [`SignatureVerification::verify`]. This
-    /// >           function is meant to be used only in debugging situations.
+    /// > **Note**: You are strongly encouraged to call
+    /// >           [`SignatureVerification::verify_and_resume`]. This function is meant to be
+    /// >           used only in debugging situations.
     pub fn resume_success(self) -> HostVm {
         self.resume(true)
     }
 
     /// Resume the execution assuming that the signature is invalid.
     ///
-    /// > **Note**: You are strongly encouraged to call [`SignatureVerification::verify`]. This
-    /// >           function is meant to be used only in debugging situations.
+    /// > **Note**: You are strongly encouraged to call
+    /// >           [`SignatureVerification::verify_and_resume`]. This function is meant to be
+    /// >           used only in debugging situations.
     pub fn resume_failed(self) -> HostVm {
         self.resume(false)
     }

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -552,6 +552,9 @@ pub enum HostVm {
     /// Must the set value of an off-chain storage entry.
     #[from]
     ExternalOffchainStorageSet(ExternalOffchainStorageSet),
+    /// Need to verify whether a signature is valid.
+    #[from]
+    SignatureVerification(SignatureVerification),
     /// Need to call `Core_version` on the given Wasm code and return the raw output (i.e.
     /// still SCALE-encoded), or an error if the call has failed.
     #[from]
@@ -594,6 +597,7 @@ impl HostVm {
             HostVm::ExternalStorageRoot(inner) => inner.inner.into_prototype(),
             HostVm::ExternalStorageNextKey(inner) => inner.inner.into_prototype(),
             HostVm::ExternalOffchainStorageSet(inner) => inner.inner.into_prototype(),
+            HostVm::SignatureVerification(inner) => inner.inner.into_prototype(),
             HostVm::CallRuntimeVersion(inner) => inner.inner.into_prototype(),
             HostVm::StartStorageTransaction(inner) => inner.inner.into_prototype(),
             HostVm::EndStorageTransaction { resume, .. } => resume.inner.into_prototype(),
@@ -848,6 +852,41 @@ impl ReadyToRun {
                         };
                     }
                 }
+            }};
+        }
+
+        macro_rules! expect_pointer_constant_size_raw {
+            ($num:expr, $size:expr) => {{
+                let ptr = match params[$num] {
+                    vm::WasmValue::I32(v) => u32::from_ne_bytes(v.to_ne_bytes()),
+                    v => {
+                        return HostVm::Error {
+                            error: Error::WrongParamTy {
+                                function: host_fn.name(),
+                                param_num: $num,
+                                expected: vm::ValueType::I32,
+                                actual: v.ty(),
+                            },
+                            prototype: self.inner.into_prototype(),
+                        }
+                    }
+                };
+
+                if u32::saturating_add($size, ptr)
+                    > u32::from(self.inner.vm.memory_size()) * 64 * 1024
+                {
+                    return HostVm::Error {
+                        error: Error::ParamOutOfRange {
+                            function: host_fn.name(),
+                            param_num: $num,
+                            pointer: ptr,
+                            length: $size,
+                        },
+                        prototype: self.inner.into_prototype(),
+                    };
+                }
+
+                ptr
             }};
         }
 
@@ -1131,22 +1170,13 @@ impl ReadyToRun {
             HostFunction::ext_crypto_ed25519_generate_version_1 => host_fn_not_implemented!(),
             HostFunction::ext_crypto_ed25519_sign_version_1 => host_fn_not_implemented!(),
             HostFunction::ext_crypto_ed25519_verify_version_1 => {
-                let success = {
-                    let public_key = ed25519_zebra::VerificationKey::try_from(
-                        expect_pointer_constant_size!(2, 32),
-                    );
-                    if let Ok(public_key) = public_key {
-                        let signature =
-                            ed25519_zebra::Signature::from(expect_pointer_constant_size!(0, 64));
-                        let message = expect_pointer_size!(1);
-                        public_key.verify(&signature, message.as_ref()).is_ok()
-                    } else {
-                        false
-                    }
-                };
-
-                HostVm::ReadyToRun(ReadyToRun {
-                    resume_value: Some(vm::WasmValue::I32(if success { 1 } else { 0 })),
+                let (message_ptr, message_size) = expect_pointer_size_raw!(1);
+                HostVm::SignatureVerification(SignatureVerification {
+                    algorithm: SignatureVerificationAlgorithm::Ed25519,
+                    signature_ptr: expect_pointer_constant_size_raw!(0, 64),
+                    public_key_ptr: expect_pointer_constant_size_raw!(2, 32),
+                    message_ptr,
+                    message_size,
                     inner: self.inner,
                 })
             }
@@ -1154,48 +1184,24 @@ impl ReadyToRun {
             HostFunction::ext_crypto_sr25519_generate_version_1 => host_fn_not_implemented!(),
             HostFunction::ext_crypto_sr25519_sign_version_1 => host_fn_not_implemented!(),
             HostFunction::ext_crypto_sr25519_verify_version_1 => {
-                let success = {
-                    // The `unwrap()` below can only panic if the input is the wrong length, which
-                    // we know can't happen.
-                    let signing_public_key =
-                        schnorrkel::PublicKey::from_bytes(&expect_pointer_constant_size!(2, 32))
-                            .unwrap();
-
-                    let signature = expect_pointer_constant_size!(0, 64);
-                    let message = expect_pointer_size!(1);
-
-                    signing_public_key
-                        .verify_simple_preaudit_deprecated(
-                            b"substrate",
-                            message.as_ref(),
-                            &signature,
-                        )
-                        .is_ok()
-                };
-
-                HostVm::ReadyToRun(ReadyToRun {
-                    resume_value: Some(vm::WasmValue::I32(if success { 1 } else { 0 })),
+                let (message_ptr, message_size) = expect_pointer_size_raw!(1);
+                HostVm::SignatureVerification(SignatureVerification {
+                    algorithm: SignatureVerificationAlgorithm::Sr25519V1,
+                    signature_ptr: expect_pointer_constant_size_raw!(0, 64),
+                    public_key_ptr: expect_pointer_constant_size_raw!(2, 32),
+                    message_ptr,
+                    message_size,
                     inner: self.inner,
                 })
             }
             HostFunction::ext_crypto_sr25519_verify_version_2 => {
-                let success = {
-                    // The two `unwrap()`s below can only panic if the input is the wrong
-                    // length, which we know can't happen.
-                    let signing_public_key =
-                        schnorrkel::PublicKey::from_bytes(&expect_pointer_constant_size!(2, 32))
-                            .unwrap();
-                    let signature =
-                        schnorrkel::Signature::from_bytes(&expect_pointer_constant_size!(0, 64))
-                            .unwrap();
-
-                    signing_public_key
-                        .verify_simple(b"substrate", expect_pointer_size!(1).as_ref(), &signature)
-                        .is_ok()
-                };
-
-                HostVm::ReadyToRun(ReadyToRun {
-                    resume_value: Some(vm::WasmValue::I32(if success { 1 } else { 0 })),
+                let (message_ptr, message_size) = expect_pointer_size_raw!(1);
+                HostVm::SignatureVerification(SignatureVerification {
+                    algorithm: SignatureVerificationAlgorithm::Sr25519V2,
+                    signature_ptr: expect_pointer_constant_size_raw!(0, 64),
+                    public_key_ptr: expect_pointer_constant_size_raw!(2, 32),
+                    message_ptr,
+                    message_size,
                     inner: self.inner,
                 })
             }
@@ -1228,36 +1234,13 @@ impl ReadyToRun {
             }
             HostFunction::ext_crypto_ecdsa_public_keys_version_1 => host_fn_not_implemented!(),
             HostFunction::ext_crypto_ecdsa_verify_version_1 => {
-                let success = {
-                    // NOTE: safe to unwrap here because we supply the nn to blake2b fn
-                    let data = <[u8; 32]>::try_from(
-                        blake2_rfc::blake2b::blake2b(32, &[], expect_pointer_size!(0).as_ref())
-                            .as_bytes(),
-                    )
-                    .unwrap();
-                    let message = libsecp256k1::Message::parse(&data);
-
-                    // signature (64 bytes) + recovery ID (1 byte)
-                    let sig_bytes = expect_pointer_constant_size!(0, 65);
-                    if let Ok(sig) = libsecp256k1::Signature::parse_standard_slice(&sig_bytes[..64])
-                    {
-                        if let Ok(ri) = libsecp256k1::RecoveryId::parse(sig_bytes[64]) {
-                            if let Ok(actual) = libsecp256k1::recover(&message, &sig, &ri) {
-                                expect_pointer_constant_size!(2, 33)[..]
-                                    == actual.serialize_compressed()[..]
-                            } else {
-                                false
-                            }
-                        } else {
-                            false
-                        }
-                    } else {
-                        false
-                    }
-                };
-
-                HostVm::ReadyToRun(ReadyToRun {
-                    resume_value: Some(vm::WasmValue::I32(if success { 1 } else { 0 })),
+                let (message_ptr, message_size) = expect_pointer_size_raw!(1);
+                HostVm::SignatureVerification(SignatureVerification {
+                    algorithm: SignatureVerificationAlgorithm::Ecdsa,
+                    signature_ptr: expect_pointer_constant_size_raw!(0, 65),
+                    public_key_ptr: expect_pointer_constant_size_raw!(2, 33),
+                    message_ptr,
+                    message_size,
                     inner: self.inner,
                 })
             }
@@ -2298,6 +2281,182 @@ impl ExternalStorageNextKey {
 impl fmt::Debug for ExternalStorageNextKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("ExternalStorageNextKey").finish()
+    }
+}
+
+/// Must verify whether a signature is correct.
+pub struct SignatureVerification {
+    inner: Inner,
+    /// Which algorithm.
+    algorithm: SignatureVerificationAlgorithm,
+    /// Pointer to the signature. The size of the signature depends on the algorithm. Guaranteed
+    /// to be in range.
+    signature_ptr: u32,
+    /// Pointer to the public key. Guaranteed to be in range.
+    public_key_ptr: u32,
+    /// Pointer to the message. Guaranteed to be in range.
+    message_ptr: u32,
+    /// Size of the message. Guaranteed to be in range.
+    message_size: u32,
+}
+
+enum SignatureVerificationAlgorithm {
+    Ed25519,
+    Sr25519V1,
+    Sr25519V2,
+    Ecdsa,
+}
+
+impl SignatureVerification {
+    /// Returns the message that the signature is expected to sign.
+    pub fn message(&'_ self) -> impl AsRef<[u8]> + '_ {
+        self.inner
+            .vm
+            .read_memory(self.message_ptr, self.message_size)
+            .unwrap()
+    }
+
+    /// Returns the signature.
+    ///
+    /// > **Note**: Be aware that this signature is untrusted input and might not be part of the
+    /// >           set of valid signatures.
+    pub fn signature(&'_ self) -> impl AsRef<[u8]> + '_ {
+        let signature_size = match self.algorithm {
+            SignatureVerificationAlgorithm::Ed25519 => 64,
+            SignatureVerificationAlgorithm::Sr25519V1 => 64,
+            SignatureVerificationAlgorithm::Sr25519V2 => 64,
+            SignatureVerificationAlgorithm::Ecdsa => 65,
+        };
+
+        self.inner
+            .vm
+            .read_memory(self.signature_ptr, signature_size)
+            .unwrap()
+    }
+
+    /// Returns the public key the signature is against.
+    ///
+    /// > **Note**: Be aware that this public key is untrusted input and might not be part of the
+    /// >           set of valid public keys.
+    pub fn public_key(&'_ self) -> impl AsRef<[u8]> + '_ {
+        let public_key_size = match self.algorithm {
+            SignatureVerificationAlgorithm::Ed25519 => 32,
+            SignatureVerificationAlgorithm::Sr25519V1 => 32,
+            SignatureVerificationAlgorithm::Sr25519V2 => 32,
+            SignatureVerificationAlgorithm::Ecdsa => 33,
+        };
+
+        self.inner
+            .vm
+            .read_memory(self.public_key_ptr, public_key_size)
+            .unwrap()
+    }
+
+    /// Verify the signature and resume execution.
+    pub fn verify_and_resume(self) -> HostVm {
+        let success = match self.algorithm {
+            SignatureVerificationAlgorithm::Ed25519 => {
+                let public_key =
+                    ed25519_zebra::VerificationKey::try_from(self.public_key().as_ref());
+
+                if let Ok(public_key) = public_key {
+                    let signature = ed25519_zebra::Signature::from(
+                        <[u8; 64]>::try_from(self.signature().as_ref()).unwrap(),
+                    );
+                    public_key
+                        .verify(&signature, self.message().as_ref())
+                        .is_ok()
+                } else {
+                    false
+                }
+            }
+            SignatureVerificationAlgorithm::Sr25519V1 => {
+                // The `unwrap()` below can only panic if the input is the wrong length, which
+                // we know can't happen.
+                schnorrkel::PublicKey::from_bytes(&self.public_key().as_ref())
+                    .unwrap()
+                    .verify_simple_preaudit_deprecated(
+                        b"substrate",
+                        self.message().as_ref(),
+                        self.signature().as_ref(),
+                    )
+                    .is_ok()
+            }
+            SignatureVerificationAlgorithm::Sr25519V2 => {
+                // The two `unwrap()`s below can only panic if the input is the wrong
+                // length, which we know can't happen.
+                schnorrkel::PublicKey::from_bytes(&self.public_key().as_ref())
+                    .unwrap()
+                    .verify_simple(
+                        b"substrate",
+                        self.message().as_ref(),
+                        &schnorrkel::Signature::from_bytes(self.signature().as_ref()).unwrap(),
+                    )
+                    .is_ok()
+            }
+            SignatureVerificationAlgorithm::Ecdsa => {
+                // NOTE: safe to unwrap here because we supply the nn to blake2b fn
+                let data = <[u8; 32]>::try_from(
+                    blake2_rfc::blake2b::blake2b(32, &[], self.message().as_ref()).as_bytes(),
+                )
+                .unwrap();
+                let message = libsecp256k1::Message::parse(&data);
+
+                // signature (64 bytes) + recovery ID (1 byte)
+                let sig_bytes = self.signature();
+                if let Ok(sig) =
+                    libsecp256k1::Signature::parse_standard_slice(&sig_bytes.as_ref()[..64])
+                {
+                    if let Ok(ri) = libsecp256k1::RecoveryId::parse(sig_bytes.as_ref()[64]) {
+                        if let Ok(actual) = libsecp256k1::recover(&message, &sig, &ri) {
+                            self.public_key().as_ref()[..] == actual.serialize_compressed()[..]
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            }
+        };
+
+        self.resume(success)
+    }
+
+    /// Resume the execution assuming that the signature is valid.
+    ///
+    /// > **Note**: You are strongly encouraged to call [`SignatureVerification::verify`]. This
+    /// >           function is meant to be used only in debugging situations.
+    pub fn resume_success(self) -> HostVm {
+        self.resume(true)
+    }
+
+    /// Resume the execution assuming that the signature is invalid.
+    ///
+    /// > **Note**: You are strongly encouraged to call [`SignatureVerification::verify`]. This
+    /// >           function is meant to be used only in debugging situations.
+    pub fn resume_failed(self) -> HostVm {
+        self.resume(false)
+    }
+
+    fn resume(self, success: bool) -> HostVm {
+        // All signature-related host functions work the same way in terms of return value.
+        HostVm::ReadyToRun(ReadyToRun {
+            resume_value: Some(vm::WasmValue::I32(if success { 1 } else { 0 })),
+            inner: self.inner,
+        })
+    }
+}
+
+impl fmt::Debug for SignatureVerification {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("SignatureVerification")
+            .field("message", &self.message().as_ref())
+            .field("signature", &self.signature().as_ref())
+            .field("public_key", &self.public_key().as_ref())
+            .finish()
     }
 }
 

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -2406,7 +2406,11 @@ impl SignatureVerification {
                 }
             }
             SignatureVerificationAlgorithm::EcdsaPrehashed => {
-                let message = libsecp256k1::Message::parse(self.message().as_ref());
+                // We can safely unwrap, as the size is checked when the `SignatureVerification`
+                // is constructed.
+                let message = libsecp256k1::Message::parse(
+                    &<[u8; 32]>::try_from(self.message().as_ref()).unwrap(),
+                );
 
                 // signature (64 bytes) + recovery ID (1 byte)
                 let sig_bytes = self.signature();

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -2337,9 +2337,9 @@ impl SignatureVerification {
             .unwrap()
     }
 
-    /// Verify the signature and resume execution.
-    pub fn verify_and_resume(self) -> HostVm {
-        let success = match self.algorithm {
+    /// Verify the signature. Returns `true` if it is valid.
+    pub fn is_valid(&self) -> bool {
+        match self.algorithm {
             SignatureVerificationAlgorithm::Ed25519 => {
                 let public_key =
                     ed25519_zebra::VerificationKey::try_from(self.public_key().as_ref());
@@ -2430,8 +2430,12 @@ impl SignatureVerification {
                     false
                 }
             }
-        };
+        }
+    }
 
+    /// Verify the signature and resume execution.
+    pub fn verify_and_resume(self) -> HostVm {
+        let success = self.is_valid();
         self.resume(success)
     }
 

--- a/src/executor/host.rs
+++ b/src/executor/host.rs
@@ -2287,12 +2287,13 @@ impl fmt::Debug for ExternalStorageNextKey {
 /// Must verify whether a signature is correct.
 pub struct SignatureVerification {
     inner: Inner,
-    /// Which algorithm.
+    /// Which cryptographic algorithm.
     algorithm: SignatureVerificationAlgorithm,
     /// Pointer to the signature. The size of the signature depends on the algorithm. Guaranteed
     /// to be in range.
     signature_ptr: u32,
-    /// Pointer to the public key. Guaranteed to be in range.
+    /// Pointer to the public key. The size of the public key depends on the algorithm. Guaranteed
+    /// to be in range.
     public_key_ptr: u32,
     /// Pointer to the message. Guaranteed to be in range.
     message_ptr: u32,

--- a/src/executor/read_only_runtime_host.rs
+++ b/src/executor/read_only_runtime_host.rs
@@ -290,6 +290,10 @@ impl Inner {
                     return RuntimeHostVm::NextKey(NextKey { inner: self });
                 }
 
+                host::HostVm::SignatureVerification(sig) => {
+                    self.vm = sig.verify_and_resume();
+                }
+
                 host::HostVm::CallRuntimeVersion(req) => {
                     // TODO: make the user execute this ; see https://github.com/paritytech/smoldot/issues/144
                     // The code below compiles the provided WebAssembly runtime code, which is a

--- a/src/executor/read_only_runtime_host.rs
+++ b/src/executor/read_only_runtime_host.rs
@@ -119,6 +119,8 @@ pub enum RuntimeHostVm {
     NextKey(NextKey),
     /// Fetching the storage trie root is required in order to continue.
     StorageRoot(StorageRoot),
+    /// Verifying whether a signature is correct is required in order to continue.
+    SignatureVerification(SignatureVerification),
 }
 
 impl RuntimeHostVm {
@@ -130,6 +132,7 @@ impl RuntimeHostVm {
             RuntimeHostVm::StorageGet(inner) => inner.inner.vm.into_prototype(),
             RuntimeHostVm::NextKey(inner) => inner.inner.vm.into_prototype(),
             RuntimeHostVm::StorageRoot(inner) => inner.inner.vm.into_prototype(),
+            RuntimeHostVm::SignatureVerification(inner) => inner.inner.vm.into_prototype(),
         }
     }
 }
@@ -247,6 +250,90 @@ impl StorageRoot {
     }
 }
 
+/// Verifying whether a signature is correct is required in order to continue.
+#[must_use]
+pub struct SignatureVerification {
+    inner: Inner,
+}
+
+impl SignatureVerification {
+    /// Returns the message that the signature is expected to sign.
+    pub fn message(&'_ self) -> impl AsRef<[u8]> + '_ {
+        match self.inner.vm {
+            host::HostVm::SignatureVerification(ref sig) => sig.message(),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Returns the signature.
+    ///
+    /// > **Note**: Be aware that this signature is untrusted input and might not be part of the
+    /// >           set of valid signatures.
+    pub fn signature(&'_ self) -> impl AsRef<[u8]> + '_ {
+        match self.inner.vm {
+            host::HostVm::SignatureVerification(ref sig) => sig.signature(),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Returns the public key the signature is against.
+    ///
+    /// > **Note**: Be aware that this public key is untrusted input and might not be part of the
+    /// >           set of valid public keys.
+    pub fn public_key(&'_ self) -> impl AsRef<[u8]> + '_ {
+        match self.inner.vm {
+            host::HostVm::SignatureVerification(ref sig) => sig.public_key(),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Verify the signature. Returns `true` if it is valid.
+    pub fn is_valid(&self) -> bool {
+        match self.inner.vm {
+            host::HostVm::SignatureVerification(ref sig) => sig.is_valid(),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Verify the signature and resume execution.
+    pub fn verify_and_resume(mut self) -> RuntimeHostVm {
+        match self.inner.vm {
+            host::HostVm::SignatureVerification(sig) => self.inner.vm = sig.verify_and_resume(),
+            _ => unreachable!(),
+        }
+
+        self.inner.run()
+    }
+
+    /// Resume the execution assuming that the signature is valid.
+    ///
+    /// > **Note**: You are strongly encouraged to call
+    /// >           [`SignatureVerification::verify_and_resume`]. This function is meant to be
+    /// >           used only in debugging situations.
+    pub fn resume_success(mut self) -> RuntimeHostVm {
+        match self.inner.vm {
+            host::HostVm::SignatureVerification(sig) => self.inner.vm = sig.resume_success(),
+            _ => unreachable!(),
+        }
+
+        self.inner.run()
+    }
+
+    /// Resume the execution assuming that the signature is invalid.
+    ///
+    /// > **Note**: You are strongly encouraged to call
+    /// >           [`SignatureVerification::verify_and_resume`]. This function is meant to be
+    /// >           used only in debugging situations.
+    pub fn resume_failed(mut self) -> RuntimeHostVm {
+        match self.inner.vm {
+            host::HostVm::SignatureVerification(sig) => self.inner.vm = sig.resume_failed(),
+            _ => unreachable!(),
+        }
+
+        self.inner.run()
+    }
+}
+
 /// Implementation detail of the execution. Shared by all the variants of [`RuntimeHostVm`]
 /// other than [`RuntimeHostVm::Finished`].
 struct Inner {
@@ -290,8 +377,11 @@ impl Inner {
                     return RuntimeHostVm::NextKey(NextKey { inner: self });
                 }
 
-                host::HostVm::SignatureVerification(sig) => {
-                    self.vm = sig.verify_and_resume();
+                host::HostVm::SignatureVerification(req) => {
+                    self.vm = req.into();
+                    return RuntimeHostVm::SignatureVerification(SignatureVerification {
+                        inner: self,
+                    });
                 }
 
                 host::HostVm::CallRuntimeVersion(req) => {

--- a/src/executor/runtime_host.rs
+++ b/src/executor/runtime_host.rs
@@ -654,6 +654,10 @@ impl Inner {
                     self.vm = req.resume();
                 }
 
+                host::HostVm::SignatureVerification(sig) => {
+                    self.vm = sig.verify_and_resume();
+                }
+
                 host::HostVm::CallRuntimeVersion(req) => {
                     // TODO: make the user execute this ; see https://github.com/paritytech/smoldot/issues/144
                     // The code below compiles the provided WebAssembly runtime code, which is a

--- a/src/executor/runtime_host.rs
+++ b/src/executor/runtime_host.rs
@@ -166,6 +166,8 @@ pub enum RuntimeHostVm {
     PrefixKeys(PrefixKeys),
     /// Fetching the key that follows a given one is required in order to continue.
     NextKey(NextKey),
+    /// Verifying whether a signature is correct is required in order to continue.
+    SignatureVerification(SignatureVerification),
 }
 
 impl RuntimeHostVm {
@@ -177,6 +179,7 @@ impl RuntimeHostVm {
             RuntimeHostVm::StorageGet(inner) => inner.inner.vm.into_prototype(),
             RuntimeHostVm::PrefixKeys(inner) => inner.inner.vm.into_prototype(),
             RuntimeHostVm::NextKey(inner) => inner.inner.vm.into_prototype(),
+            RuntimeHostVm::SignatureVerification(inner) => inner.inner.vm.into_prototype(),
         }
     }
 }
@@ -464,6 +467,90 @@ impl NextKey {
     }
 }
 
+/// Verifying whether a signature is correct is required in order to continue.
+#[must_use]
+pub struct SignatureVerification {
+    inner: Inner,
+}
+
+impl SignatureVerification {
+    /// Returns the message that the signature is expected to sign.
+    pub fn message(&'_ self) -> impl AsRef<[u8]> + '_ {
+        match self.inner.vm {
+            host::HostVm::SignatureVerification(ref sig) => sig.message(),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Returns the signature.
+    ///
+    /// > **Note**: Be aware that this signature is untrusted input and might not be part of the
+    /// >           set of valid signatures.
+    pub fn signature(&'_ self) -> impl AsRef<[u8]> + '_ {
+        match self.inner.vm {
+            host::HostVm::SignatureVerification(ref sig) => sig.signature(),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Returns the public key the signature is against.
+    ///
+    /// > **Note**: Be aware that this public key is untrusted input and might not be part of the
+    /// >           set of valid public keys.
+    pub fn public_key(&'_ self) -> impl AsRef<[u8]> + '_ {
+        match self.inner.vm {
+            host::HostVm::SignatureVerification(ref sig) => sig.public_key(),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Verify the signature. Returns `true` if it is valid.
+    pub fn is_valid(&self) -> bool {
+        match self.inner.vm {
+            host::HostVm::SignatureVerification(ref sig) => sig.is_valid(),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Verify the signature and resume execution.
+    pub fn verify_and_resume(mut self) -> RuntimeHostVm {
+        match self.inner.vm {
+            host::HostVm::SignatureVerification(sig) => self.inner.vm = sig.verify_and_resume(),
+            _ => unreachable!(),
+        }
+
+        self.inner.run()
+    }
+
+    /// Resume the execution assuming that the signature is valid.
+    ///
+    /// > **Note**: You are strongly encouraged to call
+    /// >           [`SignatureVerification::verify_and_resume`]. This function is meant to be
+    /// >           used only in debugging situations.
+    pub fn resume_success(mut self) -> RuntimeHostVm {
+        match self.inner.vm {
+            host::HostVm::SignatureVerification(sig) => self.inner.vm = sig.resume_success(),
+            _ => unreachable!(),
+        }
+
+        self.inner.run()
+    }
+
+    /// Resume the execution assuming that the signature is invalid.
+    ///
+    /// > **Note**: You are strongly encouraged to call
+    /// >           [`SignatureVerification::verify_and_resume`]. This function is meant to be
+    /// >           used only in debugging situations.
+    pub fn resume_failed(mut self) -> RuntimeHostVm {
+        match self.inner.vm {
+            host::HostVm::SignatureVerification(sig) => self.inner.vm = sig.resume_failed(),
+            _ => unreachable!(),
+        }
+
+        self.inner.run()
+    }
+}
+
 /// Implementation detail of the execution. Shared by all the variants of [`RuntimeHostVm`]
 /// other than [`RuntimeHostVm::Finished`].
 struct Inner {
@@ -654,8 +741,11 @@ impl Inner {
                     self.vm = req.resume();
                 }
 
-                host::HostVm::SignatureVerification(sig) => {
-                    self.vm = sig.verify_and_resume();
+                host::HostVm::SignatureVerification(req) => {
+                    self.vm = req.into();
+                    return RuntimeHostVm::SignatureVerification(SignatureVerification {
+                        inner: self,
+                    });
                 }
 
                 host::HostVm::CallRuntimeVersion(req) => {

--- a/src/verify/header_body.rs
+++ b/src/verify/header_body.rs
@@ -549,6 +549,9 @@ impl VerifyInner {
                         consensus_success: self.consensus_success,
                     })
                 }
+                runtime_host::RuntimeHostVm::SignatureVerification(sig) => {
+                    self.inner = sig.verify_and_resume();
+                }
             }
         }
     }


### PR DESCRIPTION
cc @xlc 
After looking at https://github.com/paritytech/smoldot/pull/2952, I thought that the approach in this PR is a better idea.

As shown in the changes to `runtime_host.rs` and `read_only_runtime_host.rs`, you now have a new variant called `SignatureVerification` that allows you to overwrite the verification if you so desire.

As I was implemented this PR, I noticed that the implementation of `ext_crypto_ecdsa_verify` loads the message from the first parameter, which is actually the signature. Oops. This is fixed at the same time.
