### PR TITLE
Update to Rust v1.65 and use its new features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
   test-64bits:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.64
+      image: rust:1.65
     steps:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v1
@@ -36,7 +36,7 @@ jobs:
   test-32bits:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.64
+      image: rust:1.65
     steps:
     - run: apt-get update && apt install -y libc6-dev-i386
     - uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
   wasm-node-check:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.64
+      image: rust:1.65
     steps:
     - run: apt-get update && apt install -y binaryen # For `wasm-opt`
     - uses: actions/checkout@v3
@@ -63,7 +63,7 @@ jobs:
   wasm-node-size-diff:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.64
+      image: rust:1.65
     steps:
     - run: apt-get update && apt install -y binaryen # For `wasm-opt`
     - uses: actions/checkout@v3
@@ -98,7 +98,7 @@ jobs:
   check-features:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.64
+      image: rust:1.65
     steps:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v1
@@ -141,7 +141,7 @@ jobs:
   check-rustdoc-links:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.64
+      image: rust:1.65
     steps:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,7 +87,7 @@ jobs:
   npm-publish:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.64
+      image: rust:1.65
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.5.1

--- a/bin/full-node/src/cli.rs
+++ b/bin/full-node/src/cli.rs
@@ -206,14 +206,13 @@ pub struct Bootnode {
 
 fn parse_bootnode(string: &str) -> Result<Bootnode, String> {
     let mut address = string.parse::<Multiaddr>().map_err(|err| err.to_string())?;
-    if let Some(ProtocolRef::P2p(peer_id)) = address.iter().last() {
-        let peer_id = PeerId::from_bytes(peer_id.to_vec())
-            .map_err(|(err, _)| format!("Failed to parse PeerId in bootnode: {}", err))?;
-        address.pop();
-        Ok(Bootnode { address, peer_id })
-    } else {
-        Err("Bootnode address must end with /p2p/...".into())
-    }
+    let Some(ProtocolRef::P2p(peer_id)) = address.iter().last() else {
+        return Err("Bootnode address must end with /p2p/...".into())
+    };
+    let peer_id = PeerId::from_bytes(peer_id.to_vec())
+        .map_err(|(err, _)| format!("Failed to parse PeerId in bootnode: {}", err))?;
+    address.pop();
+    Ok(Bootnode { address, peer_id })
 }
 
 // `clap` requires error types to implement the `std::error::Error` trait.

--- a/bin/full-node/src/run/network_service.rs
+++ b/bin/full-node/src/run/network_service.rs
@@ -1036,12 +1036,9 @@ async fn update_round(inner: &Arc<Inner>, event_senders: &mut [mpsc::Sender<Even
                 .next()
                 .cloned();
 
-            if let Some(peer_to_assign) = peer_to_assign {
-                tracing::debug!(peer_id = %peer_to_assign, %chain_index, "slot-assigned");
-                guarded.network.assign_out_slot(chain_index, peer_to_assign);
-            } else {
-                break;
-            }
+            let Some(peer_to_assign) = peer_to_assign else { break };
+            tracing::debug!(peer_id = %peer_to_assign, %chain_index, "slot-assigned");
+            guarded.network.assign_out_slot(chain_index, peer_to_assign);
         }
     }
 

--- a/bin/light-base/src/network_service.rs
+++ b/bin/light-base/src/network_service.rs
@@ -1320,18 +1320,14 @@ async fn update_round<TPlat: Platform>(
                 .next()
                 .cloned();
 
-            if let Some(peer_id) = peer_id {
-                log::debug!(
-                    target: "connections",
-                    "OutSlots({}) ∋ {}",
-                    &shared.log_chain_names[chain_index],
-                    peer_id
-                );
-
-                guarded.network.assign_out_slot(chain_index, peer_id);
-            } else {
-                break;
-            }
+            let Some(peer_id) = peer_id else { break };
+            log::debug!(
+                target: "connections",
+                "OutSlots({}) ∋ {}",
+                &shared.log_chain_names[chain_index],
+                peer_id
+            );
+            guarded.network.assign_out_slot(chain_index, peer_id);
         }
     }
 

--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -1540,7 +1540,6 @@ impl<TPlat: Platform> Background<TPlat> {
             .find(|rt| rt.runtime_code == storage_code && rt.heap_pages == storage_heap_pages);
 
         // If no identical runtime was found, try compiling the runtime.
-        // TODO: use a let-else construct here once stable
         let runtime = if let Some(existing_runtime) = existing_runtime {
             existing_runtime
         } else {

--- a/bin/wasm-node/javascript/prepare.mjs
+++ b/bin/wasm-node/javascript/prepare.mjs
@@ -40,7 +40,7 @@ if (buildProfile != 'debug' && buildProfile != 'min-size-release')
 // The Rust version is pinned because the wasi target is still unstable. Without pinning, it is
 // possible for the wasm-js bindings to change between two Rust versions. Feel free to update
 // this version pin whenever you like, provided it continues to build.
-const rustVersion = '1.64.0';
+const rustVersion = '1.65.0';
 
 // Assume that the user has `rustup` installed and make sure that `rust_version` is available.
 // Because `rustup install` requires an Internet connection, check whether the toolchain is


### PR DESCRIPTION
Updates to Rust 1.65. As usual, the CI will fail because the official Rust Docker image generally takes a day or two to be updated when a new Rust version comes out.

This PR introduces GATs in the `Platform` trait.
At the moment, if you call `Platform::next_substream` or `Platform::next_substream`, you obtain a `Future` that is completely disconnected from the object representing the connection or the stream. This means that you can for example drop the connection or stream object while the `Future` is still alive, or you can call this function multiple times with the same connection/stream.
Using GATs allows us to bind the `Future` to the object it refers to, and thus removes these annoying corner cases. This should also make the trait implementation much easier to write, but I'm not touching this complicated code right now.

I've switched some code to use `let-else`, but that's just for fun and this feature is in practice not super useful.
