### PR TITLE
Add functions for incoming multi-stream connections

### DIFF
--- a/src/libp2p/collection.rs
+++ b/src/libp2p/collection.rs
@@ -406,11 +406,11 @@ where
     ///
     /// Must be passed the moment (as a `TNow`) when the connection as been established, in order
     /// to determine when the handshake timeout expires.
-    // TODO: add an is_initiator parameter? right now we're always implicitly the initiator
     pub fn insert_multi_stream<TSubId>(
         &mut self,
         now: TNow,
         handshake_kind: MultiStreamHandshakeKind,
+        is_initiator: bool,
         user_data: TConn,
     ) -> (ConnectionId, MultiStreamConnectionTask<TNow, TSubId>)
     where
@@ -421,6 +421,7 @@ where
 
         let connection_task = MultiStreamConnectionTask::new(
             self.randomness_seeds.gen(),
+            is_initiator,
             now,
             handshake_kind,
             self.max_inbound_substreams,

--- a/src/libp2p/peers.rs
+++ b/src/libp2p/peers.rs
@@ -977,6 +977,34 @@ where
         (connection_id, connection_task)
     }
 
+    /// Inserts a multi-stream incoming connection in the state machine.
+    ///
+    /// This connection hasn't finished handshaking and the [`PeerId`] of the remote isn't known
+    /// yet.
+    ///
+    /// Must be passed the moment (as a `TNow`) when the connection as been established, in order
+    /// to determine when the handshake timeout expires.
+    pub fn add_multi_stream_incoming_connection<TSubId>(
+        &mut self,
+        when_connected: TNow,
+        handshake_kind: MultiStreamHandshakeKind,
+        user_data: TConn,
+    ) -> (ConnectionId, MultiStreamConnectionTask<TNow, TSubId>)
+    where
+        TSubId: Clone + PartialEq + Eq + Hash,
+    {
+        self.inner.insert_multi_stream(
+            when_connected,
+            handshake_kind,
+            false,
+            Connection {
+                peer_index: None,
+                user_data,
+                outbound: false,
+            },
+        )
+    }
+
     /// Inserts a multi-stream outgoing connection in the state machine.
     ///
     /// This connection hasn't finished handshaking, and the [`PeerId`] of the remote isn't known
@@ -1003,6 +1031,7 @@ where
         let (connection_id, connection_task) = self.inner.insert_multi_stream(
             when_connected,
             handshake_kind,
+            true,
             Connection {
                 peer_index: Some(peer_index),
                 user_data,

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -496,6 +496,30 @@ where
         )
     }
 
+    /// Adds a multi-stream incoming connection to the state machine.
+    ///
+    /// This connection hasn't finished handshaking and the [`PeerId`] of the remote isn't known
+    /// yet.
+    ///
+    /// Must be passed the moment (as a `TNow`) when the connection as been established, in order
+    /// to determine when the handshake timeout expires.
+    ///
+    /// The `remote_addr` is the address used to reach back the remote. In the case of TCP, it
+    /// contains the TCP dialing port of the remote. The remote can ask, through the `identify`
+    /// libp2p protocol, its own address, in which case we send it.
+    pub fn add_multi_stream_incoming_connection<TSubId>(
+        &mut self,
+        when_connected: TNow,
+        handshake_kind: MultiStreamHandshakeKind,
+        remote_addr: multiaddr::Multiaddr,
+    ) -> (ConnectionId, MultiStreamConnectionTask<TNow, TSubId>)
+    where
+        TSubId: Clone + PartialEq + Eq + Hash,
+    {
+        self.inner
+            .add_multi_stream_incoming_connection(when_connected, handshake_kind, remote_addr)
+    }
+
     pub fn pull_message_to_connection(
         &mut self,
     ) -> Option<(ConnectionId, CoordinatorToConnection<TNow>)> {


### PR DESCRIPTION
They're unused in practice, but there's no reason to not allow ingoing multi-stream connections in the underlying state machine.

cc https://github.com/paritytech/smoldot/issues/2802