### PR TITLE
Change the state_request protocol to use the proof version

### DIFF
--- a/src/network/protocol/state_request.rs
+++ b/src/network/protocol/state_request.rs
@@ -15,8 +15,38 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// TODO: also implement the "proof" way to request the state
-// TODO: support child trie requests
+//! State requests protocol.
+//!
+//! # Overview
+//!
+//! A state request consists in asking for the remote to send back all the storage entries
+//! starting at a specific key. As many storage entries are included in the response as possible,
+//! until the response fits the size of 2MiB.
+//!
+//! After a response has been received, the sender is expected to send back another request (with
+//! a start key right after the last key of the response) in order to continue downloading the
+//! storage entries.
+//!
+//! The format of the response is a compact Merkle proof.
+//!
+//! > **Note**: The implementation in this module always requests a proof from the server.
+//! >           Substrate nodes also support a "no proof" mode where, instead of a proof, the list
+//! >           of entries are simply returned without any way to verify them. This alternative
+//! >           mode is supposed to be used only in situations where the peer the request is sent
+//! >           to is trusted. Because this "no proof" mode is very niche, the implementation in
+//! >           this module doesn't support it.
+//!
+//! # About child tries
+//!
+//! For the purpose of this protocol, the content of child tries is as if they existed in the main
+//! trie under the key `:child_storage:default:`. For example, the child trie `0xabcd` is
+//! considered to be at key `concat(b":child_storage:default:", 0xabcd)`.
+//!
+//! In the response, the child trie Merkle proof is associated with the main trie entry
+//! corresponding to the child trie. In other words, it is as if the child trie entry in the main
+//! trie was a branch node, except that it has a value corresponding to the hash of the root of
+//! the child trie.
+//!
 
 use crate::util::protobuf;
 
@@ -30,43 +60,64 @@ pub struct StateRequest<'a> {
 
     /// Response shouldn't contain any key lexicographically inferior to this key.
     ///
-    /// > **Note**: Because a response has a limited size, this value lets you send additional
+    /// > **Note**: Because a response has a limited size, this field lets you send additional
     /// >           requests that start where the previous response has ended.
-    pub start_key: &'a [u8],
+    pub start_key: StateRequestStart<'a>,
 }
 
-// See https://github.com/paritytech/substrate/blob/c8653447fc8ef8d95a92fe164c96dffb37919e85/client/network/light/src/schema/light.v1.proto
+/// See [`StateRequest::start_key`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StateRequestStart<'a> {
+    /// Start iterating at a key in the main trie.
+    MainTrie(&'a [u8]),
+    /// Start iterating at a key in a child trie.
+    ChildTrieDefault {
+        /// Key of the child trie.
+        child_trie: &'a [u8],
+        /// Key within the child trie.
+        key: &'a [u8],
+    },
+}
+
+// See https://github.com/paritytech/substrate/blob/c8653447fc8ef8d95a92fe164c96dffb37919e85/client/network/sync/src/schema/api.v1.proto#L73-L106
 // for protocol definition.
 
 /// Builds the bytes corresponding to a state request.
 pub fn build_state_request(
     config: StateRequest<'_>,
 ) -> impl Iterator<Item = impl AsRef<[u8]> + '_> + '_ {
+    let start = match config.start_key {
+        StateRequestStart::MainTrie(key) => {
+            either::Left(protobuf::bytes_tag_encode(2, key).map(either::Left))
+        }
+        StateRequestStart::ChildTrieDefault { child_trie, key } => either::Right(
+            protobuf::bytes_tag_encode(2, {
+                let mut vec = b":child_storage:default:".to_vec();
+                vec.extend(child_trie);
+                vec
+            })
+            .map(either::Left)
+            .chain(protobuf::bytes_tag_encode(2, key).map(either::Right))
+            .map(either::Right),
+        ),
+    };
+
     protobuf::bytes_tag_encode(1, config.block_hash)
         .map(either::Right)
         .map(either::Right)
-        .chain(
-            protobuf::bytes_tag_encode(2, config.start_key)
-                .map(either::Left)
-                .map(either::Right),
-        )
-        .chain(protobuf::bool_tag_encode(3, true).map(either::Left))
+        .chain(start.map(either::Left).map(either::Right))
+        .chain(protobuf::bool_tag_encode(3, false).map(either::Left))
 }
 
-/// Decodes a response into a state request response.
+/// Decodes a response to a state request.
+///
+/// On success, contains a list of Merkle proof entries.
 pub fn decode_state_response(
-    response_bytes: &'_ [u8],
-) -> Result<Vec<StateResponseEntry<'_>>, DecodeStateResponseError> {
+    response_bytes: &[u8],
+) -> Result<Vec<&[u8]>, DecodeStateResponseError> {
     let mut parser = nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(
         nom::combinator::complete(protobuf::message_decode! {
-            #[repeated(max = 1)] entries = 1 => protobuf::message_decode!{
-                #[required] _state_root = 1 => protobuf::bytes_tag_decode,
-                #[repeated(max = 4 * 1024 * 1024)] entries = 2 => protobuf::message_tag_decode(protobuf::message_decode!{
-                    #[required] key = 1 => protobuf::bytes_tag_decode,
-                    #[required] value = 2 => protobuf::bytes_tag_decode,
-                }),
-                #[required] _complete = 3 => protobuf::bool_tag_decode,
-            }
+            #[repeated(max = usize::max_value())] proof = 2 => protobuf::bytes_tag_decode,
         }),
     );
 
@@ -75,33 +126,11 @@ pub fn decode_state_response(
         Err(_) => return Err(DecodeStateResponseError::ProtobufDecode),
     };
 
-    let entries = decoded
-        .entries
-        .into_iter()
-        .flat_map(|entries| entries.entries.into_iter())
-        .map(|entry| StateResponseEntry {
-            key: entry.key,
-            value: entry.value,
-        })
-        .collect();
-
-    Ok(entries)
-}
-
-/// Entry sent in a state response.
-///
-/// > **Note**: Assuming that this response comes from the network, the information in this struct
-/// >           can be erroneous and shouldn't be trusted.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StateResponseEntry<'a> {
-    /// Storage key concerned by the entry.
-    pub key: &'a [u8],
-    /// Storage value concerned by the entry.
-    pub value: &'a [u8],
+    Ok(decoded.proof)
 }
 
 /// Error potentially returned by [`decode_state_response`].
-#[derive(Debug, derive_more::Display)]
+#[derive(Debug, derive_more::Display, Clone)]
 #[display(fmt = "Failed to decode response")]
 pub enum DecodeStateResponseError {
     /// Error while decoding the Protobuf encoding.

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -2957,7 +2957,7 @@ pub enum GrandpaWarpSyncRequestError {
     Decode(protocol::DecodeGrandpaWarpSyncResponseError),
 }
 
-/// Error returned by [`ChainNetwork::start_state_request_unchecked`].
+/// Error returned by [`ChainNetwork::start_state_request`].
 #[derive(Debug, derive_more::Display)]
 pub enum StateRequestError {
     #[display(fmt = "{}", _0)]

--- a/src/util/protobuf.rs
+++ b/src/util/protobuf.rs
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#![allow(unused)] // Some of the functions here might not actually be in use.
+
 use super::leb128;
 use alloc::vec::Vec;
 use core::{iter, str};


### PR DESCRIPTION
At the moment, the state_request protocol code in smoldot uses the "no proof" version of the protocol. This turns out to be completely useless in practice. The "no proof" version is supposed to be used only if the node you query is trusted, which is in practice never the case.

This PR changes that to use the "with proof" version of the protocol, and adds proper documentation to it.
