### PR TITLE
Remove some multistream-select round-trips

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Reduced the number of networking round-trips after a connection has been opened by assuming that the remote supports the desired networking protocols instead of waiting for its confirmation.
+- Reduced the number of networking round-trips after a connection has been opened by assuming that the remote supports the desired networking protocols instead of waiting for its confirmation. ([#2984](https://github.com/paritytech/smoldot/pull/2984))
 
 ## 0.7.6 - 2022-11-04
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Reduced the number of networking round-trips after a connection has been opened by assuming that the remote supports the desired networking protocols instead of waiting for its confirmation.
+
 ## 0.7.6 - 2022-11-04
 
 ### Fixed

--- a/src/libp2p/connection/multistream_select.rs
+++ b/src/libp2p/connection/multistream_select.rs
@@ -190,6 +190,19 @@ where
         }
     }
 
+    /// If this function returns true, then the multistream-select handshake has finished writing
+    /// all its data, and the API user can now start writing the protocol-specific data if it
+    /// desires, even though the multistream-handshake isn't finished.
+    ///
+    /// If the remote supports the requested protocol, then doing so will save one networking
+    /// round-trip. If however the remote doesn't support the requested protocol, then doing so
+    /// will lead to confusing errors on the remote, as it will interpret the protocol-specific
+    /// data as being from the multistream-select protocol. Overall, saving a round-trip is
+    /// usually seen as preferable over confusing errors.
+    pub fn can_write_protocol_data(&self) -> bool {
+        matches!(self.state, InProgressState::ProtocolRequestAnswerExpected)
+    }
+
     /// Feeds data coming from a socket, updates the internal state machine, and writes data
     /// destined to the socket.
     ///

--- a/src/libp2p/connection/multistream_select.rs
+++ b/src/libp2p/connection/multistream_select.rs
@@ -197,8 +197,9 @@ where
     /// If the remote supports the requested protocol, then doing so will save one networking
     /// round-trip. If however the remote doesn't support the requested protocol, then doing so
     /// will lead to confusing errors on the remote, as it will interpret the protocol-specific
-    /// data as being from the multistream-select protocol. Overall, saving a round-trip is
-    /// usually seen as preferable over confusing errors.
+    /// data as being from the multistream-select protocol, and the substream will be rendered
+    /// unusable. Overall, saving a round-trip is usually seen as preferable over confusing
+    /// errors.
     pub fn can_write_protocol_data(&self) -> bool {
         matches!(self.state, InProgressState::ProtocolRequestAnswerExpected)
     }

--- a/src/libp2p/connection/single_stream_handshake.rs
+++ b/src/libp2p/connection/single_stream_handshake.rs
@@ -30,6 +30,7 @@
 //! TCP handshake), depending on the strategy used for the multistream-select protocol.
 
 // TODO: finish commenting on the number of round trips
+// TODO: some round-trips can be removed: the multistream-select ones, and maybe also a Noise one, but it's complicated
 
 use super::{
     super::peer_id::PeerId,


### PR DESCRIPTION
cc https://github.com/paritytech/smoldot/issues/2983

This PR removes some extra networking round-trips caused by multistream-select.

The way multistream-select works is: we tell the remote that we would like to use a specific protocol, and then the remote answers either yes or no. No is only ever returned if the remote doesn't support the protocol at all, which isn't supposed to happen unless we're talking to a buggy node or to a libp2p-compatible-but-not-Substrate node.
Before this PR, we wait for the remote to send back yes or no. After this PR, we don't wait and simply start sending the protocol-specific data immediately after the request for a protocol, and assume that the remote is going to answer yes.

The negotiation is still properly finished afterwards, so if it turns out that the remote answers no, then we'll still get an error locally. The drawback is that, if the remote answers no, the protocol-specific data that we have eagerly sent will be interpreted as being from the multistream-select protocol, which can lead to confusing decoding errors. However, the trade-off is worth it.

I've done this change only for substreams after the connection has been opened. There are two other unnecessary round-trips during the connection opening, but considering that we don't open connections that often they're actually less important. For this reason, I'll leave https://github.com/paritytech/smoldot/issues/2983 open.
