### PR TITLE
Switch CI to NodeJS v16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     - uses: Swatinem/rust-cache@v1
     - uses: actions/setup-node@v3.5.1
       with:
-        node-version: '14'  # An old version is used to ensure compatibility
+        node-version: '16'  # An old version is used to ensure compatibility
     - uses: denoland/setup-deno@v1
       with:
         deno-version: v1.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     - uses: Swatinem/rust-cache@v1
     - uses: actions/setup-node@v3.5.1
       with:
-        node-version: '12'  # An old version is used to ensure compatibility
+        node-version: '14'  # An old version is used to ensure compatibility
     - uses: denoland/setup-deno@v1
       with:
         deno-version: v1.x


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/