### PR TITLE
Fix wrong order of parachain blocks at initialization

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Fix the `ext_crypto_ecdsa_verify_version_1` and `ext_crypto_ecdsa_verify_prehashed_version_1` host functions mixing their parameters and thus always failing. ([#2955](https://github.com/paritytech/smoldot/pull/2955))
-- Fix an occasional panic in `runtime_service.rs` when adding a parachain.
+- Fix an occasional panic in `runtime_service.rs` when adding a parachain. ([#2965](https://github.com/paritytech/smoldot/pull/2965))
 
 ## 0.7.5 - 2022-10-31
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix the `ext_crypto_ecdsa_verify_version_1` and `ext_crypto_ecdsa_verify_prehashed_version_1` host functions mixing their parameters and thus always failing. ([#2955](https://github.com/paritytech/smoldot/pull/2955))
+- Fix an occasional panic in `runtime_service.rs` when adding a parachain.
 
 ## 0.7.5 - 2022-10-31
 


### PR DESCRIPTION
When we subscribe to parachain blocks, the subscription confirmation contains the list of all blocks that already exist. This list of blocks needs to be ordered from parent to child, and the field is actually named `non_finalized_blocks_ancestry_order` ("ancestry order") in order for everyone to get the memo.

Unfortunately, the author of the parachains code (me) didn't get the memo, and the parachain blocks aren't properly ordered.
This leads to a panic in `runtime_service.rs` because it assumes that the ordering is correct.
