### PR TITLE
Remove key_as_vec() functions

### DIFF
--- a/bin/full-node/src/run/consensus_service.rs
+++ b/bin/full-node/src/run/consensus_service.rs
@@ -712,10 +712,14 @@ impl SyncBackground {
                         // in full mode, in which case we shouldn't have reached this code.
                         let best_block_storage_access = self.sync.best_block_storage().unwrap();
 
-                        let key = get.key_as_vec(); // TODO: overhead?
-                        let value = best_block_storage_access.get(&key, || {
-                            self.finalized_block_storage.get(&key).map(|v| &v[..])
-                        });
+                        let value = {
+                            let key = get.key();
+                            best_block_storage_access.get(key.as_ref(), || {
+                                self.finalized_block_storage
+                                    .get(key.as_ref())
+                                    .map(|v| &v[..])
+                            })
+                        };
                         block_authoring = get.inject_value(value.map(iter::once));
                         continue;
                     }
@@ -1089,7 +1093,7 @@ impl SyncBackground {
                             all::BlockVerification::FinalizedStorageGet(req) => {
                                 let value = self
                                     .finalized_block_storage
-                                    .get(&req.key_as_vec())
+                                    .get(req.key().as_ref())
                                     .map(|v| &v[..]);
                                 verify = req.inject_value(value);
                             }

--- a/bin/light-base/src/json_rpc_service.rs
+++ b/bin/light-base/src/json_rpc_service.rs
@@ -1566,7 +1566,8 @@ impl<TPlat: Platform> Background<TPlat> {
                     break Err(RuntimeCallError::ReadOnlyRuntime(error.detail));
                 }
                 read_only_runtime_host::RuntimeHostVm::StorageGet(get) => {
-                    let storage_value = match runtime_call_lock.storage_entry(&get.key_as_vec()) {
+                    let storage_value = runtime_call_lock.storage_entry(get.key().as_ref());
+                    let storage_value = match storage_value {
                         Ok(v) => v,
                         Err(err) => {
                             runtime_call_lock.unlock(

--- a/bin/light-base/src/json_rpc_service/chain_head.rs
+++ b/bin/light-base/src/json_rpc_service/chain_head.rs
@@ -223,9 +223,9 @@ impl<TPlat: Platform> Background<TPlat> {
                                         }
                                         runtime_host::RuntimeHostVm::StorageGet(get) => {
                                             // TODO: what if the remote lied to us?
-                                            let storage_value = match runtime_call_lock
-                                                .storage_entry(&get.key_as_vec())
-                                            {
+                                            let storage_value =
+                                                runtime_call_lock.storage_entry(get.key().as_ref());
+                                            let storage_value = match storage_value {
                                                 Ok(v) => v,
                                                 Err(error) => {
                                                     runtime_call_lock.unlock(

--- a/bin/light-base/src/sync_service/parachain.rs
+++ b/bin/light-base/src/sync_service/parachain.rs
@@ -1142,7 +1142,8 @@ async fn parahead<TPlat: Platform>(
                 return Err(ParaheadError::ReadOnlyRuntime(error.detail));
             }
             read_only_runtime_host::RuntimeHostVm::StorageGet(get) => {
-                let storage_value = match runtime_call_lock.storage_entry(&get.key_as_vec()) {
+                let storage_value = runtime_call_lock.storage_entry(get.key().as_ref());
+                let storage_value = match storage_value {
                     Ok(v) => v,
                     Err(err) => {
                         runtime_call_lock.unlock(

--- a/bin/light-base/src/transactions_service.rs
+++ b/bin/light-base/src/transactions_service.rs
@@ -1196,7 +1196,8 @@ async fn validate_transaction<TPlat: Platform>(
                 ));
             }
             validate::Query::StorageGet(get) => {
-                let storage_value = match runtime_call_lock.storage_entry(&get.key_as_vec()) {
+                let storage_value = runtime_call_lock.storage_entry(get.key().as_ref());
+                let storage_value = match storage_value {
                     Ok(v) => v,
                     Err(err) => {
                         runtime_call_lock.unlock(validate::Query::StorageGet(get).into_prototype());

--- a/src/author/build.rs
+++ b/src/author/build.rs
@@ -303,15 +303,8 @@ pub struct StorageGet(runtime::StorageGet, Shared);
 
 impl StorageGet {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[u8]> + '_> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
         self.0.key()
-    }
-
-    /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    ///
-    /// This method is a shortcut for calling `key` and concatenating the returned slices.
-    pub fn key_as_vec(&self) -> Vec<u8> {
-        self.0.key_as_vec()
     }
 
     /// Injects the corresponding storage value.

--- a/src/author/runtime.rs
+++ b/src/author/runtime.rs
@@ -590,15 +590,8 @@ pub struct StorageGet(runtime_host::StorageGet, Shared);
 
 impl StorageGet {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[u8]> + '_> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
         self.0.key()
-    }
-
-    /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    ///
-    /// This method is a shortcut for calling `key` and concatenating the returned slices.
-    pub fn key_as_vec(&self) -> Vec<u8> {
-        self.0.key_as_vec()
     }
 
     /// Injects the corresponding storage value.

--- a/src/author/runtime/tests.rs
+++ b/src/author/runtime/tests.rs
@@ -58,10 +58,9 @@ fn block_building_works() {
                 builder = ext.inject_inherents(inherents::InherentData { timestamp: 1234 });
             }
             super::BlockBuild::StorageGet(get) => {
-                let key = get.key_as_vec();
                 let value = genesis_storage
                     .iter()
-                    .find(|(k, _)| *k == key)
+                    .find(|(k, _)| *k == get.key().as_ref())
                     .map(|(_, v)| iter::once(v));
                 builder = get.inject_value(value);
             }

--- a/src/chain/blocks_tree/verify.rs
+++ b/src/chain/blocks_tree/verify.rs
@@ -897,15 +897,8 @@ pub struct StorageGet<T> {
 
 impl<T> StorageGet<T> {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[u8]> + '_> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
         self.inner.key()
-    }
-
-    /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    ///
-    /// This method is a shortcut for calling `key` and concatenating the returned slices.
-    pub fn key_as_vec(&self) -> Vec<u8> {
-        self.inner.key_as_vec()
     }
 
     /// Access to the Nth ancestor's information and hierarchy. Returns `None` if `n` is too

--- a/src/chain/chain_information/build.rs
+++ b/src/chain/chain_information/build.rs
@@ -249,15 +249,8 @@ pub struct StorageGet(
 
 impl StorageGet {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[u8]> + '_> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
         self.0.key()
-    }
-
-    /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    ///
-    /// This method is a shortcut for calling `key` and concatenating the returned slices.
-    pub fn key_as_vec(&self) -> Vec<u8> {
-        self.0.key_as_vec()
     }
 
     /// Injects the corresponding storage value.

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -153,9 +153,8 @@ impl ChainSpec {
         let (chain_info, vm_prototype) = loop {
             match chain_information_build {
                 build::ChainInformationBuild::InProgress(build::InProgress::StorageGet(get)) => {
-                    let key = get.key_as_vec();
-                    chain_information_build =
-                        get.inject_value(genesis_storage.value(&key).map(iter::once));
+                    let value = genesis_storage.value(get.key().as_ref());
+                    chain_information_build = get.inject_value(value.map(iter::once));
                 }
                 build::ChainInformationBuild::InProgress(build::InProgress::NextKey(_nk)) => {
                     todo!() // TODO:

--- a/src/executor/read_only_runtime_host.rs
+++ b/src/executor/read_only_runtime_host.rs
@@ -22,7 +22,7 @@
 use crate::executor::{self, host, vm};
 
 use alloc::{string::String, vec::Vec};
-use core::{fmt, iter};
+use core::fmt;
 
 /// Configuration for [`run`].
 pub struct Config<'a, TParams> {
@@ -145,23 +145,13 @@ pub struct StorageGet {
 
 impl StorageGet {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[u8]> + '_> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
         match &self.inner.vm {
-            host::HostVm::ExternalStorageGet(req) => iter::once(req.key()),
+            host::HostVm::ExternalStorageGet(req) => req.key(),
 
             // We only create a `StorageGet` if the state is one of the above.
             _ => unreachable!(),
         }
-    }
-
-    /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    ///
-    /// This method is a shortcut for calling `key` and concatenating the returned slices.
-    pub fn key_as_vec(&self) -> Vec<u8> {
-        self.key().fold(Vec::new(), |mut a, b| {
-            a.extend_from_slice(b.as_ref());
-            a
-        })
     }
 
     /// Injects the corresponding storage value.

--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -2531,15 +2531,8 @@ pub struct StorageGet<TRq, TSrc, TBl> {
 
 impl<TRq, TSrc, TBl> StorageGet<TRq, TSrc, TBl> {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[u8]> + '_> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
         self.inner.key()
-    }
-
-    /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    ///
-    /// This method is a shortcut for calling `key` and concatenating the returned slices.
-    pub fn key_as_vec(&self) -> Vec<u8> {
-        self.inner.key_as_vec()
     }
 
     /// Injects the corresponding storage value.

--- a/src/sync/optimistic.rs
+++ b/src/sync/optimistic.rs
@@ -1131,11 +1131,11 @@ impl<TRq, TSrc, TBl> BlockVerification<TRq, TSrc, TBl> {
                     // As such, the requested value is either found in one of this diff, in which
                     // case it can be returned immediately to continue the verification, or in
                     // the finalized block, in which case the user needs to be queried.
-                    if let Some(value) = shared
+                    let value = shared
                         .inner
                         .best_to_finalized_storage_diff
-                        .diff_get(&req.key_as_vec())
-                    {
+                        .diff_get(req.key().as_ref());
+                    if let Some(value) = value {
                         inner = Inner::Step2(
                             req.inject_value(value.as_ref().map(|v| iter::once(&v[..]))),
                         );
@@ -1417,15 +1417,8 @@ pub struct StorageGet<TRq, TSrc, TBl> {
 
 impl<TRq, TSrc, TBl> StorageGet<TRq, TSrc, TBl> {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[u8]> + '_> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
         self.inner.key()
-    }
-
-    /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    ///
-    /// This method is a shortcut for calling `key` and concatenating the returned slices.
-    pub fn key_as_vec(&self) -> Vec<u8> {
-        self.inner.key_as_vec()
     }
 
     /// Injects the corresponding storage value.

--- a/src/sync/warp_sync.rs
+++ b/src/sync/warp_sync.rs
@@ -1238,7 +1238,7 @@ impl<TSrc, TRq> BuildChainInformation<TSrc, TRq> {
 
                         let value =
                             match proof_verify::verify_proof(proof_verify::VerifyProofConfig {
-                                requested_key: &get.key_as_vec(), // TODO: allocating vec
+                                requested_key: get.key().as_ref(),
                                 trie_root_hash: &header.state_root,
                                 proof: proof.iter().map(|v| &v[..]),
                             }) {

--- a/src/transactions/validate.rs
+++ b/src/transactions/validate.rs
@@ -562,20 +562,10 @@ enum StorageGetInner {
 
 impl StorageGet {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[u8]> + '_> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
         match &self.0 {
-            StorageGetInner::Stage1(inner, _) => either::Left(inner.key().map(either::Left)),
-            StorageGetInner::Stage2(inner, _) => either::Right(inner.key().map(either::Right)),
-        }
-    }
-
-    /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    ///
-    /// This method is a shortcut for calling `key` and concatenating the returned slices.
-    pub fn key_as_vec(&self) -> Vec<u8> {
-        match &self.0 {
-            StorageGetInner::Stage1(inner, _) => inner.key_as_vec(),
-            StorageGetInner::Stage2(inner, _) => inner.key_as_vec(),
+            StorageGetInner::Stage1(inner, _) => either::Left(inner.key()),
+            StorageGetInner::Stage2(inner, _) => either::Right(inner.key()),
         }
     }
 

--- a/src/verify/header_body.rs
+++ b/src/verify/header_body.rs
@@ -568,15 +568,8 @@ pub struct StorageGet {
 
 impl StorageGet {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[u8]> + '_> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
         self.inner.key()
-    }
-
-    /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    ///
-    /// This method is a shortcut for calling `key` and concatenating the returned slices.
-    pub fn key_as_vec(&self) -> Vec<u8> {
-        self.inner.key_as_vec()
     }
 
     /// Injects the corresponding storage value.


### PR DESCRIPTION
When the executor wants to obtain the value at a certain storage location, it provides us with a `StorageGet` object. This object has a `key()` function that returns the key to query.

Currently, this function returns an `impl Iterator<Item = impl AsRef<[u8]>>`, and the actual key consists in the concatenation of all the elements returned by the iterator.
In order to be more convenient to use, there's also a `key_as_vec()` function that returns a `Vec<u8>` with the key.

This iterator thing is a micro-optimization that only comes useful at a single place where we return a list of bytes instead of collecting them into a `Vec`.
However, the iterator is actually never really usable, and every use of this API uses `key_as_vec()`, which completely kills the point of this micro-optimization.
It's also not obvious to me that this optimization actually is an optimization.

In order to simplify everything, this PR removes the `key_as_vec()` functions and makes `key()` return a single `impl AsRef<[u8]>` of the key.
