### PR TITLE
Split the service request responses enum into two

### DIFF
--- a/bin/full-node/src/run/network_service.rs
+++ b/bin/full-node/src/run/network_service.rs
@@ -871,9 +871,9 @@ async fn update_round(inner: &Arc<Inner>, event_senders: &mut [mpsc::Sender<Even
                 service::Event::InboundSlotAssigned { .. } => {
                     // TODO: log this
                 }
-                service::Event::BlocksRequestResult {
+                service::Event::RequestResult {
                     request_id,
-                    response,
+                    response: service::RequestResult::Blocks(response),
                 } => {
                     let _ = guarded
                         .blocks_requests
@@ -881,12 +881,8 @@ async fn update_round(inner: &Arc<Inner>, event_senders: &mut [mpsc::Sender<Even
                         .unwrap()
                         .send(response);
                 }
-                service::Event::GrandpaWarpSyncRequestResult { .. }
-                | service::Event::StateRequestResult { .. }
-                | service::Event::StorageProofRequestResult { .. }
-                | service::Event::CallProofRequestResult { .. }
-                | service::Event::KademliaFindNodeRequestResult { .. } => {
-                    // We never start a request of this kind.
+                service::Event::RequestResult { .. } => {
+                    // We never start a request of any other kind.
                     unreachable!()
                 }
                 service::Event::RequestInCancel { .. } => {

--- a/bin/light-base/src/network_service.rs
+++ b/bin/light-base/src/network_service.rs
@@ -1114,9 +1114,9 @@ async fn update_round<TPlat: Platform>(
                         chain_index,
                     };
                 }
-                service::Event::BlocksRequestResult {
+                service::Event::RequestResult {
                     request_id,
-                    response,
+                    response: service::RequestResult::Blocks(response),
                 } => {
                     let _ = guarded
                         .blocks_requests
@@ -1124,9 +1124,9 @@ async fn update_round<TPlat: Platform>(
                         .unwrap()
                         .send(response);
                 }
-                service::Event::GrandpaWarpSyncRequestResult {
+                service::Event::RequestResult {
                     request_id,
-                    response,
+                    response: service::RequestResult::GrandpaWarpSync(response),
                 } => {
                     let _ = guarded
                         .grandpa_warp_sync_requests
@@ -1134,9 +1134,9 @@ async fn update_round<TPlat: Platform>(
                         .unwrap()
                         .send(response);
                 }
-                service::Event::StorageProofRequestResult {
+                service::Event::RequestResult {
                     request_id,
-                    response,
+                    response: service::RequestResult::StorageProof(response),
                 } => {
                     let _ = guarded
                         .storage_proof_requests
@@ -1144,9 +1144,9 @@ async fn update_round<TPlat: Platform>(
                         .unwrap()
                         .send(response);
                 }
-                service::Event::CallProofRequestResult {
+                service::Event::RequestResult {
                     request_id,
-                    response,
+                    response: service::RequestResult::CallProof(response),
                 } => {
                     let _ = guarded
                         .call_proof_requests
@@ -1154,9 +1154,8 @@ async fn update_round<TPlat: Platform>(
                         .unwrap()
                         .send(response);
                 }
-                service::Event::StateRequestResult { .. }
-                | service::Event::KademliaFindNodeRequestResult { .. } => {
-                    // We never start this kind of requests.
+                service::Event::RequestResult { .. } => {
+                    // We never start any other kind of requests.
                     unreachable!()
                 }
                 service::Event::KademliaDiscoveryResult {

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -1579,9 +1579,9 @@ where
                             }
                         }
 
-                        break Some(Event::BlocksRequestResult {
+                        break Some(Event::RequestResult {
                             request_id,
-                            response,
+                            response: RequestResult::Blocks(response),
                         });
                     }
                     (OutRequestTy::GrandpaWarpSync, chain_index) => {
@@ -1604,9 +1604,9 @@ where
                                 }
                             });
 
-                        break Some(Event::GrandpaWarpSyncRequestResult {
+                        break Some(Event::RequestResult {
                             request_id,
-                            response,
+                            response: RequestResult::GrandpaWarpSync(response),
                         });
                     }
                     (OutRequestTy::State, _) => {
@@ -1621,9 +1621,9 @@ where
                                     }
                                 });
 
-                        break Some(Event::StateRequestResult {
+                        break Some(Event::RequestResult {
                             request_id,
-                            response,
+                            response: RequestResult::State(response),
                         });
                     }
                     (OutRequestTy::StorageProof, _) => {
@@ -1643,9 +1643,9 @@ where
                                 }
                             });
 
-                        break Some(Event::StorageProofRequestResult {
+                        break Some(Event::RequestResult {
                             request_id,
-                            response,
+                            response: RequestResult::StorageProof(response),
                         });
                     }
                     (OutRequestTy::CallProof, _) => {
@@ -1668,9 +1668,9 @@ where
                                     }
                                 });
 
-                        break Some(Event::CallProofRequestResult {
+                        break Some(Event::RequestResult {
                             request_id,
-                            response,
+                            response: RequestResult::CallProof(response),
                         });
                     }
                     (OutRequestTy::KademliaFindNode, _) => {
@@ -1681,9 +1681,9 @@ where
                                     .map_err(KademliaFindNodeError::DecodeError)
                             });
 
-                        break Some(Event::KademliaFindNodeRequestResult {
+                        break Some(Event::RequestResult {
                             request_id,
-                            response,
+                            response: RequestResult::KademliaFindNode(response),
                         });
                     }
                     (OutRequestTy::KademliaDiscoveryFindNode(operation_id), _) => {
@@ -2580,34 +2580,9 @@ pub enum Event {
         unassigned_slot_ty: SlotTy,
     },
 
-    BlocksRequestResult {
+    RequestResult {
         request_id: OutRequestId,
-        response: Result<Vec<protocol::BlockData>, BlocksRequestError>,
-    },
-
-    GrandpaWarpSyncRequestResult {
-        request_id: OutRequestId,
-        response: Result<EncodedGrandpaWarpSyncResponse, GrandpaWarpSyncRequestError>,
-    },
-
-    StateRequestResult {
-        request_id: OutRequestId,
-        response: Result<EncodedStateResponse, StateRequestError>,
-    },
-
-    StorageProofRequestResult {
-        request_id: OutRequestId,
-        response: Result<EncodedMerkleProof, StorageProofRequestError>,
-    },
-
-    CallProofRequestResult {
-        request_id: OutRequestId,
-        response: Result<EncodedMerkleProof, CallProofRequestError>,
-    },
-
-    KademliaFindNodeRequestResult {
-        request_id: OutRequestId,
-        response: Result<Vec<(peer_id::PeerId, Vec<multiaddr::Multiaddr>)>, KademliaFindNodeError>,
+        response: RequestResult,
     },
 
     /// The given peer has opened a block announces substream with the local node, and an inbound
@@ -2694,6 +2669,21 @@ pub enum Event {
 pub enum SlotTy {
     Inbound,
     Outbound,
+}
+
+/// Response to an outgoing request.
+///
+/// See [`Event::RequestResult`̀].
+#[derive(Debug)]
+pub enum RequestResult {
+    Blocks(Result<Vec<protocol::BlockData>, BlocksRequestError>),
+    GrandpaWarpSync(Result<EncodedGrandpaWarpSyncResponse, GrandpaWarpSyncRequestError>),
+    State(Result<EncodedStateResponse, StateRequestError>),
+    StorageProof(Result<EncodedMerkleProof, StorageProofRequestError>),
+    CallProof(Result<EncodedMerkleProof, CallProofRequestError>),
+    KademliaFindNode(
+        Result<Vec<(peer_id::PeerId, Vec<multiaddr::Multiaddr>)>, KademliaFindNodeError>,
+    ),
 }
 
 /// Error that can happen when trying to open an outbound notifications substream.


### PR DESCRIPTION
Basic refactor to make the code less annoying to read.

We take 5 similar enum variants and merge them into one.