### PR TITLE
Don't call connection_stream_open if WebRTC connection has been reset

### DIFF
--- a/bin/light-base/src/platform.rs
+++ b/bin/light-base/src/platform.rs
@@ -81,6 +81,9 @@ pub trait Platform: Send + 'static {
     ///
     /// The substream, once opened, must be yielded by [`Platform::next_substream`].
     ///
+    /// Calls to this function should be ignored if the connection has already been killed by the
+    /// remote.
+    ///
     /// > **Note**: No mechanism exists in this API to handle the situation where a substream fails
     /// >           to open, as this is not supposed to happen. If you need to handle such a
     /// >           situation, either try again opening a substream again or reset the entire


### PR DESCRIPTION
Fix https://github.com/paritytech/smoldot/issues/2970

The browser can reset a WebRTC connection at any time. When that happens, smoldot only switches the connection state to "reset", and it's only later that the connection task will query the state and see that it's reset.
However, in the meanwhile, the connection task can try to open a new substream. This PR clarifies the behavior when that happens: trying to open a new substream should simply be ignored.
