### PR TITLE
Check runtime API versions in the JSON-RPC layer

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+
+- Add support for version 2 of the `TransactionPaymentApi` runtime API. This fixes the `payment_queryInfo` JSON-RPC call with newer runtime versions.
+
+### Changed
+
+- The version of the runtime API is now verified to match the excepted value when the `payment_queryInfo`, `state_getMetadata`, and `system_accountNextIndex` JSON-RPC functions are called. This means that without an update to the smoldot source code these JSON-RPC functions will stop working if the runtime API is out of range. However, this eliminates the likelihood that smoldot returns accidentally parses a value in a different way than intended and an incorrect result.
+
 ## 0.7.6 - 2022-11-04
 
 ### Fixed


### PR DESCRIPTION
Fix https://github.com/paritytech/smoldot/issues/2974
cc https://github.com/paritytech/smoldot/issues/949

This PR modifies `runtime_call` to support an "API version constraint". This constraint is then verified.
A `runtime_call_no_api_check` function has also been added as an escape hatch for the `state_call` JSON-RPC function.

It also updates the `payment_info` module to account for https://github.com/paritytech/substrate/pull/12633
