### PR TITLE
Refactor the execution to avoid setTimeout

### DIFF
--- a/bin/light-base/src/json_rpc_service.rs
+++ b/bin/light-base/src/json_rpc_service.rs
@@ -590,7 +590,7 @@ impl<TPlat: Platform> Background<TPlat> {
 
                         // We yield once between each request in order to politely let other tasks
                         // do some work and not monopolize the CPU.
-                        crate::util::yield_twice().await;
+                        TPlat::yield_after_cpu_intensive().await;
                     }
                 }
                 .boxed(),

--- a/bin/light-base/src/platform.rs
+++ b/bin/light-base/src/platform.rs
@@ -24,6 +24,7 @@ pub mod async_std;
 /// Access to a platform's capabilities.
 pub trait Platform: Send + 'static {
     type Delay: Future<Output = ()> + Unpin + Send + 'static;
+    type Yield: Future<Output = ()> + Unpin + Send + 'static;
     type Instant: Clone
         + ops::Add<Duration, Output = Self::Instant>
         + ops::Sub<Self::Instant, Output = Duration>
@@ -70,6 +71,11 @@ pub trait Platform: Send + 'static {
 
     /// Creates a future that becomes ready after the given instant has been reached.
     fn sleep_until(when: Self::Instant) -> Self::Delay;
+
+    /// Should be called after a CPU-intensive operation in order to yield back control.
+    ///
+    /// This function can be implemented as no-op on platforms where this is irrelevant.
+    fn yield_after_cpu_intensive() -> Self::Yield;
 
     /// Starts a connection attempt to the given multiaddress.
     ///

--- a/bin/light-base/src/platform/async_std.rs
+++ b/bin/light-base/src/platform/async_std.rs
@@ -39,6 +39,7 @@ pub struct AsyncStdTcpWebSocket;
 // TODO: this trait implementation was written before GATs were stable in Rust; now that the associated types have lifetimes, it should be possible to considerably simplify this code
 impl Platform for AsyncStdTcpWebSocket {
     type Delay = future::BoxFuture<'static, ()>;
+    type Yield = future::Ready<()>;
     type Instant = std::time::Instant;
     type Connection = std::convert::Infallible;
     type Stream = Stream;
@@ -66,6 +67,11 @@ impl Platform for AsyncStdTcpWebSocket {
     fn sleep_until(when: Self::Instant) -> Self::Delay {
         let duration = when.saturating_duration_since(std::time::Instant::now());
         Self::sleep(duration)
+    }
+
+    fn yield_after_cpu_intensive() -> Self::Yield {
+        // No-op.
+        future::ready(())
     }
 
     fn connect(multiaddr: &str) -> Self::ConnectFuture {

--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -532,7 +532,8 @@ impl<TPlat: Platform> RuntimeService<TPlat> {
             existing_runtime
         } else {
             // No identical runtime was found. Try compiling the new runtime.
-            let runtime = SuccessfulRuntime::from_storage(&storage_code, &storage_heap_pages).await;
+            let runtime =
+                SuccessfulRuntime::from_storage::<TPlat>(&storage_code, &storage_heap_pages).await;
             let runtime = Arc::new(Runtime {
                 heap_pages: storage_heap_pages,
                 runtime_code: storage_code,
@@ -1543,7 +1544,8 @@ impl<TPlat: Platform> Background<TPlat> {
         let runtime = if let Some(existing_runtime) = existing_runtime {
             existing_runtime
         } else {
-            let runtime = SuccessfulRuntime::from_storage(&storage_code, &storage_heap_pages).await;
+            let runtime =
+                SuccessfulRuntime::from_storage::<TPlat>(&storage_code, &storage_heap_pages).await;
             match &runtime {
                 Ok(runtime) => {
                     log::info!(
@@ -2013,12 +2015,12 @@ struct SuccessfulRuntime {
 }
 
 impl SuccessfulRuntime {
-    async fn from_storage(
+    async fn from_storage<TPlat: Platform>(
         code: &Option<Vec<u8>>,
         heap_pages: &Option<Vec<u8>>,
     ) -> Result<Self, RuntimeError> {
         // Since compiling the runtime is a CPU-intensive operation, we yield once before.
-        crate::util::yield_twice().await;
+        TPlat::yield_after_cpu_intensive().await;
 
         // Parameters for `HostVmPrototype::new`.
         let module = code.as_ref().ok_or(RuntimeError::CodeNotFound)?;

--- a/bin/light-base/src/sync_service/standalone.rs
+++ b/bin/light-base/src/sync_service/standalone.rs
@@ -131,11 +131,9 @@ pub(super) async fn start_standalone_chain<TPlat: Platform>(
             if has_done_verif {
                 queue_empty = false;
 
-                // Since JavaScript/Wasm is single-threaded, executing many CPU-heavy operations
-                // in a row would prevent all the other tasks in the background from running.
-                // In order to provide a better granularity, we force a yield after each
-                // verification.
-                crate::util::yield_twice().await;
+                // As explained in the documentation of `yield_after_cpu_intensive`, we should
+                // yield after a CPU-intensive operation. This helps provide a better granularity.
+                TPlat::yield_after_cpu_intensive().await;
             }
 
             queue_empty

--- a/bin/light-base/src/util.rs
+++ b/bin/light-base/src/util.rs
@@ -15,35 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-/// Use in an asynchronous context to interrupt the current task execution and schedule it back.
-/// Twice.
-///
-/// This function is useful in order to guarantee a fine granularity of tasks execution time in
-/// situations where a CPU-heavy task is being performed.
-///
-/// We do not yield once, but twice.
-/// The reason is that, at the time of writing, `FuturesUnordered` yields to the outside after
-/// one of its futures has yielded twice. We use `FuturesUnordered` in the Wasm node.
-/// Yielding to the outside is important in the context of the browser node because it gives
-/// time to the browser to run its own events loop.
-/// See <https://github.com/rust-lang/futures-rs/blob/7a98cf0bbeb397dcfaf5f020b371ab9e836d33d4/futures-util/src/stream/futures_unordered/mod.rs#L531>
-/// See <https://github.com/rust-lang/futures-rs/issues/2053> for a discussion about a proper
-/// solution.
-// TODO: this is a complete hack ^
-pub async fn yield_twice() {
-    let mut num_pending_remain = 2;
-    core::future::poll_fn(move |cx| {
-        if num_pending_remain > 0 {
-            num_pending_remain -= 1;
-            cx.waker().wake_by_ref();
-            core::task::Poll::Pending
-        } else {
-            core::task::Poll::Ready(())
-        }
-    })
-    .await
-}
-
 /// Iterator combinator. Truncates the given `char`-yielding iterator to the given number of
 /// elements, and if the limit is reached adds a `…` at the end.
 pub fn truncate_str_iter(

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- In earlier versions of smoldot, `setTimeout(callback, 0)` was frequently used in order split execution of CPU-intensive tasks in multiple smaller ones while still giving back control to the execution environment (such as NodeJS or the browser). Unfortunately, when a web page is in the background, browsers set a minimum delay of one second for `setTimeout`. For this reason, the usage of ̀`setTimeout` has now been reduced to the strict minimum, except when the environment is browser and `document.visibilityState` is equal to `visible`. ([#2999](https://github.com/paritytech/smoldot/pull/2999))
+
 ## 0.7.6 - 2022-11-04
 
 ### Fixed

--- a/bin/wasm-node/javascript/src/client.ts
+++ b/bin/wasm-node/javascript/src/client.ts
@@ -429,9 +429,7 @@ export function start(options: ClientOptions, platformBindings: PlatformBindings
             return Promise.reject(new AlreadyDestroyedError());
           if (options.disableJsonRpc)
             return Promise.reject(new JsonRpcDisabledError());
-          return new Promise((resolve, reject) => {
-            instance.nextJsonRpcResponse(chainId, resolve, reject)
-          });
+          return instance.nextJsonRpcResponse(chainId);
         },
         remove: () => {
           if (alreadyDestroyedError)

--- a/bin/wasm-node/javascript/src/index-browser.ts
+++ b/bin/wasm-node/javascript/src/index-browser.ts
@@ -50,6 +50,11 @@ export function start(options?: ClientOptions): Client {
     trustedBase64DecodeAndZlibInflate: (input) => {
       return Promise.resolve(inflate(classicDecode(input)))
     },
+    registerShouldPeriodicallyYield: (callback) => {
+      const wrappedCallback = () => callback(document.visibilityState === 'visible');
+      document.addEventListener('visibilitychange', wrappedCallback);
+      return [document.visibilityState === 'visible', () => { document.removeEventListener('visibilitychange', wrappedCallback) }]
+    },
     performanceNow: () => {
       return performance.now()
     },

--- a/bin/wasm-node/javascript/src/index-deno.ts
+++ b/bin/wasm-node/javascript/src/index-deno.ts
@@ -70,6 +70,9 @@ export function start(options?: ClientOptions): Client {
             }
             return concatenated;
         },
+        registerShouldPeriodicallyYield: (_callback) => {
+          return [true, () => {}]
+        },
         performanceNow: () => {
             return performance.now()
         },

--- a/bin/wasm-node/javascript/src/index-nodejs.ts
+++ b/bin/wasm-node/javascript/src/index-nodejs.ts
@@ -58,6 +58,9 @@ export function start(options?: ClientOptions): Client {
     trustedBase64DecodeAndZlibInflate: (input) => {
         return Promise.resolve(inflate(Buffer.from(input, 'base64')))
     },
+    registerShouldPeriodicallyYield: (_callback) => {
+      return [true, () => {}]
+    },
     performanceNow: () => {
         return performance.now()
     },

--- a/bin/wasm-node/javascript/src/instance/bindings.ts
+++ b/bin/wasm-node/javascript/src/instance/bindings.ts
@@ -23,7 +23,8 @@
  */
 export interface SmoldotWasmExports extends WebAssembly.Exports {
     memory: WebAssembly.Memory,
-    init: (maxLogLevel: number, enableCurrentTask: number, cpuRateLimit: number) => void,
+    init: (maxLogLevel: number, enableCurrentTask: number, cpuRateLimit: number, periodicallyYield: number) => void,
+    set_periodically_yield: (periodicallyYield: number) => void,
     start_shutdown: () => void,
     alloc: (len: number) => number,
     add_chain: (chainSpecPointer: number, chainSpecLen: number, databaseContentPointer: number, databaseContentLen: number, jsonRpcRunning: number, potentialRelayChainsPtr: number, potentialRelayChainsLen: number) => number;

--- a/bin/wasm-node/javascript/src/instance/raw-instance.ts
+++ b/bin/wasm-node/javascript/src/instance/raw-instance.ts
@@ -70,6 +70,19 @@ export interface PlatformBindings {
     getRandomValues: (buffer: Uint8Array) => void,
 
     /**
+     * The "should periodically yield" setting indicates whether the execution should periodically
+     * yield back control by using `setTimeout(..., 0)`.
+     *
+     * On platforms such as browsers where `setTimeout(..., 0)` takes way more than 0 milliseconds,
+     * this setting should be set to `false`.
+     *
+     * This function registers a callback that is called when the setting should be updated with
+     * a new value. It returns the initial value of the setting and a function used to unregister
+     * the callback.
+     */
+    registerShouldPeriodicallyYield: (callback: (newValue: boolean) => void) => [boolean, () => void],
+
+    /**
      * Tries to open a new connection using the given configuration.
      *
      * @see Connection

--- a/bin/wasm-node/rust/src/bindings.rs
+++ b/bin/wasm-node/rust/src/bindings.rs
@@ -24,6 +24,16 @@
 //! need to be implemented on the host side and provided to the WebAssembly virtual machine. The
 //! other functions are functions that the Rust code *exports*, and can be called by the host.
 //!
+//! # Reentrency
+//!
+//! As a rule, none of the implementations of the functions that the host provides is allowed
+//! to call a function exported by Rust.
+//!
+//! For example, the implementation of [`start_timer`] isn't allowed to call [`timer_finished`].
+//! Instead, it must return, and later [`timer_finished`] be called independently.
+//!
+//! This avoids potential stack overflows and tricky borrowing-related situations.
+//!
 //! # About wasi
 //!
 //! The Rust code is expected to be compiled for the `wasm32-wasi` target, and not just
@@ -272,9 +282,40 @@ extern "C" {
 /// `cpu_rate_limit` can be used to limit the amount of CPU that smoldot will use on average.
 /// `u32::max_value()` represents "one CPU". For example passing `rate_limit / 2` represents
 /// "`50%` of one CPU".
+///
+/// `periodically_yield` represents the initial value of the setting described in the
+/// documentation of [`set_periodically_yield`].
 #[no_mangle]
-pub extern "C" fn init(max_log_level: u32, enable_current_task: u32, cpu_rate_limit: u32) {
-    crate::init(max_log_level, enable_current_task, cpu_rate_limit)
+pub extern "C" fn init(
+    max_log_level: u32,
+    enable_current_task: u32,
+    cpu_rate_limit: u32,
+    periodically_yield: u32,
+) {
+    crate::init(
+        max_log_level,
+        enable_current_task,
+        cpu_rate_limit,
+        periodically_yield,
+    );
+    super::advance_execution();
+}
+
+/// Sets whether the smoldot client must periodically yield back control by setting up a timer
+/// using [`start_timer`] with a delay of 0.
+///
+/// A value of 0 means "no", and any other value means "yes".
+///
+/// This setting is important when smoldot is used from within a web page. When the web page is in
+/// the foreground, it should be set to `true` so that the web browser can render the page often
+/// enough to not cause any inconfort. When the web page is in the background, it should be set
+/// to `false` because `setTimeout` gets a minimum delay of 1 second making [`start_timer`]
+/// unreliable.
+/// See also <https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#timeouts_in_inactive_tabs>.
+#[no_mangle]
+pub extern "C" fn set_periodically_yield(periodically_yield: u32) {
+    crate::set_periodically_yield(periodically_yield);
+    super::advance_execution();
 }
 
 /// Instructs the client to start shutting down.
@@ -286,7 +327,8 @@ pub extern "C" fn init(max_log_level: u32, enable_current_task: u32, cpu_rate_li
 // TODO: can this be called multiple times?
 #[no_mangle]
 pub extern "C" fn start_shutdown() {
-    crate::start_shutdown()
+    crate::start_shutdown();
+    super::advance_execution();
 }
 
 /// Allocates a buffer of the given length, with an alignment of 1.
@@ -342,7 +384,7 @@ pub extern "C" fn add_chain(
     potential_relay_chains_ptr: u32,
     potential_relay_chains_len: u32,
 ) -> u32 {
-    super::add_chain(
+    let success_code = super::add_chain(
         chain_spec_pointer,
         chain_spec_len,
         database_content_pointer,
@@ -350,7 +392,9 @@ pub extern "C" fn add_chain(
         json_rpc_running,
         potential_relay_chains_ptr,
         potential_relay_chains_len,
-    )
+    );
+    super::advance_execution();
+    success_code
 }
 
 /// Removes a chain previously added using [`add_chain`]. Instantly unsubscribes all the JSON-RPC
@@ -360,7 +404,8 @@ pub extern "C" fn add_chain(
 /// returned by [`chain_error_ptr`].
 #[no_mangle]
 pub extern "C" fn remove_chain(chain_id: u32) {
-    super::remove_chain(chain_id)
+    super::remove_chain(chain_id);
+    super::advance_execution();
 }
 
 /// Returns `1` if creating this chain was successful. Otherwise, returns `0`.
@@ -416,7 +461,9 @@ pub extern "C" fn chain_error_ptr(chain_id: u32) -> u32 {
 ///
 #[no_mangle]
 pub extern "C" fn json_rpc_send(text_ptr: u32, text_len: u32, chain_id: u32) -> u32 {
-    super::json_rpc_send(text_ptr, text_len, chain_id)
+    let success_code = super::json_rpc_send(text_ptr, text_len, chain_id);
+    super::advance_execution();
+    success_code
 }
 
 /// Obtains information about the first response in the queue of JSON-RPC responses.
@@ -457,13 +504,15 @@ pub struct JsonRpcResponseInfo {
 /// `json_rpc_running` equal to 0.
 #[no_mangle]
 pub extern "C" fn json_rpc_responses_pop(chain_id: u32) {
-    super::json_rpc_responses_pop(chain_id)
+    super::json_rpc_responses_pop(chain_id);
+    super::advance_execution();
 }
 
 /// Must be called in response to [`start_timer`] after the given duration has passed.
 #[no_mangle]
 pub extern "C" fn timer_finished(timer_id: u32) {
     crate::timers::timer_finished(timer_id);
+    super::advance_execution();
 }
 
 /// Called by the JavaScript code if the connection switches to the `Open` state. The connection
@@ -482,6 +531,7 @@ pub extern "C" fn timer_finished(timer_id: u32) {
 #[no_mangle]
 pub extern "C" fn connection_open_single_stream(connection_id: u32, handshake_ty: u32) {
     crate::platform::connection_open_single_stream(connection_id, handshake_ty);
+    super::advance_execution();
 }
 
 /// Called by the JavaScript code if the connection switches to the `Open` state. The connection
@@ -506,7 +556,12 @@ pub extern "C" fn connection_open_multi_stream(
     handshake_ty_ptr: u32,
     handshake_ty_len: u32,
 ) {
-    crate::platform::connection_open_multi_stream(connection_id, handshake_ty_ptr, handshake_ty_len)
+    crate::platform::connection_open_multi_stream(
+        connection_id,
+        handshake_ty_ptr,
+        handshake_ty_len,
+    );
+    super::advance_execution();
 }
 
 /// Notify of a message being received on the stream. The connection associated with that stream
@@ -522,7 +577,8 @@ pub extern "C" fn connection_open_multi_stream(
 /// called.
 #[no_mangle]
 pub extern "C" fn stream_message(connection_id: u32, stream_id: u32, ptr: u32, len: u32) {
-    crate::platform::stream_message(connection_id, stream_id, ptr, len)
+    crate::platform::stream_message(connection_id, stream_id, ptr, len);
+    super::advance_execution();
 }
 
 /// Called by the JavaScript code when the given multi-stream connection has a new substream.
@@ -537,7 +593,8 @@ pub extern "C" fn stream_message(connection_id: u32, stream_id: u32, ptr: u32, l
 /// [`connection_stream_open`].
 #[no_mangle]
 pub extern "C" fn connection_stream_opened(connection_id: u32, stream_id: u32, outbound: u32) {
-    crate::platform::connection_stream_opened(connection_id, stream_id, outbound)
+    crate::platform::connection_stream_opened(connection_id, stream_id, outbound);
+    super::advance_execution();
 }
 
 /// Can be called at any point by the JavaScript code if the connection switches to the `Reset`
@@ -551,7 +608,8 @@ pub extern "C" fn connection_stream_opened(connection_id: u32, stream_id: u32, o
 /// See also [`connection_new`].
 #[no_mangle]
 pub extern "C" fn connection_reset(connection_id: u32, ptr: u32, len: u32) {
-    crate::platform::connection_reset(connection_id, ptr, len)
+    crate::platform::connection_reset(connection_id, ptr, len);
+    super::advance_execution();
 }
 
 /// Can be called at any point by the JavaScript code if the stream switches to the `Reset`
@@ -566,5 +624,6 @@ pub extern "C" fn connection_reset(connection_id: u32, ptr: u32, len: u32) {
 /// See also [`connection_open_multi_stream`].
 #[no_mangle]
 pub extern "C" fn stream_reset(connection_id: u32, stream_id: u32) {
-    crate::platform::stream_reset(connection_id, stream_id)
+    crate::platform::stream_reset(connection_id, stream_id);
+    super::advance_execution();
 }

--- a/bin/wasm-node/rust/src/bindings.rs
+++ b/bin/wasm-node/rust/src/bindings.rs
@@ -24,7 +24,7 @@
 //! need to be implemented on the host side and provided to the WebAssembly virtual machine. The
 //! other functions are functions that the Rust code *exports*, and can be called by the host.
 //!
-//! # Reentrency
+//! # Re-entrency
 //!
 //! As a rule, none of the implementations of the functions that the host provides is allowed
 //! to call a function exported by Rust.
@@ -308,7 +308,7 @@ pub extern "C" fn init(
 ///
 /// This setting is important when smoldot is used from within a web page. When the web page is in
 /// the foreground, it should be set to `true` so that the web browser can render the page often
-/// enough to not cause any inconfort. When the web page is in the background, it should be set
+/// enough to not cause any discomfort. When the web page is in the background, it should be set
 /// to `false` because `setTimeout` gets a minimum delay of 1 second making [`start_timer`]
 /// unreliable.
 /// See also <https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#timeouts_in_inactive_tabs>.


### PR DESCRIPTION
Close https://github.com/paritytech/smoldot/issues/2996

This PR does many things:

- Remove the `crate::util::yield_twice` function in favor of a platform-specific function `TPlat::yield_after_cpu_intensive`. This way, the implementation of the yielding, which is a bit hacky due to the requirements of the Wasm node, is specific to the Wasm node.

- Refactor the `nextJsonRpcResponse` function and the `jsonRpcResponsesNonEmptyCallback` callback. Right now, when we wait for a JSON-RPC response to come, we wait for smoldot to notify that it has a response available. But because this notification is done through a callback, we can't immediately query the content of the response, so instead we use `setTimeout(..., 0)` to register a task that queries the content of the response and then notify the `Promise` that was waiting. Now we instead immediately notify a `Promise`, and this `Promise` then queries the content of the response as an aftermath.

- In the JS code, add a `registerShouldPeriodicallyYield` function whose implementation is "platform-specific" (browsers, NodeJS, Deno). This function controls a new setting called "should periodically yield". In NodeJS and Deno, this is always `false`. In the browser, this is `false` if and only if the page is in the background and `true` if it is in the foreground. Passing `false` reduces the usage of `setTimeout`, while passing `true` promotes the usage of `setTimeout` to avoid blocking the browser.

- In the JS <-> Rust bindings, add a `periodically_yield` parameter to `init` and add a new `set_periodically_yield` function. See above point.

- Refactor the way the execution is done. Currently we spawn at initialization a task (using `setTimeout(..., 0)`) that runs everything. When something needs to be executed, this task wakes up by calling `setTimeout(..., 0)` again. After this PR, there is no "background task" anymore. Instead, the `Future` that drives everything is now put in `CLIENT` variable, and every single binding function calls a new `advance_execution` function before returning. `advance_execution` polls that `Future` and, depending on the `periodically_yield` setting, either executes everything until there is nothing more to do, or executes until the first yield.

All these changes eliminate the usage of `setTimeout` to the strict minimum, which is when we actually need a timer.
