### PR TITLE
Return a ValidChainInformation when building the chain spec info

### DIFF
--- a/src/author/runtime/tests.rs
+++ b/src/author/runtime/tests.rs
@@ -29,7 +29,7 @@ fn block_building_works() {
     let genesis_storage = chain_specs.genesis_storage().into_genesis_items().unwrap();
 
     let (chain_info, genesis_runtime) = chain_specs.as_chain_information().unwrap();
-    let genesis_hash = chain_info.finalized_block_header.hash(4);
+    let genesis_hash = chain_info.as_ref().finalized_block_header.hash(4);
 
     let mut builder = super::build_block(super::Config {
         block_number_bytes: 4,

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -37,7 +37,7 @@
 use crate::{
     chain::chain_information::{
         build, BabeEpochInformation, ChainInformation, ChainInformationConsensus,
-        ChainInformationFinality,
+        ChainInformationFinality, ValidChainInformation,
     },
     executor, libp2p, trie,
 };
@@ -86,7 +86,8 @@ impl ChainSpec {
     /// genesis block.
     pub fn as_chain_information(
         &self,
-    ) -> Result<(ChainInformation, executor::host::HostVmPrototype), FromGenesisStorageError> {
+    ) -> Result<(ValidChainInformation, executor::host::HostVmPrototype), FromGenesisStorageError>
+    {
         let genesis_storage = match self.genesis_storage() {
             GenesisStorage::Items(items) => items,
             GenesisStorage::TrieRootHash(_) => {
@@ -173,8 +174,7 @@ impl ChainSpec {
             }
         };
 
-        // TODO: ! we return a ChainInformation while we have a ValidChainInformation
-        Ok((chain_info.into(), vm_prototype))
+        Ok((chain_info, vm_prototype))
     }
 
     /// Returns the name of the chain. Meant to be displayed to the user.


### PR DESCRIPTION
The "chain information building process" is done in two steps: fetching all the info, then validating that the values are coherent together.

In the past, the `chain_spec` module used to do only the first step, leaving the second step to the API user of this module. Then I've changed the implementation to produce a `ValidChainInformation` and turn it back into an (not-validated) `ChainInformation`.

This PR changes the return type to `ValidChainInformation`, and thus the API user doesn't need to handle that.