### PR TITLE
Clean up service.rs by extracting code to child modules

### DIFF
--- a/src/libp2p/collection.rs
+++ b/src/libp2p/collection.rs
@@ -65,7 +65,8 @@ use rand_chacha::{rand_core::SeedableRng as _, ChaCha20Rng};
 pub use super::peer_id::PeerId;
 pub use super::read_write::ReadWrite;
 pub use established::{
-    ConfigRequestResponse, ConfigRequestResponseIn, InboundError, SubstreamFate,
+    ConfigNotifications, ConfigRequestResponse, ConfigRequestResponseIn, InboundError,
+    SubstreamFate,
 };
 pub use single_stream_handshake::HandshakeError;
 

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::header;
 use crate::libp2p::{
     connection, multiaddr, peer_id,
     peers::{self, QueueNotificationError},
@@ -50,6 +49,14 @@ pub use crate::libp2p::{
 };
 
 mod addresses;
+mod requests_responses;
+
+pub use requests_responses::{
+    BlocksRequestError, BlocksRequestResponseEntryError, CallProofRequestError, DiscoveryError,
+    EncodedGrandpaWarpSyncResponse, EncodedMerkleProof, EncodedStateResponse,
+    GrandpaWarpSyncRequestError, KademliaFindNodeError, KademliaOperationId, RequestResult,
+    StateRequestError, StorageProofRequestError,
+};
 
 /// Configuration for a [`ChainNetwork`].
 pub struct Config<TNow> {
@@ -142,10 +149,6 @@ pub struct GrandpaState {
 /// Identifier of a pending connection requested by the network through a [`StartConnect`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PendingId(usize);
-
-/// Identifier for a Kademlia iterative query.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct KademliaOperationId(u64);
 
 /// Data structure containing the list of all connections, pending or not, and their latest known
 /// state. See also [the module-level documentation](..).
@@ -262,8 +265,6 @@ enum OutRequestTy {
     KademliaDiscoveryFindNode(KademliaOperationId),
 }
 
-// Update this when a new request response protocol is added.
-const REQUEST_RESPONSE_PROTOCOLS_PER_CHAIN: usize = 5;
 // Update this when a new notifications protocol is added.
 const NOTIFICATIONS_PROTOCOLS_PER_CHAIN: usize = 3;
 
@@ -303,57 +304,7 @@ where
             })
             .collect();
 
-        // The order of protocols here is important, as it defines the values of `protocol_index`
-        // to pass to libp2p or that libp2p produces.
-        let request_response_protocols = iter::once(peers::ConfigRequestResponse {
-            name: "/ipfs/id/1.0.0".into(),
-            inbound_config: peers::ConfigRequestResponseIn::Empty,
-            max_response_size: 4096,
-            inbound_allowed: true,
-        })
-        .chain(config.chains.iter().flat_map(|chain| {
-            // TODO: limits are arbitrary
-            iter::once(peers::ConfigRequestResponse {
-                name: format!("/{}/sync/2", chain.protocol_id),
-                inbound_config: peers::ConfigRequestResponseIn::Payload { max_size: 1024 },
-                max_response_size: 16 * 1024 * 1024,
-                inbound_allowed: chain.allow_inbound_block_requests,
-            })
-            .chain(iter::once(peers::ConfigRequestResponse {
-                name: format!("/{}/light/2", chain.protocol_id),
-                inbound_config: peers::ConfigRequestResponseIn::Payload {
-                    max_size: 1024 * 512,
-                },
-                max_response_size: 10 * 1024 * 1024,
-                // TODO: make this configurable
-                inbound_allowed: false,
-            }))
-            .chain(iter::once(peers::ConfigRequestResponse {
-                name: format!("/{}/kad", chain.protocol_id),
-                inbound_config: peers::ConfigRequestResponseIn::Payload { max_size: 1024 },
-                max_response_size: 1024 * 1024,
-                // TODO: `false` here means we don't insert ourselves in the DHT, which is the polite thing to do for as long as Kad isn't implemented
-                inbound_allowed: false,
-            }))
-            .chain(iter::once(peers::ConfigRequestResponse {
-                name: format!("/{}/sync/warp", chain.protocol_id),
-                inbound_config: peers::ConfigRequestResponseIn::Payload { max_size: 32 },
-                max_response_size: 16 * 1024 * 1024,
-                // We don't support inbound warp sync requests (yet).
-                inbound_allowed: false,
-            }))
-            .chain(iter::once(peers::ConfigRequestResponse {
-                name: format!("/{}/state/2", chain.protocol_id),
-                inbound_config: peers::ConfigRequestResponseIn::Payload { max_size: 1024 },
-                // The sender tries to cap the response to 2MiB. However, if one storage item
-                // is larger than 2MiB, the response is allowed to be bigger, as otherwise it
-                // wouldn't be possible to make progress.
-                max_response_size: 16 * 1024 * 1024,
-                // We don't support inbound state requests (yet).
-                inbound_allowed: false,
-            }))
-        }))
-        .collect();
+        let request_response_protocols = requests_responses::protocols(config.chains.iter());
 
         let mut randomness = rand_chacha::ChaCha20Rng::from_seed(config.randomness_seed);
 
@@ -391,7 +342,8 @@ where
         // a time. However, we multiply this value by 2 in order to be generous. We also add 1
         // to account for the ping protocol.
         let max_inbound_substreams = chains.len()
-            * (1 + REQUEST_RESPONSE_PROTOCOLS_PER_CHAIN + NOTIFICATIONS_PROTOCOLS_PER_CHAIN)
+            * (1 + requests_responses::REQUEST_RESPONSE_PROTOCOLS_PER_CHAIN
+                + NOTIFICATIONS_PROTOCOLS_PER_CHAIN)
             * 2;
 
         ChainNetwork {
@@ -437,7 +389,7 @@ where
     }
 
     fn protocol_index(&self, chain_index: usize, protocol: usize) -> usize {
-        1 + chain_index * REQUEST_RESPONSE_PROTOCOLS_PER_CHAIN + protocol
+        1 + chain_index * requests_responses::REQUEST_RESPONSE_PROTOCOLS_PER_CHAIN + protocol
     }
 
     /// Returns the number of established TCP connections, both incoming and outgoing.
@@ -605,228 +557,6 @@ where
             .unwrap() = grandpa_state;
     }
 
-    /// Sends a blocks request to the given peer.
-    ///
-    /// This function might generate a message destined a connection. Use
-    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
-    // TODO: more docs
-    pub fn start_blocks_request(
-        &mut self,
-        now: TNow,
-        target: &PeerId,
-        chain_index: usize,
-        config: protocol::BlocksRequestConfig,
-        timeout: Duration,
-    ) -> OutRequestId {
-        self.start_blocks_request_inner(now, target, chain_index, config, timeout, true)
-    }
-
-    /// Sends a blocks request to the given peer.
-    ///
-    /// This function might generate a message destined a connection. Use
-    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
-    // TODO: more docs
-    pub fn start_blocks_request_unchecked(
-        &mut self,
-        now: TNow,
-        target: &PeerId,
-        chain_index: usize,
-        config: protocol::BlocksRequestConfig,
-        timeout: Duration,
-    ) -> OutRequestId {
-        self.start_blocks_request_inner(now, target, chain_index, config, timeout, false)
-    }
-
-    fn start_blocks_request_inner(
-        &mut self,
-        now: TNow,
-        target: &PeerId,
-        chain_index: usize,
-        config: protocol::BlocksRequestConfig,
-        timeout: Duration,
-        checked: bool,
-    ) -> OutRequestId {
-        let request_data = protocol::build_block_request(
-            self.chains[chain_index].chain_config.block_number_bytes,
-            &config,
-        )
-        .fold(Vec::new(), |mut a, b| {
-            a.extend_from_slice(b.as_ref());
-            a
-        });
-
-        let id = self.inner.start_request(
-            target,
-            self.protocol_index(chain_index, 0),
-            request_data,
-            now + timeout,
-        );
-
-        let _prev_value = self.out_requests_types.insert(
-            id,
-            (
-                OutRequestTy::Blocks {
-                    checked: if checked { Some(config) } else { None },
-                },
-                chain_index,
-            ),
-        );
-        debug_assert!(_prev_value.is_none());
-
-        id
-    }
-
-    ///
-    /// This function might generate a message destined a connection. Use
-    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
-    pub fn start_grandpa_warp_sync_request(
-        &mut self,
-        now: TNow,
-        target: &PeerId,
-        chain_index: usize,
-        begin_hash: [u8; 32],
-        timeout: Duration,
-    ) -> OutRequestId {
-        let request_data = begin_hash.to_vec();
-
-        let id = self.inner.start_request(
-            target,
-            self.protocol_index(chain_index, 3),
-            request_data,
-            now + timeout,
-        );
-
-        let _prev_value = self
-            .out_requests_types
-            .insert(id, (OutRequestTy::GrandpaWarpSync, chain_index));
-        debug_assert!(_prev_value.is_none());
-
-        id
-    }
-
-    /// Sends a state request to a peer.
-    ///
-    /// A state request makes it possible to download the storage of the chain at a given block.
-    /// The response is not unverified by this function. In other words, the peer is free to send
-    /// back erroneous data. It is the responsibility of the API user to verify the storage by
-    /// calculating the state trie root hash and comparing it with the value stored in the
-    /// block's header.
-    ///
-    /// Because response have a size limit, it is unlikely that a single request will return the
-    /// entire storage of the chain at once. Instead, call this function multiple times, each call
-    /// passing a `start_key` that follows the last key of the previous response.
-    ///
-    /// This function might generate a message destined a connection. Use
-    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
-    pub fn start_state_request(
-        &mut self,
-        now: TNow,
-        target: &PeerId,
-        chain_index: usize,
-        block_hash: &[u8; 32],
-        start_key: protocol::StateRequestStart,
-        timeout: Duration,
-    ) -> OutRequestId {
-        let request_data = protocol::build_state_request(protocol::StateRequest {
-            block_hash,
-            start_key,
-        })
-        .fold(Vec::new(), |mut a, b| {
-            a.extend_from_slice(b.as_ref());
-            a
-        });
-
-        let id = self.inner.start_request(
-            target,
-            self.protocol_index(chain_index, 4),
-            request_data,
-            now + timeout,
-        );
-
-        let _prev_value = self
-            .out_requests_types
-            .insert(id, (OutRequestTy::State, chain_index));
-        debug_assert!(_prev_value.is_none());
-
-        id
-    }
-
-    /// Sends a storage request to the given peer.
-    ///
-    /// This function might generate a message destined a connection. Use
-    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
-    // TODO: more docs
-    pub fn start_storage_proof_request(
-        &mut self,
-        now: TNow,
-        target: &PeerId,
-        chain_index: usize,
-        config: protocol::StorageProofRequestConfig<impl Iterator<Item = impl AsRef<[u8]> + Clone>>,
-        timeout: Duration,
-    ) -> OutRequestId {
-        let request_data =
-            protocol::build_storage_proof_request(config).fold(Vec::new(), |mut a, b| {
-                a.extend_from_slice(b.as_ref());
-                a
-            });
-
-        let id = self.inner.start_request(
-            target,
-            self.protocol_index(chain_index, 1),
-            request_data,
-            now + timeout,
-        );
-
-        let _prev_value = self
-            .out_requests_types
-            .insert(id, (OutRequestTy::StorageProof, chain_index));
-        debug_assert!(_prev_value.is_none());
-
-        id
-    }
-
-    /// Sends a call proof request to the given peer.
-    ///
-    /// This request is similar to [`ChainNetwork::start_storage_proof_request`]. Instead of
-    /// requesting specific keys, we request the list of all the keys that are accessed for a
-    /// specific runtime call.
-    ///
-    /// There exists no guarantee that the proof is complete (i.e. that it contains all the
-    /// necessary entries), as it is impossible to know this from just the proof itself. As such,
-    /// this method is just an optimization. When performing the actual call, regular storage proof
-    /// requests should be performed if the key is not present in the call proof response.
-    ///
-    /// This function might generate a message destined a connection. Use
-    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
-    pub fn start_call_proof_request(
-        &mut self,
-        now: TNow,
-        target: &PeerId,
-        chain_index: usize,
-        config: protocol::CallProofRequestConfig<'_, impl Iterator<Item = impl AsRef<[u8]>>>,
-        timeout: Duration,
-    ) -> OutRequestId {
-        let request_data =
-            protocol::build_call_proof_request(config).fold(Vec::new(), |mut a, b| {
-                a.extend_from_slice(b.as_ref());
-                a
-            });
-
-        let id = self.inner.start_request(
-            target,
-            self.protocol_index(chain_index, 1),
-            request_data,
-            now + timeout,
-        );
-
-        let _prev_value = self
-            .out_requests_types
-            .insert(id, (OutRequestTy::CallProof, chain_index));
-        debug_assert!(_prev_value.is_none());
-
-        id
-    }
-
     ///
     /// This function might generate a message destined a connection. Use
     /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
@@ -896,129 +626,6 @@ where
             chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN + 1,
             val,
         )
-    }
-
-    /// Inserts the given list of nodes into the list of known nodes held within the state machine.
-    pub fn discover(
-        &mut self,
-        now: &TNow,
-        chain_index: usize,
-        peer_id: PeerId,
-        discovered_addrs: impl IntoIterator<Item = multiaddr::Multiaddr>,
-    ) {
-        let kbuckets = &mut self.chains[chain_index].kbuckets;
-
-        let mut discovered_addrs = discovered_addrs.into_iter().peekable();
-
-        // Check whether there is any address in the iterator at all before inserting the
-        // node in the buckets.
-        if discovered_addrs.peek().is_none() {
-            return;
-        }
-
-        let kbuckets_peer = match kbuckets.entry(&peer_id) {
-            kademlia::kbuckets::Entry::LocalKey => return, // TODO: return some diagnostic?
-            kademlia::kbuckets::Entry::Vacant(entry) => {
-                match entry.insert((), now, kademlia::kbuckets::PeerState::Disconnected) {
-                    Err(kademlia::kbuckets::InsertError::Full) => return, // TODO: return some diagnostic?
-                    Ok((_, removed_entry)) => {
-                        // `removed_entry` is the peer that was removed the k-buckets as the
-                        // result of the new insertion. Purge it from `self.kbuckets_peers`
-                        // if necessary.
-                        if let Some((removed_peer_id, _)) = removed_entry {
-                            match self.kbuckets_peers.entry(removed_peer_id) {
-                                hashbrown::hash_map::Entry::Occupied(e)
-                                    if e.get().num_references.get() == 1 =>
-                                {
-                                    e.remove();
-                                }
-                                hashbrown::hash_map::Entry::Occupied(e) => {
-                                    let num_refs = &mut e.into_mut().num_references;
-                                    *num_refs = NonZeroUsize::new(num_refs.get() - 1).unwrap();
-                                }
-                                hashbrown::hash_map::Entry::Vacant(_) => unreachable!(),
-                            }
-                        }
-
-                        match self.kbuckets_peers.entry(peer_id) {
-                            hashbrown::hash_map::Entry::Occupied(e) => {
-                                let e = e.into_mut();
-                                e.num_references = e.num_references.checked_add(1).unwrap();
-                                e
-                            }
-                            hashbrown::hash_map::Entry::Vacant(e) => {
-                                // The peer was not in the k-buckets, but it is possible that
-                                // we already have existing connections to it.
-                                let mut addresses = addresses::Addresses::with_capacity(
-                                    self.max_addresses_per_peer.get(),
-                                );
-
-                                for connection_id in
-                                    self.inner.established_peer_connections(&e.key())
-                                {
-                                    let state = self.inner.connection_state(connection_id);
-                                    debug_assert!(state.established);
-                                    // Because we mark addresses as disconnected when the
-                                    // shutdown process starts, we ignore shutting down
-                                    // connections.
-                                    if state.shutting_down {
-                                        continue;
-                                    }
-                                    if state.outbound {
-                                        addresses
-                                            .insert_discovered(self.inner[connection_id].clone());
-                                        addresses.set_connected(&self.inner[connection_id]);
-                                    }
-                                }
-
-                                for connection_id in
-                                    self.inner.handshaking_peer_connections(&e.key())
-                                {
-                                    let state = self.inner.connection_state(connection_id);
-                                    debug_assert!(!state.established);
-                                    debug_assert!(state.outbound);
-                                    // Because we mark addresses as disconnected when the
-                                    // shutdown process starts, we ignore shutting down
-                                    // connections.
-                                    if state.shutting_down {
-                                        continue;
-                                    }
-                                    addresses.insert_discovered(self.inner[connection_id].clone());
-                                    addresses.set_pending(&self.inner[connection_id]);
-                                }
-
-                                // TODO: O(n)
-                                for (_, (p, addr, _)) in &self.pending_ids {
-                                    if p == e.key() {
-                                        addresses.insert_discovered(addr.clone());
-                                        addresses.set_pending(addr);
-                                    }
-                                }
-
-                                e.insert(KBucketsPeer {
-                                    num_references: NonZeroUsize::new(1).unwrap(),
-                                    addresses,
-                                })
-                            }
-                        }
-                    }
-                }
-            }
-            kademlia::kbuckets::Entry::Occupied(_) => {
-                self.kbuckets_peers.get_mut(&peer_id).unwrap()
-            }
-        };
-
-        for to_insert in discovered_addrs {
-            if kbuckets_peer.addresses.len() >= self.max_addresses_per_peer.get() {
-                continue;
-            }
-
-            kbuckets_peer.addresses.insert_discovered(to_insert);
-        }
-
-        // List of addresses must never be empty.
-        debug_assert!(!kbuckets_peer.addresses.is_empty());
     }
 
     /// Returns a list of nodes (their [`PeerId`] and multiaddresses) that we know are part of
@@ -1400,80 +1007,27 @@ where
                     });
                 }
 
-                // Incoming requests of the "identify" protocol.
+                // Incoming requests.
                 peers::Event::RequestIn {
-                    protocol_index: 0,
+                    peer_id,
                     connection_id,
-                    peer_id,
-                    request_payload,
-                    request_id,
-                    ..
-                } => {
-                    if request_payload.is_empty() {
-                        let observed_addr = self.inner[connection_id].clone();
-                        let _prev_value = self
-                            .in_requests_types
-                            .insert(request_id, InRequestTy::Identify { observed_addr });
-                        debug_assert!(_prev_value.is_none());
-
-                        break Some(Event::IdentifyRequestIn {
-                            peer_id,
-                            request_id,
-                        });
-                    }
-
-                    let _ = self.inner.respond_in_request(request_id, Err(()));
-                    break Some(Event::ProtocolError {
-                        peer_id,
-                        error: ProtocolError::BadIdentifyRequest,
-                    });
-                }
-                // Incoming requests of the "sync" protocol.
-                peers::Event::RequestIn {
-                    peer_id,
                     request_id,
                     protocol_index,
                     request_payload,
                     ..
-                } if ((protocol_index - 1) % REQUEST_RESPONSE_PROTOCOLS_PER_CHAIN) == 0 => {
-                    let chain_index = (protocol_index - 1) / REQUEST_RESPONSE_PROTOCOLS_PER_CHAIN;
-
-                    match protocol::decode_block_request(
-                        self.chains[chain_index].chain_config.block_number_bytes,
-                        &request_payload,
-                    ) {
-                        Ok(config) => {
-                            let _prev_value = self
-                                .in_requests_types
-                                .insert(request_id, InRequestTy::Blocks);
-                            debug_assert!(_prev_value.is_none());
-
-                            break Some(Event::BlocksRequestIn {
-                                peer_id,
-                                chain_index,
-                                config,
-                                request_id,
-                            });
-                        }
-                        Err(error) => {
-                            let _ = self.inner.respond_in_request(request_id, Err(()));
-                            break Some(Event::ProtocolError {
-                                peer_id,
-                                error: ProtocolError::BadBlocksRequest(error),
-                            });
-                        }
-                    }
+                } => {
+                    break Some(self.on_request_in(
+                        request_id,
+                        peer_id,
+                        connection_id,
+                        protocol_index,
+                        request_payload,
+                    ))
                 }
-                // Protocols that receive requests are whitelisted, meaning that no other protocol
-                // indices can reach here.
-                peers::Event::RequestIn { .. } => unreachable!(),
 
                 // Remote is no longer interested in the response.
-                // We don't do anything yet. The obsolescence is detected when trying to answer
-                // it.
                 peers::Event::RequestInCancel { id, .. } => {
-                    self.in_requests_types.remove(&id).unwrap();
-                    break Some(Event::RequestInCancel { request_id: id });
+                    break Some(self.on_request_in_cancel(id))
                 }
 
                 // Successfully opened block announces substream.
@@ -1583,148 +1137,7 @@ where
                 peers::Event::Response {
                     request_id,
                     response,
-                } => match self.out_requests_types.remove(&request_id).unwrap() {
-                    (OutRequestTy::Blocks { checked }, chain_index) => {
-                        let mut response =
-                            response
-                                .map_err(BlocksRequestError::Request)
-                                .and_then(|payload| {
-                                    protocol::decode_block_response(&payload)
-                                        .map_err(BlocksRequestError::Decode)
-                                });
-
-                        if let (Some(config), &mut Ok(ref mut blocks)) = (checked, &mut response) {
-                            if let Err(err) = check_blocks_response(
-                                self.chains[chain_index].chain_config.block_number_bytes,
-                                config,
-                                blocks,
-                            ) {
-                                response = Err(err);
-                            }
-                        }
-
-                        break Some(Event::RequestResult {
-                            request_id,
-                            response: RequestResult::Blocks(response),
-                        });
-                    }
-                    (OutRequestTy::GrandpaWarpSync, chain_index) => {
-                        let block_number_bytes =
-                            self.chains[chain_index].chain_config.block_number_bytes;
-
-                        let response = response
-                            .map_err(GrandpaWarpSyncRequestError::Request)
-                            .and_then(|message| {
-                                if let Err(err) = protocol::decode_grandpa_warp_sync_response(
-                                    &message,
-                                    block_number_bytes,
-                                ) {
-                                    Err(GrandpaWarpSyncRequestError::Decode(err))
-                                } else {
-                                    Ok(EncodedGrandpaWarpSyncResponse {
-                                        message,
-                                        block_number_bytes,
-                                    })
-                                }
-                            });
-
-                        break Some(Event::RequestResult {
-                            request_id,
-                            response: RequestResult::GrandpaWarpSync(response),
-                        });
-                    }
-                    (OutRequestTy::State, _) => {
-                        let response =
-                            response
-                                .map_err(StateRequestError::Request)
-                                .and_then(|payload| {
-                                    if let Err(err) = protocol::decode_state_response(&payload) {
-                                        Err(StateRequestError::Decode(err))
-                                    } else {
-                                        Ok(EncodedStateResponse(payload))
-                                    }
-                                });
-
-                        break Some(Event::RequestResult {
-                            request_id,
-                            response: RequestResult::State(response),
-                        });
-                    }
-                    (OutRequestTy::StorageProof, _) => {
-                        let response = response
-                            .map_err(StorageProofRequestError::Request)
-                            .and_then(|payload| {
-                                if let Err(err) = protocol::decode_storage_or_call_proof_response(
-                                    protocol::StorageOrCallProof::StorageProof,
-                                    &payload,
-                                ) {
-                                    Err(StorageProofRequestError::Decode(err))
-                                } else {
-                                    Ok(EncodedMerkleProof(
-                                        payload,
-                                        protocol::StorageOrCallProof::StorageProof,
-                                    ))
-                                }
-                            });
-
-                        break Some(Event::RequestResult {
-                            request_id,
-                            response: RequestResult::StorageProof(response),
-                        });
-                    }
-                    (OutRequestTy::CallProof, _) => {
-                        let response =
-                            response
-                                .map_err(CallProofRequestError::Request)
-                                .and_then(|payload| {
-                                    if let Err(err) =
-                                        protocol::decode_storage_or_call_proof_response(
-                                            protocol::StorageOrCallProof::CallProof,
-                                            &payload,
-                                        )
-                                    {
-                                        Err(CallProofRequestError::Decode(err))
-                                    } else {
-                                        Ok(EncodedMerkleProof(
-                                            payload,
-                                            protocol::StorageOrCallProof::CallProof,
-                                        ))
-                                    }
-                                });
-
-                        break Some(Event::RequestResult {
-                            request_id,
-                            response: RequestResult::CallProof(response),
-                        });
-                    }
-                    (OutRequestTy::KademliaFindNode, _) => {
-                        let response = response
-                            .map_err(KademliaFindNodeError::RequestFailed)
-                            .and_then(|payload| {
-                                protocol::decode_find_node_response(&payload)
-                                    .map_err(KademliaFindNodeError::DecodeError)
-                            });
-
-                        break Some(Event::RequestResult {
-                            request_id,
-                            response: RequestResult::KademliaFindNode(response),
-                        });
-                    }
-                    (OutRequestTy::KademliaDiscoveryFindNode(operation_id), _) => {
-                        let result = response
-                            .map_err(KademliaFindNodeError::RequestFailed)
-                            .and_then(|payload| {
-                                protocol::decode_find_node_response(&payload)
-                                    .map_err(KademliaFindNodeError::DecodeError)
-                            })
-                            .map_err(DiscoveryError::FindNode);
-
-                        break Some(Event::KademliaDiscoveryResult {
-                            operation_id,
-                            result,
-                        });
-                    }
-                },
+                } => break Some(self.on_response(request_id, response)),
 
                 // Successfully opened Grandpa substream.
                 // Need to send a Grandpa neighbor packet in response.
@@ -2199,118 +1612,6 @@ where
         event_to_return
     }
 
-    /// Performs a round of Kademlia discovery.
-    ///
-    /// This future yields once a list of nodes on the network has been discovered, or a problem
-    /// happened.
-    ///
-    /// This function might generate a message destined a connection. Use
-    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
-    pub fn start_kademlia_discovery_round(
-        &'_ mut self,
-        now: TNow,
-        chain_index: usize,
-    ) -> KademliaOperationId {
-        let random_peer_id = {
-            let pub_key = self.randomness.sample(rand::distributions::Standard);
-            PeerId::from_public_key(&peer_id::PublicKey::Ed25519(pub_key))
-        };
-
-        let queried_peer = {
-            let peer_id = self.chains[chain_index]
-                .kbuckets
-                .closest_entries(&random_peer_id)
-                // TODO: instead of filtering by connectd only, connect to nodes if not connected
-                // TODO: additionally, this only takes outgoing connections into account
-                .find(|(peer_id, _)| {
-                    self.kbuckets_peers
-                        .get(peer_id)
-                        .unwrap()
-                        .addresses
-                        .iter_connected()
-                        .next()
-                        .is_some()
-                })
-                .map(|(peer_id, _)| peer_id.clone());
-            peer_id
-        };
-
-        let kademlia_operation_id = self.next_kademlia_operation_id;
-        self.next_kademlia_operation_id.0 += 1;
-
-        if let Some(queried_peer) = queried_peer {
-            debug_assert!(self
-                .inner
-                .established_peer_connections(&queried_peer)
-                .any(|cid| !self.inner.connection_state(cid).shutting_down));
-
-            self.start_kademlia_find_node_inner(
-                &queried_peer,
-                now,
-                chain_index,
-                random_peer_id.as_bytes(),
-                Some(kademlia_operation_id),
-            );
-        } else {
-            self.pending_kademlia_errors
-                .push_back((kademlia_operation_id, DiscoveryError::NoPeer))
-        }
-
-        kademlia_operation_id
-    }
-
-    /// Sends a Kademlia "find node" request to a single peer, and waits for it to answer.
-    ///
-    /// Returns an error if there is no active connection with that peer.
-    ///
-    /// This function might generate a message destined a connection. Use
-    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
-    pub fn start_kademlia_find_node(
-        &mut self,
-        target: &PeerId,
-        now: TNow,
-        chain_index: usize,
-        close_to_key: &[u8],
-    ) -> OutRequestId {
-        self.start_kademlia_find_node_inner(target, now, chain_index, close_to_key, None)
-    }
-
-    fn start_kademlia_find_node_inner(
-        &mut self,
-        target: &PeerId,
-        now: TNow,
-        chain_index: usize,
-        close_to_key: &[u8],
-        part_of_operation: Option<KademliaOperationId>,
-    ) -> OutRequestId {
-        let request_data = protocol::build_find_node_request(close_to_key);
-        // The timeout needs to be long enough to potentially download the maximum
-        // response size of 1 MiB. Assuming a 128 kiB/sec connection, that's 8 seconds.
-        let timeout = now + Duration::from_secs(8);
-
-        let id = self.inner.start_request(
-            target,
-            self.protocol_index(chain_index, 2),
-            request_data,
-            timeout,
-        );
-
-        let _prev_value = self.out_requests_types.insert(
-            id,
-            (
-                if let Some(operation_id) = part_of_operation {
-                    OutRequestTy::KademliaDiscoveryFindNode(operation_id)
-                } else {
-                    OutRequestTy::KademliaFindNode
-                },
-                chain_index,
-            ),
-        );
-        debug_assert!(_prev_value.is_none());
-
-        id
-    }
-
     /// Allocates a [`PendingId`] and returns a [`StartConnect`] indicating a multiaddress that
     /// the API user must try to dial.
     ///
@@ -2382,18 +1683,6 @@ where
         None
     }
 
-    /// Returns `true` if if it possible to send requests (i.e. through
-    /// [`ChainNetwork::start_grandpa_warp_sync_request`],
-    /// [`ChainNetwork::start_blocks_request`], etc.) to the given peer.
-    ///
-    /// If `false` is returned, starting a request will panic.
-    ///
-    /// In other words, returns `true` if there exists an established connection non-shutting-down
-    /// connection with the given peer.
-    pub fn can_start_requests(&self, peer_id: &PeerId) -> bool {
-        self.inner.can_start_requests(peer_id)
-    }
-
     /// Returns an iterator to the list of [`PeerId`]s that we have an established connection
     /// with.
     pub fn peers_list(&self) -> impl Iterator<Item = &PeerId> {
@@ -2448,74 +1737,6 @@ where
         );
 
         chain.out_peers.insert(peer_id);
-    }
-
-    ///
-    /// This function might generate a message destined a connection. Use
-    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
-    pub fn respond_identify(&mut self, request_id: InRequestId, agent_version: &str) {
-        let observed_addr = match self.in_requests_types.remove(&request_id) {
-            Some(InRequestTy::Identify { observed_addr }) => observed_addr,
-            _ => panic!(),
-        };
-
-        let response = {
-            protocol::build_identify_response(protocol::IdentifyResponse {
-                protocol_version: "/substrate/1.0", // TODO: same value as in Substrate
-                agent_version,
-                ed25519_public_key: *self.inner.noise_key().libp2p_public_ed25519_key(),
-                listen_addrs: iter::empty(), // TODO:
-                observed_addr,
-                protocols: self
-                    .inner
-                    .request_response_protocols()
-                    .filter(|p| p.inbound_allowed)
-                    .map(|p| &p.name[..])
-                    .chain(
-                        self.inner
-                            .notification_protocols()
-                            .map(|p| &p.protocol_name[..]),
-                    ),
-            })
-            .fold(Vec::new(), |mut a, b| {
-                a.extend_from_slice(b.as_ref());
-                a
-            })
-        };
-
-        let _ = self.inner.respond_in_request(request_id, Ok(response));
-    }
-
-    /// Queue the response to send back.
-    ///
-    /// Pass `None` in order to deny the request. Do this if blocks aren't available locally.
-    ///
-    /// Has no effect if the connection that sends the request no longer exists.
-    ///
-    /// This function might generate a message destined a connection. Use
-    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
-    pub fn respond_blocks(
-        &mut self,
-        request_id: InRequestId,
-        response: Option<Vec<protocol::BlockData>>,
-    ) {
-        match self.in_requests_types.remove(&request_id) {
-            Some(InRequestTy::Blocks) => {}
-            _ => panic!(),
-        };
-
-        let response = if let Some(response) = response {
-            Ok(
-                protocol::build_block_response(response).fold(Vec::new(), |mut a, b| {
-                    a.extend_from_slice(b.as_ref());
-                    a
-                }),
-            )
-        } else {
-            Err(())
-        };
-
-        let _ = self.inner.respond_in_request(request_id, response);
     }
 
     /// Removes the slot assignment of the given peer, if any.
@@ -2695,21 +1916,6 @@ pub enum SlotTy {
     Outbound,
 }
 
-/// Response to an outgoing request.
-///
-/// See [`Event::RequestResult`̀].
-#[derive(Debug)]
-pub enum RequestResult {
-    Blocks(Result<Vec<protocol::BlockData>, BlocksRequestError>),
-    GrandpaWarpSync(Result<EncodedGrandpaWarpSyncResponse, GrandpaWarpSyncRequestError>),
-    State(Result<EncodedStateResponse, StateRequestError>),
-    StorageProof(Result<EncodedMerkleProof, StorageProofRequestError>),
-    CallProof(Result<EncodedMerkleProof, CallProofRequestError>),
-    KademliaFindNode(
-        Result<Vec<(peer_id::PeerId, Vec<multiaddr::Multiaddr>)>, KademliaFindNodeError>,
-    ),
-}
-
 /// Error that can happen when trying to open an outbound notifications substream.
 #[derive(Debug, Clone, derive_more::Display)]
 pub enum NotificationsOutErr {
@@ -2766,23 +1972,6 @@ impl fmt::Debug for EncodedBlockAnnounce {
     }
 }
 
-/// Undecoded but valid Merkle proof.
-#[derive(Clone)]
-pub struct EncodedMerkleProof(Vec<u8>, protocol::StorageOrCallProof);
-
-impl EncodedMerkleProof {
-    /// Returns the decoded version of the proof.
-    pub fn decode(&self) -> Vec<&[u8]> {
-        protocol::decode_storage_or_call_proof_response(self.1, &self.0).unwrap()
-    }
-}
-
-impl fmt::Debug for EncodedMerkleProof {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&self.decode(), f)
-    }
-}
-
 /// Undecoded but valid GrandPa commit message.
 #[derive(Clone)]
 pub struct EncodedGrandpaCommitMessage {
@@ -2819,167 +2008,6 @@ impl fmt::Debug for EncodedGrandpaCommitMessage {
     }
 }
 
-/// Undecoded but valid GrandPa warp sync response.
-#[derive(Clone)]
-pub struct EncodedGrandpaWarpSyncResponse {
-    message: Vec<u8>,
-    block_number_bytes: usize,
-}
-
-impl EncodedGrandpaWarpSyncResponse {
-    /// Returns the encoded bytes of the warp sync message.
-    pub fn as_encoded(&self) -> &[u8] {
-        &self.message
-    }
-
-    /// Returns the decoded version of the warp sync message.
-    pub fn decode(&self) -> protocol::GrandpaWarpSyncResponse {
-        match protocol::decode_grandpa_warp_sync_response(&self.message, self.block_number_bytes) {
-            Ok(msg) => msg,
-            _ => unreachable!(),
-        }
-    }
-}
-
-impl fmt::Debug for EncodedGrandpaWarpSyncResponse {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&self.decode(), f)
-    }
-}
-
-/// Undecoded but valid state response.
-#[derive(Clone)]
-pub struct EncodedStateResponse(Vec<u8>);
-
-impl EncodedStateResponse {
-    /// Returns the decoded version of the state response.
-    pub fn decode(&self) -> Vec<&[u8]> {
-        match protocol::decode_state_response(&self.0) {
-            Ok(r) => r,
-            Err(_) => unreachable!(),
-        }
-    }
-}
-
-impl fmt::Debug for EncodedStateResponse {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&self.decode(), f)
-    }
-}
-
-/// Error during [`ChainNetwork::start_kademlia_discovery_round`].
-#[derive(Debug, derive_more::Display)]
-pub enum DiscoveryError {
-    /// Not currently connected to any other node.
-    NoPeer,
-    /// Error during the request.
-    #[display(fmt = "{}", _0)]
-    FindNode(KademliaFindNodeError),
-}
-
-/// Error during [`ChainNetwork::start_kademlia_find_node`].
-#[derive(Debug, derive_more::Display)]
-pub enum KademliaFindNodeError {
-    /// Error during the request.
-    #[display(fmt = "{}", _0)]
-    RequestFailed(peers::RequestError),
-    /// Failed to decode the response.
-    #[display(fmt = "Response decoding error: {}", _0)]
-    DecodeError(protocol::DecodeFindNodeResponseError),
-}
-
-/// Error returned by [`ChainNetwork::start_blocks_request`].
-#[derive(Debug, derive_more::Display)]
-pub enum BlocksRequestError {
-    /// Error while waiting for the response from the peer.
-    #[display(fmt = "{}", _0)]
-    Request(peers::RequestError),
-    /// Error while decoding the response returned by the peer.
-    #[display(fmt = "Response decoding error: {}", _0)]
-    Decode(protocol::DecodeBlockResponseError),
-    /// Block request doesn't request headers, and as such its validity cannot be verified.
-    NotVerifiable,
-    /// Response returned by the remote doesn't contain any entry.
-    EmptyResponse,
-    /// Start of the response doesn't correspond to the requested start.
-    InvalidStart,
-    /// Error at a specific index in the response.
-    #[display(fmt = "Error in response at offset {}: {}", index, error)]
-    Entry {
-        /// Index in the response where the problem happened.
-        index: usize,
-        /// Problem in question.
-        error: BlocksRequestResponseEntryError,
-    },
-}
-
-/// See [`BlocksRequestError`].
-#[derive(Debug, derive_more::Display)]
-pub enum BlocksRequestResponseEntryError {
-    /// One of the requested fields is missing from the block.
-    MissingField,
-    /// The header has an extrinsics root that doesn't match the body. Can only happen if both the
-    /// header and body were requested.
-    #[display(fmt = "The header has an extrinsics root that doesn't match the body")]
-    InvalidExtrinsicsRoot {
-        /// Extrinsics root that was calculated from the body.
-        calculated: [u8; 32],
-        /// Extrinsics root found in the header.
-        in_header: [u8; 32],
-    },
-    /// The header has an invalid format.
-    InvalidHeader,
-    /// The hash of the header doesn't match the hash provided by the remote.
-    InvalidHash,
-}
-
-/// Error returned by [`ChainNetwork::start_storage_proof_request`].
-#[derive(Debug, derive_more::Display, Clone)]
-pub enum StorageProofRequestError {
-    #[display(fmt = "{}", _0)]
-    Request(peers::RequestError),
-    #[display(fmt = "Response decoding error: {}", _0)]
-    Decode(protocol::DecodeStorageCallProofResponseError),
-}
-
-/// Error returned by [`ChainNetwork::start_call_proof_request`].
-#[derive(Debug, Clone, derive_more::Display)]
-pub enum CallProofRequestError {
-    #[display(fmt = "{}", _0)]
-    Request(peers::RequestError),
-    #[display(fmt = "Response decoding error: {}", _0)]
-    Decode(protocol::DecodeStorageCallProofResponseError),
-}
-
-impl CallProofRequestError {
-    /// Returns `true` if this is caused by networking issues, as opposed to a consensus-related
-    /// issue.
-    pub fn is_network_problem(&self) -> bool {
-        match self {
-            CallProofRequestError::Request(_) => true,
-            CallProofRequestError::Decode(_) => false,
-        }
-    }
-}
-
-/// Error returned by [`ChainNetwork::start_grandpa_warp_sync_request`].
-#[derive(Debug, derive_more::Display)]
-pub enum GrandpaWarpSyncRequestError {
-    #[display(fmt = "{}", _0)]
-    Request(peers::RequestError),
-    #[display(fmt = "Response decoding error: {}", _0)]
-    Decode(protocol::DecodeGrandpaWarpSyncResponseError),
-}
-
-/// Error returned by [`ChainNetwork::start_state_request`].
-#[derive(Debug, derive_more::Display)]
-pub enum StateRequestError {
-    #[display(fmt = "{}", _0)]
-    Request(peers::RequestError),
-    #[display(fmt = "Response decoding error: {}", _0)]
-    Decode(protocol::DecodeStateResponseError),
-}
-
 /// See [`Event::ProtocolError`].
 #[derive(Debug, derive_more::Display)]
 pub enum ProtocolError {
@@ -3003,95 +2031,4 @@ pub enum ProtocolError {
     /// Error while decoding a received blocks request.
     #[display(fmt = "Error while decoding a received blocks request: {}", _0)]
     BadBlocksRequest(protocol::DecodeBlockRequestError),
-}
-
-fn check_blocks_response(
-    block_number_bytes: usize,
-    config: protocol::BlocksRequestConfig,
-    result: &mut [protocol::BlockData],
-) -> Result<(), BlocksRequestError> {
-    if !config.fields.header {
-        return Err(BlocksRequestError::NotVerifiable);
-    }
-
-    if result.is_empty() {
-        return Err(BlocksRequestError::EmptyResponse);
-    }
-
-    // Verify validity of all the blocks.
-    for (block_index, block) in result.iter_mut().enumerate() {
-        if block.header.is_none() {
-            return Err(BlocksRequestError::Entry {
-                index: block_index,
-                error: BlocksRequestResponseEntryError::MissingField,
-            });
-        }
-
-        if block
-            .header
-            .as_ref()
-            .map_or(false, |h| header::decode(h, block_number_bytes).is_err())
-        {
-            return Err(BlocksRequestError::Entry {
-                index: block_index,
-                error: BlocksRequestResponseEntryError::InvalidHeader,
-            });
-        }
-
-        match (block.body.is_some(), config.fields.body) {
-            (false, true) => {
-                return Err(BlocksRequestError::Entry {
-                    index: block_index,
-                    error: BlocksRequestResponseEntryError::MissingField,
-                });
-            }
-            (true, false) => {
-                block.body = None;
-            }
-            _ => {}
-        }
-
-        // Note: the presence of a justification isn't checked and can't be checked, as not
-        // all blocks have a justification in the first place.
-
-        if block.header.as_ref().map_or(false, |h| {
-            header::hash_from_scale_encoded_header(&h) != block.hash
-        }) {
-            return Err(BlocksRequestError::Entry {
-                index: block_index,
-                error: BlocksRequestResponseEntryError::InvalidHash,
-            });
-        }
-
-        if let (Some(header), Some(body)) = (&block.header, &block.body) {
-            let decoded_header = header::decode(header, block_number_bytes).unwrap();
-            let expected = header::extrinsics_root(&body[..]);
-            if expected != *decoded_header.extrinsics_root {
-                return Err(BlocksRequestError::Entry {
-                    index: block_index,
-                    error: BlocksRequestResponseEntryError::InvalidExtrinsicsRoot {
-                        calculated: expected,
-                        in_header: *decoded_header.extrinsics_root,
-                    },
-                });
-            }
-        }
-    }
-
-    match config.start {
-        protocol::BlocksRequestConfigStart::Hash(hash) if result[0].hash != hash => {
-            return Err(BlocksRequestError::InvalidStart);
-        }
-        protocol::BlocksRequestConfigStart::Number(n)
-            if header::decode(result[0].header.as_ref().unwrap(), block_number_bytes)
-                .unwrap()
-                .number
-                != n =>
-        {
-            return Err(BlocksRequestError::InvalidStart)
-        }
-        _ => {}
-    }
-
-    Ok(())
 }

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -15,13 +15,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::libp2p::{
-    connection, multiaddr, peer_id,
-    peers::{self, QueueNotificationError},
-    PeerId,
-};
+use crate::libp2p::{connection, multiaddr, peer_id, peers, PeerId};
 use crate::network::{kademlia, protocol};
-use crate::util::{self, SipHasherBuild};
+use crate::util::SipHasherBuild;
 
 use alloc::{
     collections::VecDeque,
@@ -30,7 +26,6 @@ use alloc::{
     vec::Vec,
 };
 use core::{
-    fmt,
     hash::Hash,
     iter,
     num::NonZeroUsize,
@@ -49,7 +44,13 @@ pub use crate::libp2p::{
 };
 
 mod addresses;
+mod notifications;
 mod requests_responses;
+
+pub use notifications::{
+    EncodedBlockAnnounce, EncodedBlockAnnounceHandshake, EncodedGrandpaCommitMessage, GrandpaState,
+    NotificationsOutErr,
+};
 
 pub use requests_responses::{
     BlocksRequestError, BlocksRequestResponseEntryError, CallProofRequestError, DiscoveryError,
@@ -133,17 +134,6 @@ pub struct ChainConfig {
     /// Hash of the genesis block (i.e. block number 0) according to the local node.
     pub genesis_hash: [u8; 32],
     pub role: protocol::Role,
-}
-
-#[derive(Debug, Copy, Clone)]
-// TODO: link to some doc about how GrandPa works: what is a round, what is the set id, etc.
-pub struct GrandpaState {
-    pub round_number: u64,
-    /// Set of authorities that will be used by the node to try finalize the children of the block
-    /// of [`GrandpaState::commit_finalized_height`].
-    pub set_id: u64,
-    /// Height of the highest block considered final by the node.
-    pub commit_finalized_height: u64,
 }
 
 /// Identifier of a pending connection requested by the network through a [`StartConnect`].
@@ -274,36 +264,7 @@ where
 {
     /// Initializes a new [`ChainNetwork`].
     pub fn new(config: Config<TNow>) -> Self {
-        // The order of protocols here is important, as it defines the values of `protocol_index`
-        // to pass to libp2p or that libp2p produces.
-        let notification_protocols = config
-            .chains
-            .iter()
-            .flat_map(|chain| {
-                iter::once(peers::NotificationProtocolConfig {
-                    protocol_name: format!("/{}/block-announces/1", chain.protocol_id),
-                    max_handshake_size: 1024 * 1024, // TODO: arbitrary
-                    max_notification_size: 1024 * 1024,
-                })
-                .chain(iter::once(peers::NotificationProtocolConfig {
-                    protocol_name: format!("/{}/transactions/1", chain.protocol_id),
-                    max_handshake_size: 4,
-                    max_notification_size: 16 * 1024 * 1024,
-                }))
-                .chain({
-                    // The `has_grandpa_protocol` flag controls whether the chain uses GrandPa.
-                    // Note, however, that GrandPa is technically left enabled (but unused) on all
-                    // chains, in order to make the rest of the code of this module more
-                    // comprehensible.
-                    iter::once(peers::NotificationProtocolConfig {
-                        protocol_name: "/paritytech/grandpa/1".to_string(),
-                        max_handshake_size: 4,
-                        max_notification_size: 1024 * 1024,
-                    })
-                })
-            })
-            .collect();
-
+        let notification_protocols = notifications::protocols(config.chains.iter());
         let request_response_protocols = requests_responses::protocols(config.chains.iter());
 
         let mut randomness = rand_chacha::ChaCha20Rng::from_seed(config.randomness_seed);
@@ -487,145 +448,6 @@ where
         message: ConnectionToCoordinator,
     ) {
         self.inner.inject_connection_message(connection_id, message)
-    }
-
-    /// Modifies the best block of the local node. See [`ChainConfig::best_hash`] and
-    /// [`ChainConfig::best_number`].
-    ///
-    /// # Panic
-    ///
-    /// Panics if `chain_index` is out of range.
-    ///
-    pub fn set_local_best_block(
-        &mut self,
-        chain_index: usize,
-        best_hash: [u8; 32],
-        best_number: u64,
-    ) {
-        let mut config = &mut self.chains[chain_index].chain_config;
-        config.best_hash = best_hash;
-        config.best_number = best_number;
-    }
-
-    /// Update the state of the local node with regards to GrandPa rounds.
-    ///
-    /// Calling this method does two things:
-    ///
-    /// - Send on all the active GrandPa substreams a "neighbor packet" indicating the state of
-    ///   the local node.
-    /// - Update the neighbor packet that is automatically sent to peers when a GrandPa substream
-    ///   gets opened.
-    ///
-    /// In other words, calling this function atomically informs all the present and future peers
-    /// of the state of the local node regarding the GrandPa protocol.
-    ///
-    /// > **Note**: The information passed as parameter isn't validated in any way by this method.
-    ///
-    /// This function might generate a message destined to connections. Use
-    /// [`ChainNetwork::pull_message_to_connection`] to process these messages after it has
-    /// returned.
-    ///
-    /// # Panic
-    ///
-    /// Panics if `chain_index` is out of range, or if the chain has GrandPa disabled.
-    ///
-    pub fn set_local_grandpa_state(&mut self, chain_index: usize, grandpa_state: GrandpaState) {
-        // Bytes of the neighbor packet to send out.
-        let packet = protocol::GrandpaNotificationRef::Neighbor(protocol::NeighborPacket {
-            round_number: grandpa_state.round_number,
-            set_id: grandpa_state.set_id,
-            commit_finalized_height: grandpa_state.commit_finalized_height,
-        })
-        .scale_encoding(self.chains[chain_index].chain_config.block_number_bytes)
-        .fold(Vec::new(), |mut a, b| {
-            a.extend_from_slice(b.as_ref());
-            a
-        });
-
-        // Now sending out.
-        let _ = self
-            .inner
-            .broadcast_notification(chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN + 2, packet);
-
-        // Update the locally-stored state, but only after the notification has been broadcasted.
-        // This way, if the user cancels the future while `broadcast_notification` is executing,
-        // the whole operation is cancelled.
-        *self.chains[chain_index]
-            .chain_config
-            .grandpa_protocol_config
-            .as_mut()
-            .unwrap() = grandpa_state;
-    }
-
-    ///
-    /// This function might generate a message destined a connection. Use
-    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
-    // TODO: there this extra parameter in block announces that is unused on many chains but not always
-    pub fn send_block_announce(
-        &mut self,
-        target: &PeerId,
-        chain_index: usize,
-        scale_encoded_header: &[u8],
-        is_best: bool,
-    ) -> Result<(), QueueNotificationError> {
-        let buffers_to_send = protocol::encode_block_announce(protocol::BlockAnnounceRef {
-            scale_encoded_header,
-            is_best,
-        });
-
-        let notification = buffers_to_send.fold(Vec::new(), |mut a, b| {
-            a.extend_from_slice(b.as_ref());
-            a
-        });
-
-        self.inner.queue_notification(
-            target,
-            chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN,
-            notification,
-        )
-    }
-
-    /// Returns `true` if it is allowed to call [`ChainNetwork::send_block_announce`], in other
-    /// words if there is an outbound block announces substream currently open with the target.
-    ///
-    /// If this function returns `false`, calling [`ChainNetwork::send_block_announce`] will
-    /// panic.
-    pub fn can_send_block_announces(&self, target: &PeerId, chain_index: usize) -> bool {
-        self.inner
-            .can_queue_notification(target, chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN)
-    }
-
-    /// Returns the list of peers for which we have a fully established notifications protocol of
-    /// the given protocol.
-    pub fn opened_transactions_substream(
-        &'_ self,
-        chain_index: usize,
-    ) -> impl Iterator<Item = &'_ PeerId> + '_ {
-        self.inner
-            .opened_out_notifications(chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN + 1)
-    }
-
-    ///
-    ///
-    /// Must be passed the SCALE-encoded transaction.
-    ///
-    /// This function might generate a message destined connections. Use
-    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
-    // TODO: -> broadcast_transaction
-    pub fn announce_transaction(
-        &mut self,
-        target: &PeerId,
-        chain_index: usize,
-        extrinsic: &[u8],
-    ) -> Result<(), QueueNotificationError> {
-        let mut val = Vec::with_capacity(1 + extrinsic.len());
-        val.extend_from_slice(util::encode_scale_compact_usize(1).as_ref());
-        val.extend_from_slice(extrinsic);
-        self.inner.queue_notification(
-            target,
-            chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN + 1,
-            val,
-        )
     }
 
     /// Returns a list of nodes (their [`PeerId`] and multiaddresses) that we know are part of
@@ -848,10 +670,11 @@ where
                                 // desired, and thus didn't have a slot.
                             }
                             peers::OpenOrPending::Open => {
+                                // TODO: refactor to directly call on_notifications_out_close, making the code more readable
                                 break Some(peers::Event::NotificationsOutClose {
                                     notifications_protocol_index,
                                     peer_id,
-                                })
+                                });
                             }
                         }
                     } else {
@@ -1030,108 +853,19 @@ where
                     break Some(self.on_request_in_cancel(id))
                 }
 
-                // Successfully opened block announces substream.
-                // The block announces substream is the main substream that determines whether
-                // a "chain" is open.
                 peers::Event::NotificationsOutResult {
                     peer_id,
                     notifications_protocol_index,
-                    result: Ok(remote_handshake),
-                } if notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN == 0 => {
-                    let chain_index =
-                        notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
-
-                    // Check validity of the handshake.
-                    let remote_handshake = match protocol::decode_block_announces_handshake(
-                        self.chains[chain_index].chain_config.block_number_bytes,
-                        &remote_handshake,
-                    ) {
-                        Ok(hs) => hs,
-                        Err(err) => {
-                            // TODO: must close the substream and unassigned the slot
-                            break Some(Event::ProtocolError {
-                                error: ProtocolError::BadBlockAnnouncesHandshake(err),
-                                peer_id,
-                            });
-                        }
-                    };
-
-                    // The desirability of the transactions and grandpa substreams is always equal
-                    // to whether the block announces substream is open.
-                    self.inner.set_peer_notifications_out_desired(
-                        &peer_id,
-                        chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN + 1,
-                        peers::DesiredState::DesiredReset,
-                    );
-                    self.inner.set_peer_notifications_out_desired(
-                        &peer_id,
-                        chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN + 2,
-                        peers::DesiredState::DesiredReset,
-                    );
-
-                    let slot_ty = {
-                        let local_genesis = self.chains[chain_index].chain_config.genesis_hash;
-                        let remote_genesis = *remote_handshake.genesis_hash;
-
-                        if remote_genesis != local_genesis {
-                            let unassigned_slot_ty =
-                                self.unassign_slot(chain_index, &peer_id).unwrap();
-
-                            break Some(Event::ChainConnectAttemptFailed {
-                                peer_id,
-                                chain_index,
-                                unassigned_slot_ty,
-                                error: NotificationsOutErr::GenesisMismatch {
-                                    local_genesis,
-                                    remote_genesis,
-                                },
-                            });
-                        }
-
-                        // Update the k-buckets to mark the peer as connected.
-                        // Note that this is done after having made sure that the handshake
-                        // was correct.
-                        // TODO: should we not insert the entry in the k-buckets as well? seems important for incoming connections
-                        if let Some(mut entry) = self.chains[chain_index]
-                            .kbuckets
-                            .entry(&peer_id)
-                            .into_occupied()
-                        {
-                            entry.set_state(&now, kademlia::kbuckets::PeerState::Connected);
-                        }
-
-                        if self.chains[chain_index].in_peers.contains(&peer_id) {
-                            SlotTy::Inbound
-                        } else {
-                            debug_assert!(self.chains[chain_index].out_peers.contains(&peer_id));
-                            SlotTy::Outbound
-                        }
-                    };
-
-                    let _was_inserted = self.open_chains.insert((peer_id.clone(), chain_index));
-                    debug_assert!(_was_inserted);
-
-                    let best_hash = *remote_handshake.best_hash;
-                    let best_number = remote_handshake.best_number;
-                    let role = remote_handshake.role;
-
-                    break Some(Event::ChainConnected {
+                    result,
+                } => {
+                    if let Some(event) = self.on_notifications_out_result(
+                        &now,
                         peer_id,
-                        chain_index,
-                        slot_ty,
-                        best_hash,
-                        best_number,
-                        role,
-                    });
-                }
-
-                // Successfully opened transactions substream.
-                peers::Event::NotificationsOutResult {
-                    notifications_protocol_index,
-                    result: Ok(_),
-                    ..
-                } if notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN == 1 => {
-                    // Nothing to do.
+                        notifications_protocol_index,
+                        result,
+                    ) {
+                        return Some(event);
+                    }
                 }
 
                 peers::Event::Response {
@@ -1139,424 +873,61 @@ where
                     response,
                 } => break Some(self.on_response(request_id, response)),
 
-                // Successfully opened Grandpa substream.
-                // Need to send a Grandpa neighbor packet in response.
-                peers::Event::NotificationsOutResult {
-                    peer_id,
-                    notifications_protocol_index,
-                    result: Ok(_),
-                    ..
-                } if notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN == 2 => {
-                    let chain_index =
-                        notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
-
-                    let notification = {
-                        let grandpa_config = *self.chains[chain_index]
-                            .chain_config
-                            .grandpa_protocol_config
-                            .as_ref()
-                            .unwrap();
-
-                        protocol::GrandpaNotificationRef::Neighbor(protocol::NeighborPacket {
-                            round_number: grandpa_config.round_number,
-                            set_id: grandpa_config.set_id,
-                            commit_finalized_height: grandpa_config.commit_finalized_height,
-                        })
-                        .scale_encoding(self.chains[chain_index].chain_config.block_number_bytes)
-                        .fold(Vec::new(), |mut a, b| {
-                            a.extend_from_slice(b.as_ref());
-                            a
-                        })
-                    };
-
-                    let _ = self.inner.queue_notification(
-                        &peer_id,
-                        notifications_protocol_index,
-                        notification.clone(),
-                    );
-                }
-
-                // Unrecognized protocol.
-                peers::Event::NotificationsOutResult { result: Ok(_), .. } => unreachable!(),
-
-                // Failed to open block announces substream.
-                peers::Event::NotificationsOutResult {
-                    notifications_protocol_index,
-                    peer_id,
-                    result: Err(error),
-                } if notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN == 0 => {
-                    let chain_index =
-                        notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
-
-                    let unassigned_slot_ty = self.unassign_slot(chain_index, &peer_id).unwrap();
-
-                    break Some(Event::ChainConnectAttemptFailed {
-                        peer_id,
-                        chain_index,
-                        unassigned_slot_ty,
-                        error: NotificationsOutErr::Substream(error),
-                    });
-                }
-
-                // Other protocol.
-                peers::Event::NotificationsOutResult { result: Err(_), .. } => {}
-
-                // Remote closes our outbound block announces substream.
                 peers::Event::NotificationsOutClose {
                     notifications_protocol_index,
                     peer_id,
-                } if notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN == 0 => {
-                    let chain_index =
-                        notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
-
-                    // The desirability of the transactions and grandpa substreams is always equal
-                    // to whether the block announces substream is open.
-                    //
-                    // These two calls modify `self.inner`, but they are still cancellation-safe
-                    // as they can be repeated multiple times.
-                    self.inner.set_peer_notifications_out_desired(
-                        &peer_id,
-                        chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN + 1,
-                        peers::DesiredState::NotDesired,
-                    );
-                    self.inner.set_peer_notifications_out_desired(
-                        &peer_id,
-                        chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN + 2,
-                        peers::DesiredState::NotDesired,
-                    );
-
-                    // The chain is now considered as closed.
-                    // TODO: can was_open ever be false?
-                    let was_open = self.open_chains.remove(&(peer_id.clone(), chain_index)); // TODO: cloning :(
-
-                    if was_open {
-                        // Update the k-buckets, marking the peer as disconnected.
-                        let unassigned_slot_ty = {
-                            let unassigned_slot_ty =
-                                self.unassign_slot(chain_index, &peer_id).unwrap();
-
-                            if let Some(mut entry) = self.chains[chain_index]
-                                .kbuckets
-                                .entry(&peer_id)
-                                .into_occupied()
-                            {
-                                // Note that the state might have already be `Disconnected`, which
-                                // can happen for example in case of a problem in the handshake
-                                // sent back by the remote.
-                                entry.set_state(&now, kademlia::kbuckets::PeerState::Disconnected);
-                            }
-
-                            unassigned_slot_ty
-                        };
-
-                        break Some(Event::ChainDisconnected {
-                            chain_index,
-                            peer_id,
-                            unassigned_slot_ty,
-                        });
-                    }
-                }
-
-                // Other protocol.
-                peers::Event::NotificationsOutClose {
-                    peer_id,
-                    notifications_protocol_index,
-                    ..
                 } => {
-                    let chain_index =
-                        notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
-
-                    // The state of notification substreams other than block announces must
-                    // always match the state of the block announces.
-                    // Therefore, if the peer is considered open, try to reopen the substream that
-                    // has just been closed.
-                    // TODO: cloning of peer_id :-/
-                    if self.open_chains.contains(&(peer_id.clone(), chain_index)) {
-                        self.inner.set_peer_notifications_out_desired(
-                            &peer_id,
-                            notifications_protocol_index,
-                            peers::DesiredState::DesiredReset,
-                        );
+                    if let Some(event) =
+                        self.on_notifications_out_close(&now, peer_id, notifications_protocol_index)
+                    {
+                        return Some(event);
                     }
                 }
 
-                // Remote closes a block announce substream.
                 peers::Event::NotificationsInClose {
                     peer_id,
                     notifications_protocol_index,
                     ..
-                } if notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN == 0 => {
-                    let chain_index =
-                        notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
-
-                    // We unassign the inbound slot of the peer if it had one.
-                    // If the peer had an outbound slot, then this does nothing.
-                    if self.chains[chain_index].in_peers.remove(&peer_id) {
-                        self.inner.set_peer_notifications_out_desired(
-                            &peer_id,
-                            notifications_protocol_index,
-                            peers::DesiredState::NotDesired,
-                        );
-                    }
-                }
-
-                // Remote closes another substream.
-                peers::Event::NotificationsInClose { .. } => {}
-
-                // Received a block announce.
-                peers::Event::NotificationsIn {
-                    notifications_protocol_index,
-                    peer_id,
-                    notification,
-                } if notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN == 0 => {
-                    let chain_index =
-                        notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
-
-                    // Don't report events about nodes we don't have an outbound substream with.
-                    // TODO: think about possible race conditions regarding missing block
-                    // announcements, as the remote will think we know it's at a certain block
-                    // while we ignored its announcement ; it isn't problematic as long as blocks
-                    // are generated continuously, as announcements will be generated periodically
-                    // as well and the state will no longer mismatch
-                    // TODO: cloning of peer_id :(
-                    if !self.open_chains.contains(&(peer_id.clone(), chain_index)) {
-                        continue;
-                    }
-
-                    let block_number_bytes =
-                        self.chains[chain_index].chain_config.block_number_bytes;
-
-                    // Check the format of the block announce.
-                    if let Err(err) =
-                        protocol::decode_block_announce(&notification, block_number_bytes)
+                } => {
+                    if let Some(event) =
+                        self.on_notifications_in_close(peer_id, notifications_protocol_index)
                     {
-                        break Some(Event::ProtocolError {
-                            error: ProtocolError::BadBlockAnnounce(err),
-                            peer_id,
-                        });
+                        return Some(event);
                     }
-
-                    break Some(Event::BlockAnnounce {
-                        chain_index,
-                        peer_id,
-                        announce: EncodedBlockAnnounce {
-                            message: notification,
-                            block_number_bytes,
-                        },
-                    });
                 }
 
-                // Received transaction notification.
-                peers::Event::NotificationsIn {
-                    peer_id,
-                    notifications_protocol_index,
-                    ..
-                } if notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN == 1 => {
-                    let chain_index =
-                        notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
-
-                    // Don't report events about nodes we don't have an outbound substream with.
-                    // TODO: cloning of peer_id :(
-                    if !self.open_chains.contains(&(peer_id.clone(), chain_index)) {
-                        continue;
-                    }
-
-                    // TODO: this is unimplemented
-                }
-
-                // Received Grandpa notification.
                 peers::Event::NotificationsIn {
                     notifications_protocol_index,
                     peer_id,
                     notification,
-                } if notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN == 2 => {
-                    let chain_index =
-                        notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
-                    let block_number_bytes =
-                        self.chains[chain_index].chain_config.block_number_bytes;
-
-                    // Don't report events about nodes we don't have an outbound substream with.
-                    // TODO: cloning of peer_id :(
-                    if !self.open_chains.contains(&(peer_id.clone(), chain_index)) {
-                        continue;
-                    }
-
-                    let decoded_notif = match protocol::decode_grandpa_notification(
-                        &notification,
-                        block_number_bytes,
-                    ) {
-                        Ok(n) => n,
-                        Err(err) => {
-                            break Some(Event::ProtocolError {
-                                error: ProtocolError::BadGrandpaNotification(err),
-                                peer_id,
-                            });
-                        }
-                    };
-
-                    // Commit messages are the only type of message that is important for
-                    // light clients. Anything else is presently ignored.
-                    if let protocol::GrandpaNotificationRef::Commit(_) = decoded_notif {
-                        break Some(Event::GrandpaCommitMessage {
-                            chain_index,
-                            peer_id,
-                            message: EncodedGrandpaCommitMessage {
-                                message: notification,
-                                block_number_bytes,
-                            },
-                        });
+                } => {
+                    if let Some(event) =
+                        self.on_notification_in(peer_id, notifications_protocol_index, notification)
+                    {
+                        break Some(event);
                     }
                 }
 
-                peers::Event::NotificationsIn { .. } => {
-                    // Unrecognized notifications protocol.
-                    unreachable!();
-                }
-
-                // Remote wants to open a block announces substream.
-                // The block announces substream is the main substream that determines whether
-                // a "chain" is open.
                 peers::Event::NotificationsInOpen {
                     peer_id,
                     handshake,
-                    id: substream_id,
+                    id,
                     notifications_protocol_index,
-                } if (notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN) == 0 => {
-                    let chain_index =
-                        notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
-
-                    // Immediately reject the substream if the handshake fails to parse.
-                    if let Err(err) = protocol::decode_block_announces_handshake(
-                        self.chains[chain_index].chain_config.block_number_bytes,
-                        &handshake,
+                } => {
+                    if let Some(event) = self.on_notifications_in_open(
+                        id,
+                        peer_id,
+                        notifications_protocol_index,
+                        handshake,
                     ) {
-                        self.inner.in_notification_refuse(substream_id);
-
-                        break Some(Event::ProtocolError {
-                            error: ProtocolError::BadBlockAnnouncesHandshake(err),
-                            peer_id,
-                        });
-                    }
-
-                    // If the peer doesn't already have an outbound slot, check whether we can
-                    // allocate an inbound slot for it.
-                    let has_out_slot = self.chains[chain_index].out_peers.contains(&peer_id);
-                    if !has_out_slot
-                        && self.chains[chain_index].in_peers.len()
-                            >= usize::try_from(self.chains[chain_index].chain_config.in_slots)
-                                .unwrap_or(usize::max_value())
-                    {
-                        // All in slots are occupied. Refuse the substream.
-                        self.inner.in_notification_refuse(substream_id);
-                        continue;
-                    }
-
-                    // At this point, accept the node can no longer fail.
-
-                    // Generate the handshake to send back.
-                    let handshake = {
-                        let chain_config = &self.chains[chain_index].chain_config;
-                        protocol::encode_block_announces_handshake(
-                            protocol::BlockAnnouncesHandshakeRef {
-                                best_hash: &chain_config.best_hash,
-                                best_number: chain_config.best_number,
-                                genesis_hash: &chain_config.genesis_hash,
-                                role: chain_config.role,
-                            },
-                            chain_config.block_number_bytes,
-                        )
-                        .fold(Vec::new(), |mut a, b| {
-                            a.extend_from_slice(b.as_ref());
-                            a
-                        })
-                    };
-
-                    self.inner.in_notification_accept(substream_id, handshake);
-
-                    if !has_out_slot {
-                        // TODO: future cancellation issue; if this future is cancelled, then trying to do the `in_notification_accept` again next time will panic
-                        self.inner.set_peer_notifications_out_desired(
-                            &peer_id,
-                            notifications_protocol_index,
-                            peers::DesiredState::DesiredReset,
-                        );
-
-                        // The state modification is done at the very end, to not have any
-                        // future cancellation issue.
-                        let _was_inserted =
-                            self.chains[chain_index].in_peers.insert(peer_id.clone());
-                        debug_assert!(_was_inserted);
-
-                        break Some(Event::InboundSlotAssigned {
-                            chain_index,
-                            peer_id,
-                        });
+                        break Some(event);
                     }
                 }
 
-                // Remote wants to open a transactions substream.
-                peers::Event::NotificationsInOpen {
-                    peer_id,
-                    id: substream_id,
-                    notifications_protocol_index,
-                    ..
-                } if (notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN) == 1 => {
-                    let chain_index =
-                        notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
-
-                    // Accept the substream only if the peer is "chain connected".
-                    if self
-                        .open_chains // TODO: clone :-/
-                        .contains(&(peer_id.clone(), chain_index))
-                    {
-                        self.inner.in_notification_accept(substream_id, Vec::new());
-                    } else {
-                        self.inner.in_notification_refuse(substream_id);
+                peers::Event::NotificationsInOpenCancel { id } => {
+                    if let Some(event) = self.on_notifications_in_open_cancel(id) {
+                        break Some(event);
                     }
-                }
-
-                // Remote wants to open a grandpa substream.
-                peers::Event::NotificationsInOpen {
-                    peer_id,
-                    id: substream_id,
-                    notifications_protocol_index,
-                    ..
-                } if (notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN) == 2 => {
-                    let chain_index =
-                        notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
-
-                    // Reject the substream if the this peer isn't "chain connected".
-                    if !self
-                        .open_chains // TODO: clone :-/
-                        .contains(&(peer_id.clone(), chain_index))
-                    {
-                        self.inner.in_notification_refuse(substream_id);
-                        continue;
-                    }
-
-                    // Peer is indeed connected. Accept the substream.
-
-                    // Build the handshake to send back.
-                    let handshake = {
-                        self.chains[chain_index]
-                            .chain_config
-                            .role
-                            .scale_encoding()
-                            .to_vec()
-                    };
-
-                    self.inner.in_notification_accept(substream_id, handshake);
-                }
-
-                peers::Event::NotificationsInOpen { .. } => {
-                    // Unrecognized notifications protocol.
-                    unreachable!();
-                }
-
-                peers::Event::NotificationsInOpenCancel { .. } => {
-                    // Because we always accept/refuse incoming notification substreams instantly,
-                    // there's no possibility for a cancellation to happen.
-                    unreachable!()
                 }
             }
         };
@@ -1914,98 +1285,6 @@ pub enum Event {
 pub enum SlotTy {
     Inbound,
     Outbound,
-}
-
-/// Error that can happen when trying to open an outbound notifications substream.
-#[derive(Debug, Clone, derive_more::Display)]
-pub enum NotificationsOutErr {
-    /// Error in the underlying protocol.
-    #[display(fmt = "{}", _0)]
-    Substream(peers::NotificationsOutErr),
-    /// Mismatch between the genesis hash of the remote and the local genesis hash.
-    #[display(fmt = "Mismatch between the genesis hash of the remote and the local genesis hash")]
-    GenesisMismatch {
-        /// Hash of the genesis block of the chain according to the local node.
-        local_genesis: [u8; 32],
-        /// Hash of the genesis block of the chain according to the remote node.
-        remote_genesis: [u8; 32],
-    },
-}
-
-/// Undecoded but valid block announce handshake.
-pub struct EncodedBlockAnnounceHandshake {
-    handshake: Vec<u8>,
-    block_number_bytes: usize,
-}
-
-impl EncodedBlockAnnounceHandshake {
-    /// Returns the decoded version of the handshake.
-    pub fn decode(&self) -> protocol::BlockAnnouncesHandshakeRef {
-        protocol::decode_block_announces_handshake(self.block_number_bytes, &self.handshake)
-            .unwrap()
-    }
-}
-
-impl fmt::Debug for EncodedBlockAnnounceHandshake {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&self.decode(), f)
-    }
-}
-
-/// Undecoded but valid block announce.
-#[derive(Clone)]
-pub struct EncodedBlockAnnounce {
-    message: Vec<u8>,
-    block_number_bytes: usize,
-}
-
-impl EncodedBlockAnnounce {
-    /// Returns the decoded version of the announcement.
-    pub fn decode(&self) -> protocol::BlockAnnounceRef {
-        protocol::decode_block_announce(&self.message, self.block_number_bytes).unwrap()
-    }
-}
-
-impl fmt::Debug for EncodedBlockAnnounce {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&self.decode(), f)
-    }
-}
-
-/// Undecoded but valid GrandPa commit message.
-#[derive(Clone)]
-pub struct EncodedGrandpaCommitMessage {
-    message: Vec<u8>,
-    block_number_bytes: usize,
-}
-
-impl EncodedGrandpaCommitMessage {
-    /// Returns the encoded bytes of the commit message.
-    pub fn into_encoded(mut self) -> Vec<u8> {
-        // Skip the first byte because `self.message` is a `GrandpaNotificationRef`.
-        self.message.remove(0);
-        self.message
-    }
-
-    /// Returns the encoded bytes of the commit message.
-    pub fn as_encoded(&self) -> &[u8] {
-        // Skip the first byte because `self.message` is a `GrandpaNotificationRef`.
-        &self.message[1..]
-    }
-
-    /// Returns the decoded version of the commit message.
-    pub fn decode(&self) -> protocol::CommitMessageRef {
-        match protocol::decode_grandpa_notification(&self.message, self.block_number_bytes) {
-            Ok(protocol::GrandpaNotificationRef::Commit(msg)) => msg,
-            _ => unreachable!(),
-        }
-    }
-}
-
-impl fmt::Debug for EncodedGrandpaCommitMessage {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&self.decode(), f)
-    }
 }
 
 /// See [`Event::ProtocolError`].

--- a/src/network/service/notifications.rs
+++ b/src/network/service/notifications.rs
@@ -1,0 +1,817 @@
+// Smoldot
+// Copyright (C) 2019-2022  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::libp2p::{
+    peers::{self, QueueNotificationError},
+    PeerId,
+};
+use crate::network::protocol;
+use crate::util;
+
+use alloc::vec::Vec;
+use core::{
+    fmt,
+    ops::{Add, Sub},
+    time::Duration,
+};
+
+pub use crate::libp2p::{
+    collection::{self, ReadWrite},
+    peers::{
+        ConnectionId, ConnectionToCoordinator, CoordinatorToConnection, InRequestId, InboundError,
+        MultiStreamConnectionTask, MultiStreamHandshakeKind, OutRequestId,
+        SingleStreamConnectionTask, SingleStreamHandshakeKind,
+    },
+};
+
+use super::*;
+
+#[derive(Debug, Copy, Clone)]
+// TODO: link to some doc about how GrandPa works: what is a round, what is the set id, etc.
+pub struct GrandpaState {
+    pub round_number: u64,
+    /// Set of authorities that will be used by the node to try finalize the children of the block
+    /// of [`GrandpaState::commit_finalized_height`].
+    pub set_id: u64,
+    /// Height of the highest block considered final by the node.
+    pub commit_finalized_height: u64,
+}
+
+// Update this when a new notifications protocol is added.
+pub(super) const NOTIFICATIONS_PROTOCOLS_PER_CHAIN: usize = 3;
+
+pub(super) fn protocols<'a>(
+    chains: impl Iterator<Item = &'a ChainConfig>,
+) -> Vec<peers::NotificationProtocolConfig> {
+    // The order of protocols here is important, as it defines the values of `protocol_index`
+    // to pass to libp2p or that libp2p produces.
+    chains
+        .flat_map(|chain| {
+            iter::once(peers::NotificationProtocolConfig {
+                protocol_name: format!("/{}/block-announces/1", chain.protocol_id),
+                max_handshake_size: 1024 * 1024, // TODO: arbitrary
+                max_notification_size: 1024 * 1024,
+            })
+            .chain(iter::once(peers::NotificationProtocolConfig {
+                protocol_name: format!("/{}/transactions/1", chain.protocol_id),
+                max_handshake_size: 4,
+                max_notification_size: 16 * 1024 * 1024,
+            }))
+            .chain({
+                // The `has_grandpa_protocol` flag controls whether the chain uses GrandPa.
+                // Note, however, that GrandPa is technically left enabled (but unused) on all
+                // chains, in order to make the rest of the code of this module more
+                // comprehensible.
+                iter::once(peers::NotificationProtocolConfig {
+                    protocol_name: "/paritytech/grandpa/1".to_string(),
+                    max_handshake_size: 4,
+                    max_notification_size: 1024 * 1024,
+                })
+            })
+        })
+        .collect()
+}
+
+impl<TNow> ChainNetwork<TNow>
+where
+    TNow: Clone + Add<Duration, Output = TNow> + Sub<TNow, Output = Duration> + Ord,
+{
+    /// Called when the underlying state machine has generated a
+    /// [`peers::Event::NotificationsOutResult`].
+    pub(super) fn on_notifications_out_result(
+        &mut self,
+        now: &TNow,
+        peer_id: PeerId,
+        notifications_protocol_index: usize,
+        result: Result<Vec<u8>, collection::NotificationsOutErr>,
+    ) -> Option<Event> {
+        match result {
+            // Successfully opened block announces substream.
+            // The block announces substream is the main substream that determines whether
+            // a "chain" is open.
+            Ok(remote_handshake)
+                if notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN == 0 =>
+            {
+                let chain_index = notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
+
+                // Check validity of the handshake.
+                let remote_handshake = match protocol::decode_block_announces_handshake(
+                    self.chains[chain_index].chain_config.block_number_bytes,
+                    &remote_handshake,
+                ) {
+                    Ok(hs) => hs,
+                    Err(err) => {
+                        // TODO: must close the substream and unassigned the slot
+                        return Some(Event::ProtocolError {
+                            error: ProtocolError::BadBlockAnnouncesHandshake(err),
+                            peer_id,
+                        });
+                    }
+                };
+
+                // The desirability of the transactions and grandpa substreams is always equal
+                // to whether the block announces substream is open.
+                self.inner.set_peer_notifications_out_desired(
+                    &peer_id,
+                    chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN + 1,
+                    peers::DesiredState::DesiredReset,
+                );
+                self.inner.set_peer_notifications_out_desired(
+                    &peer_id,
+                    chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN + 2,
+                    peers::DesiredState::DesiredReset,
+                );
+
+                let slot_ty = {
+                    let local_genesis = self.chains[chain_index].chain_config.genesis_hash;
+                    let remote_genesis = *remote_handshake.genesis_hash;
+
+                    if remote_genesis != local_genesis {
+                        let unassigned_slot_ty = self.unassign_slot(chain_index, &peer_id).unwrap();
+
+                        return Some(Event::ChainConnectAttemptFailed {
+                            peer_id,
+                            chain_index,
+                            unassigned_slot_ty,
+                            error: NotificationsOutErr::GenesisMismatch {
+                                local_genesis,
+                                remote_genesis,
+                            },
+                        });
+                    }
+
+                    // Update the k-buckets to mark the peer as connected.
+                    // Note that this is done after having made sure that the handshake
+                    // was correct.
+                    // TODO: should we not insert the entry in the k-buckets as well? seems important for incoming connections
+                    if let Some(mut entry) = self.chains[chain_index]
+                        .kbuckets
+                        .entry(&peer_id)
+                        .into_occupied()
+                    {
+                        entry.set_state(&now, kademlia::kbuckets::PeerState::Connected);
+                    }
+
+                    if self.chains[chain_index].in_peers.contains(&peer_id) {
+                        SlotTy::Inbound
+                    } else {
+                        debug_assert!(self.chains[chain_index].out_peers.contains(&peer_id));
+                        SlotTy::Outbound
+                    }
+                };
+
+                let _was_inserted = self.open_chains.insert((peer_id.clone(), chain_index));
+                debug_assert!(_was_inserted);
+
+                let best_hash = *remote_handshake.best_hash;
+                let best_number = remote_handshake.best_number;
+                let role = remote_handshake.role;
+
+                Some(Event::ChainConnected {
+                    peer_id,
+                    chain_index,
+                    slot_ty,
+                    best_hash,
+                    best_number,
+                    role,
+                })
+            }
+
+            // Successfully opened transactions substream.
+            Ok(_) if notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN == 1 => {
+                // Nothing to do.
+                None
+            }
+
+            // Successfully opened Grandpa substream.
+            // Need to send a Grandpa neighbor packet in response.
+            Ok(_) if notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN == 2 => {
+                let chain_index = notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
+
+                let notification = {
+                    let grandpa_config = *self.chains[chain_index]
+                        .chain_config
+                        .grandpa_protocol_config
+                        .as_ref()
+                        .unwrap();
+
+                    protocol::GrandpaNotificationRef::Neighbor(protocol::NeighborPacket {
+                        round_number: grandpa_config.round_number,
+                        set_id: grandpa_config.set_id,
+                        commit_finalized_height: grandpa_config.commit_finalized_height,
+                    })
+                    .scale_encoding(self.chains[chain_index].chain_config.block_number_bytes)
+                    .fold(Vec::new(), |mut a, b| {
+                        a.extend_from_slice(b.as_ref());
+                        a
+                    })
+                };
+
+                let _ = self.inner.queue_notification(
+                    &peer_id,
+                    notifications_protocol_index,
+                    notification.clone(),
+                );
+
+                None
+            }
+
+            // Failed to open block announces substream.
+            Err(error) if notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN == 0 => {
+                let chain_index = notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
+
+                let unassigned_slot_ty = self.unassign_slot(chain_index, &peer_id).unwrap();
+
+                Some(Event::ChainConnectAttemptFailed {
+                    peer_id,
+                    chain_index,
+                    unassigned_slot_ty,
+                    error: NotificationsOutErr::Substream(error),
+                })
+            }
+
+            // Other protocol.
+            Err(_) => None,
+
+            // Unrecognized protocol.
+            Ok(_) => unreachable!(),
+        }
+    }
+
+    /// Called when the underlying state machine has generated a
+    /// [`peers::Event::NotificationsOutClose`].
+    pub(super) fn on_notifications_out_close(
+        &mut self,
+        now: &TNow,
+        peer_id: PeerId,
+        notifications_protocol_index: usize,
+    ) -> Option<Event> {
+        if notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN == 0 {
+            let chain_index = notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
+
+            // The desirability of the transactions and grandpa substreams is always equal
+            // to whether the block announces substream is open.
+            //
+            // These two calls modify `self.inner`, but they are still cancellation-safe
+            // as they can be repeated multiple times.
+            self.inner.set_peer_notifications_out_desired(
+                &peer_id,
+                chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN + 1,
+                peers::DesiredState::NotDesired,
+            );
+            self.inner.set_peer_notifications_out_desired(
+                &peer_id,
+                chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN + 2,
+                peers::DesiredState::NotDesired,
+            );
+
+            // The chain is now considered as closed.
+            // TODO: can was_open ever be false?
+            let was_open = self.open_chains.remove(&(peer_id.clone(), chain_index)); // TODO: cloning :(
+
+            if was_open {
+                // Update the k-buckets, marking the peer as disconnected.
+                let unassigned_slot_ty = {
+                    let unassigned_slot_ty = self.unassign_slot(chain_index, &peer_id).unwrap();
+
+                    if let Some(mut entry) = self.chains[chain_index]
+                        .kbuckets
+                        .entry(&peer_id)
+                        .into_occupied()
+                    {
+                        // Note that the state might have already be `Disconnected`, which
+                        // can happen for example in case of a problem in the handshake
+                        // sent back by the remote.
+                        entry.set_state(&now, kademlia::kbuckets::PeerState::Disconnected);
+                    }
+
+                    unassigned_slot_ty
+                };
+
+                return Some(Event::ChainDisconnected {
+                    chain_index,
+                    peer_id,
+                    unassigned_slot_ty,
+                });
+            }
+
+            None
+        } else {
+            let chain_index = notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
+
+            // The state of notification substreams other than block announces must
+            // always match the state of the block announces.
+            // Therefore, if the peer is considered open, try to reopen the substream that
+            // has just been closed.
+            // TODO: cloning of peer_id :-/
+            if self.open_chains.contains(&(peer_id.clone(), chain_index)) {
+                self.inner.set_peer_notifications_out_desired(
+                    &peer_id,
+                    notifications_protocol_index,
+                    peers::DesiredState::DesiredReset,
+                );
+            }
+
+            None
+        }
+    }
+
+    /// Called when the underlying state machine has generated a
+    /// [`peers::Event::NotificationsInOpen`].
+    pub(super) fn on_notifications_in_open(
+        &mut self,
+        substream_id: peers::SubstreamId,
+        peer_id: PeerId,
+        notifications_protocol_index: usize,
+        handshake: Vec<u8>,
+    ) -> Option<Event> {
+        if (notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN) == 0 {
+            // Remote wants to open a block announces substream.
+            // The block announces substream is the main substream that determines whether
+            // a "chain" is open.
+            let chain_index = notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
+
+            // Immediately reject the substream if the handshake fails to parse.
+            if let Err(err) = protocol::decode_block_announces_handshake(
+                self.chains[chain_index].chain_config.block_number_bytes,
+                &handshake,
+            ) {
+                self.inner.in_notification_refuse(substream_id);
+
+                return Some(Event::ProtocolError {
+                    error: ProtocolError::BadBlockAnnouncesHandshake(err),
+                    peer_id,
+                });
+            }
+
+            // If the peer doesn't already have an outbound slot, check whether we can
+            // allocate an inbound slot for it.
+            let has_out_slot = self.chains[chain_index].out_peers.contains(&peer_id);
+            if !has_out_slot
+                && self.chains[chain_index].in_peers.len()
+                    >= usize::try_from(self.chains[chain_index].chain_config.in_slots)
+                        .unwrap_or(usize::max_value())
+            {
+                // All in slots are occupied. Refuse the substream.
+                self.inner.in_notification_refuse(substream_id);
+                return None;
+            }
+
+            // At this point, accept the node can no longer fail.
+
+            // Generate the handshake to send back.
+            let handshake = {
+                let chain_config = &self.chains[chain_index].chain_config;
+                protocol::encode_block_announces_handshake(
+                    protocol::BlockAnnouncesHandshakeRef {
+                        best_hash: &chain_config.best_hash,
+                        best_number: chain_config.best_number,
+                        genesis_hash: &chain_config.genesis_hash,
+                        role: chain_config.role,
+                    },
+                    chain_config.block_number_bytes,
+                )
+                .fold(Vec::new(), |mut a, b| {
+                    a.extend_from_slice(b.as_ref());
+                    a
+                })
+            };
+
+            self.inner.in_notification_accept(substream_id, handshake);
+
+            if !has_out_slot {
+                // TODO: future cancellation issue; if this future is cancelled, then trying to do the `in_notification_accept` again next time will panic
+                self.inner.set_peer_notifications_out_desired(
+                    &peer_id,
+                    notifications_protocol_index,
+                    peers::DesiredState::DesiredReset,
+                );
+
+                // The state modification is done at the very end, to not have any
+                // future cancellation issue.
+                let _was_inserted = self.chains[chain_index].in_peers.insert(peer_id.clone());
+                debug_assert!(_was_inserted);
+
+                return Some(Event::InboundSlotAssigned {
+                    chain_index,
+                    peer_id,
+                });
+            }
+        } else if (notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN) == 1 {
+            // Remote wants to open a transactions substream.
+            let chain_index = notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
+
+            // Accept the substream only if the peer is "chain connected".
+            if self
+                .open_chains // TODO: clone :-/
+                .contains(&(peer_id.clone(), chain_index))
+            {
+                self.inner.in_notification_accept(substream_id, Vec::new());
+            } else {
+                self.inner.in_notification_refuse(substream_id);
+            }
+        } else if (notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN) == 2 {
+            // Remote wants to open a grandpa substream.
+            let chain_index = notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
+
+            // Reject the substream if the this peer isn't "chain connected".
+            if !self
+                .open_chains // TODO: clone :-/
+                .contains(&(peer_id.clone(), chain_index))
+            {
+                self.inner.in_notification_refuse(substream_id);
+                return None;
+            }
+
+            // Peer is indeed connected. Accept the substream.
+
+            // Build the handshake to send back.
+            let handshake = {
+                self.chains[chain_index]
+                    .chain_config
+                    .role
+                    .scale_encoding()
+                    .to_vec()
+            };
+
+            self.inner.in_notification_accept(substream_id, handshake);
+        } else {
+            // Unrecognized notifications protocol.
+            unreachable!();
+        }
+
+        None
+    }
+
+    /// Called when the underlying state machine has generated a
+    /// [`peers::Event::NotificationsInClose`].
+    pub(super) fn on_notifications_in_close(
+        &mut self,
+        peer_id: PeerId,
+        notifications_protocol_index: usize,
+    ) -> Option<Event> {
+        if notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN == 0 {
+            // Remote closes a block announce substream.
+            let chain_index = notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
+
+            // We unassign the inbound slot of the peer if it had one.
+            // If the peer had an outbound slot, then this does nothing.
+            if self.chains[chain_index].in_peers.remove(&peer_id) {
+                self.inner.set_peer_notifications_out_desired(
+                    &peer_id,
+                    notifications_protocol_index,
+                    peers::DesiredState::NotDesired,
+                );
+            }
+        }
+
+        None
+    }
+
+    /// Called when the underlying state machine has generated a
+    /// [`peers::Event::NotificationsInOpenCancel`].
+    pub(super) fn on_notifications_in_open_cancel(
+        &mut self,
+        _id: peers::SubstreamId,
+    ) -> Option<Event> {
+        // Because we always accept/refuse incoming notification substreams instantly,
+        // there's no possibility for a cancellation to happen.
+        unreachable!()
+    }
+
+    /// Called when the underlying state machine has generated a [`peers::Event::NotificationsIn`].
+    pub(super) fn on_notification_in(
+        &mut self,
+        peer_id: PeerId,
+        notifications_protocol_index: usize,
+        notification: Vec<u8>,
+    ) -> Option<Event> {
+        if notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN == 0 {
+            let chain_index = notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
+
+            // Don't report events about nodes we don't have an outbound substream with.
+            // TODO: think about possible race conditions regarding missing block
+            // announcements, as the remote will think we know it's at a certain block
+            // while we ignored its announcement ; it isn't problematic as long as blocks
+            // are generated continuously, as announcements will be generated periodically
+            // as well and the state will no longer mismatch
+            // TODO: cloning of peer_id :(
+            if !self.open_chains.contains(&(peer_id.clone(), chain_index)) {
+                return None;
+            }
+
+            let block_number_bytes = self.chains[chain_index].chain_config.block_number_bytes;
+
+            // Check the format of the block announce.
+            if let Err(err) = protocol::decode_block_announce(&notification, block_number_bytes) {
+                return Some(Event::ProtocolError {
+                    error: ProtocolError::BadBlockAnnounce(err),
+                    peer_id,
+                });
+            }
+
+            Some(Event::BlockAnnounce {
+                chain_index,
+                peer_id,
+                announce: EncodedBlockAnnounce {
+                    message: notification,
+                    block_number_bytes,
+                },
+            })
+        } else if notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN == 1 {
+            let chain_index = notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
+
+            // Don't report events about nodes we don't have an outbound substream with.
+            // TODO: cloning of peer_id :(
+            if !self.open_chains.contains(&(peer_id.clone(), chain_index)) {
+                return None;
+            }
+
+            // TODO: this is unimplemented
+            None
+        } else if notifications_protocol_index % NOTIFICATIONS_PROTOCOLS_PER_CHAIN == 2 {
+            let chain_index = notifications_protocol_index / NOTIFICATIONS_PROTOCOLS_PER_CHAIN;
+            let block_number_bytes = self.chains[chain_index].chain_config.block_number_bytes;
+
+            // Don't report events about nodes we don't have an outbound substream with.
+            // TODO: cloning of peer_id :(
+            if !self.open_chains.contains(&(peer_id.clone(), chain_index)) {
+                return None;
+            }
+
+            let decoded_notif =
+                match protocol::decode_grandpa_notification(&notification, block_number_bytes) {
+                    Ok(n) => n,
+                    Err(err) => {
+                        return Some(Event::ProtocolError {
+                            error: ProtocolError::BadGrandpaNotification(err),
+                            peer_id,
+                        })
+                    }
+                };
+
+            // Commit messages are the only type of message that is important for
+            // light clients. Anything else is presently ignored.
+            if let protocol::GrandpaNotificationRef::Commit(_) = decoded_notif {
+                Some(Event::GrandpaCommitMessage {
+                    chain_index,
+                    peer_id,
+                    message: EncodedGrandpaCommitMessage {
+                        message: notification,
+                        block_number_bytes,
+                    },
+                })
+            } else {
+                None
+            }
+        } else {
+            // Unrecognized notifications protocol.
+            unreachable!();
+        }
+    }
+
+    /// Modifies the best block of the local node. See [`ChainConfig::best_hash`] and
+    /// [`ChainConfig::best_number`].
+    ///
+    /// # Panic
+    ///
+    /// Panics if `chain_index` is out of range.
+    ///
+    pub fn set_local_best_block(
+        &mut self,
+        chain_index: usize,
+        best_hash: [u8; 32],
+        best_number: u64,
+    ) {
+        let mut config = &mut self.chains[chain_index].chain_config;
+        config.best_hash = best_hash;
+        config.best_number = best_number;
+    }
+
+    /// Update the state of the local node with regards to GrandPa rounds.
+    ///
+    /// Calling this method does two things:
+    ///
+    /// - Send on all the active GrandPa substreams a "neighbor packet" indicating the state of
+    ///   the local node.
+    /// - Update the neighbor packet that is automatically sent to peers when a GrandPa substream
+    ///   gets opened.
+    ///
+    /// In other words, calling this function atomically informs all the present and future peers
+    /// of the state of the local node regarding the GrandPa protocol.
+    ///
+    /// > **Note**: The information passed as parameter isn't validated in any way by this method.
+    ///
+    /// This function might generate a message destined to connections. Use
+    /// [`ChainNetwork::pull_message_to_connection`] to process these messages after it has
+    /// returned.
+    ///
+    /// # Panic
+    ///
+    /// Panics if `chain_index` is out of range, or if the chain has GrandPa disabled.
+    ///
+    pub fn set_local_grandpa_state(&mut self, chain_index: usize, grandpa_state: GrandpaState) {
+        // Bytes of the neighbor packet to send out.
+        let packet = protocol::GrandpaNotificationRef::Neighbor(protocol::NeighborPacket {
+            round_number: grandpa_state.round_number,
+            set_id: grandpa_state.set_id,
+            commit_finalized_height: grandpa_state.commit_finalized_height,
+        })
+        .scale_encoding(self.chains[chain_index].chain_config.block_number_bytes)
+        .fold(Vec::new(), |mut a, b| {
+            a.extend_from_slice(b.as_ref());
+            a
+        });
+
+        // Now sending out.
+        let _ = self
+            .inner
+            .broadcast_notification(chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN + 2, packet);
+
+        // Update the locally-stored state, but only after the notification has been broadcasted.
+        // This way, if the user cancels the future while `broadcast_notification` is executing,
+        // the whole operation is cancelled.
+        *self.chains[chain_index]
+            .chain_config
+            .grandpa_protocol_config
+            .as_mut()
+            .unwrap() = grandpa_state;
+    }
+
+    ///
+    /// This function might generate a message destined a connection. Use
+    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
+    // TODO: there this extra parameter in block announces that is unused on many chains but not always
+    pub fn send_block_announce(
+        &mut self,
+        target: &PeerId,
+        chain_index: usize,
+        scale_encoded_header: &[u8],
+        is_best: bool,
+    ) -> Result<(), QueueNotificationError> {
+        let buffers_to_send = protocol::encode_block_announce(protocol::BlockAnnounceRef {
+            scale_encoded_header,
+            is_best,
+        });
+
+        let notification = buffers_to_send.fold(Vec::new(), |mut a, b| {
+            a.extend_from_slice(b.as_ref());
+            a
+        });
+
+        self.inner.queue_notification(
+            target,
+            chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN,
+            notification,
+        )
+    }
+
+    /// Returns `true` if it is allowed to call [`ChainNetwork::send_block_announce`], in other
+    /// words if there is an outbound block announces substream currently open with the target.
+    ///
+    /// If this function returns `false`, calling [`ChainNetwork::send_block_announce`] will
+    /// panic.
+    pub fn can_send_block_announces(&self, target: &PeerId, chain_index: usize) -> bool {
+        self.inner
+            .can_queue_notification(target, chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN)
+    }
+
+    /// Returns the list of peers for which we have a fully established notifications protocol of
+    /// the given protocol.
+    pub fn opened_transactions_substream(
+        &'_ self,
+        chain_index: usize,
+    ) -> impl Iterator<Item = &'_ PeerId> + '_ {
+        self.inner
+            .opened_out_notifications(chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN + 1)
+    }
+
+    ///
+    ///
+    /// Must be passed the SCALE-encoded transaction.
+    ///
+    /// This function might generate a message destined connections. Use
+    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
+    // TODO: -> broadcast_transaction
+    pub fn announce_transaction(
+        &mut self,
+        target: &PeerId,
+        chain_index: usize,
+        extrinsic: &[u8],
+    ) -> Result<(), QueueNotificationError> {
+        let mut val = Vec::with_capacity(1 + extrinsic.len());
+        val.extend_from_slice(util::encode_scale_compact_usize(1).as_ref());
+        val.extend_from_slice(extrinsic);
+        self.inner.queue_notification(
+            target,
+            chain_index * NOTIFICATIONS_PROTOCOLS_PER_CHAIN + 1,
+            val,
+        )
+    }
+}
+
+/// Error that can happen when trying to open an outbound notifications substream.
+#[derive(Debug, Clone, derive_more::Display)]
+pub enum NotificationsOutErr {
+    /// Error in the underlying protocol.
+    #[display(fmt = "{}", _0)]
+    Substream(peers::NotificationsOutErr),
+    /// Mismatch between the genesis hash of the remote and the local genesis hash.
+    #[display(fmt = "Mismatch between the genesis hash of the remote and the local genesis hash")]
+    GenesisMismatch {
+        /// Hash of the genesis block of the chain according to the local node.
+        local_genesis: [u8; 32],
+        /// Hash of the genesis block of the chain according to the remote node.
+        remote_genesis: [u8; 32],
+    },
+}
+
+/// Undecoded but valid block announce handshake.
+pub struct EncodedBlockAnnounceHandshake {
+    handshake: Vec<u8>,
+    block_number_bytes: usize,
+}
+
+impl EncodedBlockAnnounceHandshake {
+    /// Returns the decoded version of the handshake.
+    pub fn decode(&self) -> protocol::BlockAnnouncesHandshakeRef {
+        protocol::decode_block_announces_handshake(self.block_number_bytes, &self.handshake)
+            .unwrap()
+    }
+}
+
+impl fmt::Debug for EncodedBlockAnnounceHandshake {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.decode(), f)
+    }
+}
+
+/// Undecoded but valid block announce.
+#[derive(Clone)]
+pub struct EncodedBlockAnnounce {
+    message: Vec<u8>,
+    block_number_bytes: usize,
+}
+
+impl EncodedBlockAnnounce {
+    /// Returns the decoded version of the announcement.
+    pub fn decode(&self) -> protocol::BlockAnnounceRef {
+        protocol::decode_block_announce(&self.message, self.block_number_bytes).unwrap()
+    }
+}
+
+impl fmt::Debug for EncodedBlockAnnounce {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.decode(), f)
+    }
+}
+
+/// Undecoded but valid GrandPa commit message.
+#[derive(Clone)]
+pub struct EncodedGrandpaCommitMessage {
+    message: Vec<u8>,
+    block_number_bytes: usize,
+}
+
+impl EncodedGrandpaCommitMessage {
+    /// Returns the encoded bytes of the commit message.
+    pub fn into_encoded(mut self) -> Vec<u8> {
+        // Skip the first byte because `self.message` is a `GrandpaNotificationRef`.
+        self.message.remove(0);
+        self.message
+    }
+
+    /// Returns the encoded bytes of the commit message.
+    pub fn as_encoded(&self) -> &[u8] {
+        // Skip the first byte because `self.message` is a `GrandpaNotificationRef`.
+        &self.message[1..]
+    }
+
+    /// Returns the decoded version of the commit message.
+    pub fn decode(&self) -> protocol::CommitMessageRef {
+        match protocol::decode_grandpa_notification(&self.message, self.block_number_bytes) {
+            Ok(protocol::GrandpaNotificationRef::Commit(msg)) => msg,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl fmt::Debug for EncodedGrandpaCommitMessage {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.decode(), f)
+    }
+}

--- a/src/network/service/requests_responses.rs
+++ b/src/network/service/requests_responses.rs
@@ -1,0 +1,1172 @@
+// Smoldot
+// Copyright (C) 2019-2022  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::header;
+use crate::libp2p::{
+    multiaddr, peer_id,
+    peers::{self, ConfigRequestResponse},
+    PeerId,
+};
+use crate::network::{kademlia, protocol};
+
+use super::*;
+
+use alloc::{format, vec::Vec};
+use core::{
+    fmt,
+    hash::Hash,
+    iter,
+    num::NonZeroUsize,
+    ops::{Add, Sub},
+    time::Duration,
+};
+
+pub use crate::libp2p::{
+    collection::ReadWrite,
+    peers::{
+        ConnectionId, ConnectionToCoordinator, CoordinatorToConnection, InRequestId, InboundError,
+        MultiStreamConnectionTask, MultiStreamHandshakeKind, OutRequestId,
+        SingleStreamConnectionTask, SingleStreamHandshakeKind,
+    },
+};
+
+/// Identifier for a Kademlia iterative query.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct KademliaOperationId(pub(super) u64);
+
+// Update this when a new request response protocol is added.
+pub(super) const REQUEST_RESPONSE_PROTOCOLS_PER_CHAIN: usize = 5;
+
+pub(super) fn protocols<'a>(
+    chains: impl Iterator<Item = &'a ChainConfig>,
+) -> Vec<ConfigRequestResponse> {
+    // The order of protocols here is important, as it defines the values of `protocol_index`
+    // to pass to libp2p or that libp2p produces.
+    iter::once(peers::ConfigRequestResponse {
+        name: "/ipfs/id/1.0.0".into(),
+        inbound_config: peers::ConfigRequestResponseIn::Empty,
+        max_response_size: 4096,
+        inbound_allowed: true,
+    })
+    .chain(chains.flat_map(|chain| {
+        // TODO: limits are arbitrary
+        iter::once(peers::ConfigRequestResponse {
+            name: format!("/{}/sync/2", chain.protocol_id),
+            inbound_config: peers::ConfigRequestResponseIn::Payload { max_size: 1024 },
+            max_response_size: 16 * 1024 * 1024,
+            inbound_allowed: chain.allow_inbound_block_requests,
+        })
+        .chain(iter::once(peers::ConfigRequestResponse {
+            name: format!("/{}/light/2", chain.protocol_id),
+            inbound_config: peers::ConfigRequestResponseIn::Payload {
+                max_size: 1024 * 512,
+            },
+            max_response_size: 10 * 1024 * 1024,
+            // TODO: make this configurable
+            inbound_allowed: false,
+        }))
+        .chain(iter::once(peers::ConfigRequestResponse {
+            name: format!("/{}/kad", chain.protocol_id),
+            inbound_config: peers::ConfigRequestResponseIn::Payload { max_size: 1024 },
+            max_response_size: 1024 * 1024,
+            // TODO: `false` here means we don't insert ourselves in the DHT, which is the polite thing to do for as long as Kad isn't implemented
+            inbound_allowed: false,
+        }))
+        .chain(iter::once(peers::ConfigRequestResponse {
+            name: format!("/{}/sync/warp", chain.protocol_id),
+            inbound_config: peers::ConfigRequestResponseIn::Payload { max_size: 32 },
+            max_response_size: 16 * 1024 * 1024,
+            // We don't support inbound warp sync requests (yet).
+            inbound_allowed: false,
+        }))
+        .chain(iter::once(peers::ConfigRequestResponse {
+            name: format!("/{}/state/2", chain.protocol_id),
+            inbound_config: peers::ConfigRequestResponseIn::Payload { max_size: 1024 },
+            // The sender tries to cap the response to 2MiB. However, if one storage item
+            // is larger than 2MiB, the response is allowed to be bigger, as otherwise it
+            // wouldn't be possible to make progress.
+            max_response_size: 16 * 1024 * 1024,
+            // We don't support inbound state requests (yet).
+            inbound_allowed: false,
+        }))
+    }))
+    .collect()
+}
+
+impl<TNow> ChainNetwork<TNow>
+where
+    TNow: Clone + Add<Duration, Output = TNow> + Sub<TNow, Output = Duration> + Ord,
+{
+    /// Called when the underlying state machine has generated a [`peers::Event::Response`].
+    pub(super) fn on_response(
+        &mut self,
+        request_id: peers::OutRequestId,
+        response: Result<Vec<u8>, peers::RequestError>,
+    ) -> Event {
+        match self.out_requests_types.remove(&request_id).unwrap() {
+            (OutRequestTy::Blocks { checked }, chain_index) => {
+                let mut response =
+                    response
+                        .map_err(BlocksRequestError::Request)
+                        .and_then(|payload| {
+                            protocol::decode_block_response(&payload)
+                                .map_err(BlocksRequestError::Decode)
+                        });
+
+                if let (Some(config), &mut Ok(ref mut blocks)) = (checked, &mut response) {
+                    if let Err(err) = check_blocks_response(
+                        self.chains[chain_index].chain_config.block_number_bytes,
+                        config,
+                        blocks,
+                    ) {
+                        response = Err(err);
+                    }
+                }
+
+                Event::RequestResult {
+                    request_id,
+                    response: RequestResult::Blocks(response),
+                }
+            }
+            (OutRequestTy::GrandpaWarpSync, chain_index) => {
+                let block_number_bytes = self.chains[chain_index].chain_config.block_number_bytes;
+
+                let response = response
+                    .map_err(GrandpaWarpSyncRequestError::Request)
+                    .and_then(|message| {
+                        if let Err(err) = protocol::decode_grandpa_warp_sync_response(
+                            &message,
+                            block_number_bytes,
+                        ) {
+                            Err(GrandpaWarpSyncRequestError::Decode(err))
+                        } else {
+                            Ok(EncodedGrandpaWarpSyncResponse {
+                                message,
+                                block_number_bytes,
+                            })
+                        }
+                    });
+
+                Event::RequestResult {
+                    request_id,
+                    response: RequestResult::GrandpaWarpSync(response),
+                }
+            }
+            (OutRequestTy::State, _) => {
+                let response = response
+                    .map_err(StateRequestError::Request)
+                    .and_then(|payload| {
+                        if let Err(err) = protocol::decode_state_response(&payload) {
+                            Err(StateRequestError::Decode(err))
+                        } else {
+                            Ok(EncodedStateResponse(payload))
+                        }
+                    });
+
+                Event::RequestResult {
+                    request_id,
+                    response: RequestResult::State(response),
+                }
+            }
+            (OutRequestTy::StorageProof, _) => {
+                let response = response
+                    .map_err(StorageProofRequestError::Request)
+                    .and_then(|payload| {
+                        if let Err(err) = protocol::decode_storage_or_call_proof_response(
+                            protocol::StorageOrCallProof::StorageProof,
+                            &payload,
+                        ) {
+                            Err(StorageProofRequestError::Decode(err))
+                        } else {
+                            Ok(EncodedMerkleProof(
+                                payload,
+                                protocol::StorageOrCallProof::StorageProof,
+                            ))
+                        }
+                    });
+
+                Event::RequestResult {
+                    request_id,
+                    response: RequestResult::StorageProof(response),
+                }
+            }
+            (OutRequestTy::CallProof, _) => {
+                let response =
+                    response
+                        .map_err(CallProofRequestError::Request)
+                        .and_then(|payload| {
+                            if let Err(err) = protocol::decode_storage_or_call_proof_response(
+                                protocol::StorageOrCallProof::CallProof,
+                                &payload,
+                            ) {
+                                Err(CallProofRequestError::Decode(err))
+                            } else {
+                                Ok(EncodedMerkleProof(
+                                    payload,
+                                    protocol::StorageOrCallProof::CallProof,
+                                ))
+                            }
+                        });
+
+                Event::RequestResult {
+                    request_id,
+                    response: RequestResult::CallProof(response),
+                }
+            }
+            (OutRequestTy::KademliaFindNode, _) => {
+                let response = response
+                    .map_err(KademliaFindNodeError::RequestFailed)
+                    .and_then(|payload| {
+                        protocol::decode_find_node_response(&payload)
+                            .map_err(KademliaFindNodeError::DecodeError)
+                    });
+
+                Event::RequestResult {
+                    request_id,
+                    response: RequestResult::KademliaFindNode(response),
+                }
+            }
+            (OutRequestTy::KademliaDiscoveryFindNode(operation_id), _) => {
+                let result = response
+                    .map_err(KademliaFindNodeError::RequestFailed)
+                    .and_then(|payload| {
+                        protocol::decode_find_node_response(&payload)
+                            .map_err(KademliaFindNodeError::DecodeError)
+                    })
+                    .map_err(DiscoveryError::FindNode);
+
+                Event::KademliaDiscoveryResult {
+                    operation_id,
+                    result,
+                }
+            }
+        }
+    }
+
+    /// Called when the underlying state machine has generated a [`peers::Event::RequestIn`].
+    pub(super) fn on_request_in(
+        &mut self,
+        request_id: InRequestId,
+        peer_id: PeerId,
+        connection_id: ConnectionId,
+        protocol_index: usize,
+        request_payload: Vec<u8>,
+    ) -> Event {
+        if protocol_index == 0 {
+            if request_payload.is_empty() {
+                let observed_addr = self.inner[connection_id].clone();
+                let _prev_value = self
+                    .in_requests_types
+                    .insert(request_id, InRequestTy::Identify { observed_addr });
+                debug_assert!(_prev_value.is_none());
+
+                Event::IdentifyRequestIn {
+                    peer_id,
+                    request_id,
+                }
+            } else {
+                let _ = self.inner.respond_in_request(request_id, Err(()));
+                Event::ProtocolError {
+                    peer_id,
+                    error: ProtocolError::BadIdentifyRequest,
+                }
+            }
+        } else if ((protocol_index - 1) % requests_responses::REQUEST_RESPONSE_PROTOCOLS_PER_CHAIN)
+            != 0
+        {
+            // Protocols that receive requests are whitelisted, meaning that no other protocol
+            // indices can reach here.
+            unreachable!()
+        } else {
+            let chain_index =
+                (protocol_index - 1) / requests_responses::REQUEST_RESPONSE_PROTOCOLS_PER_CHAIN;
+
+            match protocol::decode_block_request(
+                self.chains[chain_index].chain_config.block_number_bytes,
+                &request_payload,
+            ) {
+                Ok(config) => {
+                    let _prev_value = self
+                        .in_requests_types
+                        .insert(request_id, InRequestTy::Blocks);
+                    debug_assert!(_prev_value.is_none());
+
+                    Event::BlocksRequestIn {
+                        peer_id,
+                        chain_index,
+                        config,
+                        request_id,
+                    }
+                }
+                Err(error) => {
+                    let _ = self.inner.respond_in_request(request_id, Err(()));
+                    Event::ProtocolError {
+                        peer_id,
+                        error: ProtocolError::BadBlocksRequest(error),
+                    }
+                }
+            }
+        }
+    }
+
+    /// Called when the underlying state machine has generated a [`peers::Event::RequestInCancel`].
+    pub(super) fn on_request_in_cancel(&mut self, id: InRequestId) -> Event {
+        self.in_requests_types.remove(&id).unwrap();
+        Event::RequestInCancel { request_id: id }
+    }
+
+    /// Sends a blocks request to the given peer.
+    ///
+    /// This function might generate a message destined a connection. Use
+    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
+    // TODO: more docs
+    pub fn start_blocks_request(
+        &mut self,
+        now: TNow,
+        target: &PeerId,
+        chain_index: usize,
+        config: protocol::BlocksRequestConfig,
+        timeout: Duration,
+    ) -> OutRequestId {
+        self.start_blocks_request_inner(now, target, chain_index, config, timeout, true)
+    }
+
+    /// Sends a blocks request to the given peer.
+    ///
+    /// This function might generate a message destined a connection. Use
+    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
+    // TODO: more docs
+    pub fn start_blocks_request_unchecked(
+        &mut self,
+        now: TNow,
+        target: &PeerId,
+        chain_index: usize,
+        config: protocol::BlocksRequestConfig,
+        timeout: Duration,
+    ) -> OutRequestId {
+        self.start_blocks_request_inner(now, target, chain_index, config, timeout, false)
+    }
+
+    fn start_blocks_request_inner(
+        &mut self,
+        now: TNow,
+        target: &PeerId,
+        chain_index: usize,
+        config: protocol::BlocksRequestConfig,
+        timeout: Duration,
+        checked: bool,
+    ) -> OutRequestId {
+        let request_data = protocol::build_block_request(
+            self.chains[chain_index].chain_config.block_number_bytes,
+            &config,
+        )
+        .fold(Vec::new(), |mut a, b| {
+            a.extend_from_slice(b.as_ref());
+            a
+        });
+
+        let id = self.inner.start_request(
+            target,
+            self.protocol_index(chain_index, 0),
+            request_data,
+            now + timeout,
+        );
+
+        let _prev_value = self.out_requests_types.insert(
+            id,
+            (
+                OutRequestTy::Blocks {
+                    checked: if checked { Some(config) } else { None },
+                },
+                chain_index,
+            ),
+        );
+        debug_assert!(_prev_value.is_none());
+
+        id
+    }
+
+    ///
+    /// This function might generate a message destined a connection. Use
+    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
+    pub fn start_grandpa_warp_sync_request(
+        &mut self,
+        now: TNow,
+        target: &PeerId,
+        chain_index: usize,
+        begin_hash: [u8; 32],
+        timeout: Duration,
+    ) -> OutRequestId {
+        let request_data = begin_hash.to_vec();
+
+        let id = self.inner.start_request(
+            target,
+            self.protocol_index(chain_index, 3),
+            request_data,
+            now + timeout,
+        );
+
+        let _prev_value = self
+            .out_requests_types
+            .insert(id, (OutRequestTy::GrandpaWarpSync, chain_index));
+        debug_assert!(_prev_value.is_none());
+
+        id
+    }
+
+    /// Sends a state request to a peer.
+    ///
+    /// A state request makes it possible to download the storage of the chain at a given block.
+    /// The response is not unverified by this function. In other words, the peer is free to send
+    /// back erroneous data. It is the responsibility of the API user to verify the storage by
+    /// calculating the state trie root hash and comparing it with the value stored in the
+    /// block's header.
+    ///
+    /// Because response have a size limit, it is unlikely that a single request will return the
+    /// entire storage of the chain at once. Instead, call this function multiple times, each call
+    /// passing a `start_key` that follows the last key of the previous response.
+    ///
+    /// This function might generate a message destined a connection. Use
+    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
+    pub fn start_state_request(
+        &mut self,
+        now: TNow,
+        target: &PeerId,
+        chain_index: usize,
+        block_hash: &[u8; 32],
+        start_key: protocol::StateRequestStart,
+        timeout: Duration,
+    ) -> OutRequestId {
+        let request_data = protocol::build_state_request(protocol::StateRequest {
+            block_hash,
+            start_key,
+        })
+        .fold(Vec::new(), |mut a, b| {
+            a.extend_from_slice(b.as_ref());
+            a
+        });
+
+        let id = self.inner.start_request(
+            target,
+            self.protocol_index(chain_index, 4),
+            request_data,
+            now + timeout,
+        );
+
+        let _prev_value = self
+            .out_requests_types
+            .insert(id, (OutRequestTy::State, chain_index));
+        debug_assert!(_prev_value.is_none());
+
+        id
+    }
+
+    /// Sends a storage request to the given peer.
+    ///
+    /// This function might generate a message destined a connection. Use
+    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
+    // TODO: more docs
+    pub fn start_storage_proof_request(
+        &mut self,
+        now: TNow,
+        target: &PeerId,
+        chain_index: usize,
+        config: protocol::StorageProofRequestConfig<impl Iterator<Item = impl AsRef<[u8]> + Clone>>,
+        timeout: Duration,
+    ) -> OutRequestId {
+        let request_data =
+            protocol::build_storage_proof_request(config).fold(Vec::new(), |mut a, b| {
+                a.extend_from_slice(b.as_ref());
+                a
+            });
+
+        let id = self.inner.start_request(
+            target,
+            self.protocol_index(chain_index, 1),
+            request_data,
+            now + timeout,
+        );
+
+        let _prev_value = self
+            .out_requests_types
+            .insert(id, (OutRequestTy::StorageProof, chain_index));
+        debug_assert!(_prev_value.is_none());
+
+        id
+    }
+
+    /// Sends a call proof request to the given peer.
+    ///
+    /// This request is similar to [`ChainNetwork::start_storage_proof_request`]. Instead of
+    /// requesting specific keys, we request the list of all the keys that are accessed for a
+    /// specific runtime call.
+    ///
+    /// There exists no guarantee that the proof is complete (i.e. that it contains all the
+    /// necessary entries), as it is impossible to know this from just the proof itself. As such,
+    /// this method is just an optimization. When performing the actual call, regular storage proof
+    /// requests should be performed if the key is not present in the call proof response.
+    ///
+    /// This function might generate a message destined a connection. Use
+    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
+    pub fn start_call_proof_request(
+        &mut self,
+        now: TNow,
+        target: &PeerId,
+        chain_index: usize,
+        config: protocol::CallProofRequestConfig<'_, impl Iterator<Item = impl AsRef<[u8]>>>,
+        timeout: Duration,
+    ) -> OutRequestId {
+        let request_data =
+            protocol::build_call_proof_request(config).fold(Vec::new(), |mut a, b| {
+                a.extend_from_slice(b.as_ref());
+                a
+            });
+
+        let id = self.inner.start_request(
+            target,
+            self.protocol_index(chain_index, 1),
+            request_data,
+            now + timeout,
+        );
+
+        let _prev_value = self
+            .out_requests_types
+            .insert(id, (OutRequestTy::CallProof, chain_index));
+        debug_assert!(_prev_value.is_none());
+
+        id
+    }
+
+    /// Inserts the given list of nodes into the list of known nodes held within the state machine.
+    pub fn discover(
+        &mut self,
+        now: &TNow,
+        chain_index: usize,
+        peer_id: PeerId,
+        discovered_addrs: impl IntoIterator<Item = multiaddr::Multiaddr>,
+    ) {
+        let kbuckets = &mut self.chains[chain_index].kbuckets;
+
+        let mut discovered_addrs = discovered_addrs.into_iter().peekable();
+
+        // Check whether there is any address in the iterator at all before inserting the
+        // node in the buckets.
+        if discovered_addrs.peek().is_none() {
+            return;
+        }
+
+        let kbuckets_peer = match kbuckets.entry(&peer_id) {
+            kademlia::kbuckets::Entry::LocalKey => return, // TODO: return some diagnostic?
+            kademlia::kbuckets::Entry::Vacant(entry) => {
+                match entry.insert((), now, kademlia::kbuckets::PeerState::Disconnected) {
+                    Err(kademlia::kbuckets::InsertError::Full) => return, // TODO: return some diagnostic?
+                    Ok((_, removed_entry)) => {
+                        // `removed_entry` is the peer that was removed the k-buckets as the
+                        // result of the new insertion. Purge it from `self.kbuckets_peers`
+                        // if necessary.
+                        if let Some((removed_peer_id, _)) = removed_entry {
+                            match self.kbuckets_peers.entry(removed_peer_id) {
+                                hashbrown::hash_map::Entry::Occupied(e)
+                                    if e.get().num_references.get() == 1 =>
+                                {
+                                    e.remove();
+                                }
+                                hashbrown::hash_map::Entry::Occupied(e) => {
+                                    let num_refs = &mut e.into_mut().num_references;
+                                    *num_refs = NonZeroUsize::new(num_refs.get() - 1).unwrap();
+                                }
+                                hashbrown::hash_map::Entry::Vacant(_) => unreachable!(),
+                            }
+                        }
+
+                        match self.kbuckets_peers.entry(peer_id) {
+                            hashbrown::hash_map::Entry::Occupied(e) => {
+                                let e = e.into_mut();
+                                e.num_references = e.num_references.checked_add(1).unwrap();
+                                e
+                            }
+                            hashbrown::hash_map::Entry::Vacant(e) => {
+                                // The peer was not in the k-buckets, but it is possible that
+                                // we already have existing connections to it.
+                                let mut addresses = addresses::Addresses::with_capacity(
+                                    self.max_addresses_per_peer.get(),
+                                );
+
+                                for connection_id in
+                                    self.inner.established_peer_connections(&e.key())
+                                {
+                                    let state = self.inner.connection_state(connection_id);
+                                    debug_assert!(state.established);
+                                    // Because we mark addresses as disconnected when the
+                                    // shutdown process starts, we ignore shutting down
+                                    // connections.
+                                    if state.shutting_down {
+                                        continue;
+                                    }
+                                    if state.outbound {
+                                        addresses
+                                            .insert_discovered(self.inner[connection_id].clone());
+                                        addresses.set_connected(&self.inner[connection_id]);
+                                    }
+                                }
+
+                                for connection_id in
+                                    self.inner.handshaking_peer_connections(&e.key())
+                                {
+                                    let state = self.inner.connection_state(connection_id);
+                                    debug_assert!(!state.established);
+                                    debug_assert!(state.outbound);
+                                    // Because we mark addresses as disconnected when the
+                                    // shutdown process starts, we ignore shutting down
+                                    // connections.
+                                    if state.shutting_down {
+                                        continue;
+                                    }
+                                    addresses.insert_discovered(self.inner[connection_id].clone());
+                                    addresses.set_pending(&self.inner[connection_id]);
+                                }
+
+                                // TODO: O(n)
+                                for (_, (p, addr, _)) in &self.pending_ids {
+                                    if p == e.key() {
+                                        addresses.insert_discovered(addr.clone());
+                                        addresses.set_pending(addr);
+                                    }
+                                }
+
+                                e.insert(KBucketsPeer {
+                                    num_references: NonZeroUsize::new(1).unwrap(),
+                                    addresses,
+                                })
+                            }
+                        }
+                    }
+                }
+            }
+            kademlia::kbuckets::Entry::Occupied(_) => {
+                self.kbuckets_peers.get_mut(&peer_id).unwrap()
+            }
+        };
+
+        for to_insert in discovered_addrs {
+            if kbuckets_peer.addresses.len() >= self.max_addresses_per_peer.get() {
+                continue;
+            }
+
+            kbuckets_peer.addresses.insert_discovered(to_insert);
+        }
+
+        // List of addresses must never be empty.
+        debug_assert!(!kbuckets_peer.addresses.is_empty());
+    }
+
+    /// Performs a round of Kademlia discovery.
+    ///
+    /// This future yields once a list of nodes on the network has been discovered, or a problem
+    /// happened.
+    ///
+    /// This function might generate a message destined a connection. Use
+    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
+    pub fn start_kademlia_discovery_round(
+        &'_ mut self,
+        now: TNow,
+        chain_index: usize,
+    ) -> KademliaOperationId {
+        let random_peer_id = {
+            let pub_key = self.randomness.sample(rand::distributions::Standard);
+            PeerId::from_public_key(&peer_id::PublicKey::Ed25519(pub_key))
+        };
+
+        let queried_peer = {
+            let peer_id = self.chains[chain_index]
+                .kbuckets
+                .closest_entries(&random_peer_id)
+                // TODO: instead of filtering by connectd only, connect to nodes if not connected
+                // TODO: additionally, this only takes outgoing connections into account
+                .find(|(peer_id, _)| {
+                    self.kbuckets_peers
+                        .get(peer_id)
+                        .unwrap()
+                        .addresses
+                        .iter_connected()
+                        .next()
+                        .is_some()
+                })
+                .map(|(peer_id, _)| peer_id.clone());
+            peer_id
+        };
+
+        let kademlia_operation_id = self.next_kademlia_operation_id;
+        self.next_kademlia_operation_id.0 += 1;
+
+        if let Some(queried_peer) = queried_peer {
+            debug_assert!(self
+                .inner
+                .established_peer_connections(&queried_peer)
+                .any(|cid| !self.inner.connection_state(cid).shutting_down));
+
+            self.start_kademlia_find_node_inner(
+                &queried_peer,
+                now,
+                chain_index,
+                random_peer_id.as_bytes(),
+                Some(kademlia_operation_id),
+            );
+        } else {
+            self.pending_kademlia_errors
+                .push_back((kademlia_operation_id, DiscoveryError::NoPeer))
+        }
+
+        kademlia_operation_id
+    }
+
+    /// Sends a Kademlia "find node" request to a single peer, and waits for it to answer.
+    ///
+    /// Returns an error if there is no active connection with that peer.
+    ///
+    /// This function might generate a message destined a connection. Use
+    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
+    pub fn start_kademlia_find_node(
+        &mut self,
+        target: &PeerId,
+        now: TNow,
+        chain_index: usize,
+        close_to_key: &[u8],
+    ) -> OutRequestId {
+        self.start_kademlia_find_node_inner(target, now, chain_index, close_to_key, None)
+    }
+
+    fn start_kademlia_find_node_inner(
+        &mut self,
+        target: &PeerId,
+        now: TNow,
+        chain_index: usize,
+        close_to_key: &[u8],
+        part_of_operation: Option<KademliaOperationId>,
+    ) -> OutRequestId {
+        let request_data = protocol::build_find_node_request(close_to_key);
+        // The timeout needs to be long enough to potentially download the maximum
+        // response size of 1 MiB. Assuming a 128 kiB/sec connection, that's 8 seconds.
+        let timeout = now + Duration::from_secs(8);
+
+        let id = self.inner.start_request(
+            target,
+            self.protocol_index(chain_index, 2),
+            request_data,
+            timeout,
+        );
+
+        let _prev_value = self.out_requests_types.insert(
+            id,
+            (
+                if let Some(operation_id) = part_of_operation {
+                    OutRequestTy::KademliaDiscoveryFindNode(operation_id)
+                } else {
+                    OutRequestTy::KademliaFindNode
+                },
+                chain_index,
+            ),
+        );
+        debug_assert!(_prev_value.is_none());
+
+        id
+    }
+
+    /// Returns `true` if if it possible to send requests (i.e. through
+    /// [`ChainNetwork::start_grandpa_warp_sync_request`],
+    /// [`ChainNetwork::start_blocks_request`], etc.) to the given peer.
+    ///
+    /// If `false` is returned, starting a request will panic.
+    ///
+    /// In other words, returns `true` if there exists an established connection non-shutting-down
+    /// connection with the given peer.
+    pub fn can_start_requests(&self, peer_id: &PeerId) -> bool {
+        self.inner.can_start_requests(peer_id)
+    }
+
+    ///
+    /// This function might generate a message destined a connection. Use
+    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
+    pub fn respond_identify(&mut self, request_id: InRequestId, agent_version: &str) {
+        let observed_addr = match self.in_requests_types.remove(&request_id) {
+            Some(InRequestTy::Identify { observed_addr }) => observed_addr,
+            _ => panic!(),
+        };
+
+        let response = {
+            protocol::build_identify_response(protocol::IdentifyResponse {
+                protocol_version: "/substrate/1.0", // TODO: same value as in Substrate
+                agent_version,
+                ed25519_public_key: *self.inner.noise_key().libp2p_public_ed25519_key(),
+                listen_addrs: iter::empty(), // TODO:
+                observed_addr,
+                protocols: self
+                    .inner
+                    .request_response_protocols()
+                    .filter(|p| p.inbound_allowed)
+                    .map(|p| &p.name[..])
+                    .chain(
+                        self.inner
+                            .notification_protocols()
+                            .map(|p| &p.protocol_name[..]),
+                    ),
+            })
+            .fold(Vec::new(), |mut a, b| {
+                a.extend_from_slice(b.as_ref());
+                a
+            })
+        };
+
+        let _ = self.inner.respond_in_request(request_id, Ok(response));
+    }
+
+    /// Queue the response to send back.
+    ///
+    /// Pass `None` in order to deny the request. Do this if blocks aren't available locally.
+    ///
+    /// Has no effect if the connection that sends the request no longer exists.
+    ///
+    /// This function might generate a message destined a connection. Use
+    /// [`ChainNetwork::pull_message_to_connection`] to process messages after it has returned.
+    pub fn respond_blocks(
+        &mut self,
+        request_id: InRequestId,
+        response: Option<Vec<protocol::BlockData>>,
+    ) {
+        match self.in_requests_types.remove(&request_id) {
+            Some(InRequestTy::Blocks) => {}
+            _ => panic!(),
+        };
+
+        let response = if let Some(response) = response {
+            Ok(
+                protocol::build_block_response(response).fold(Vec::new(), |mut a, b| {
+                    a.extend_from_slice(b.as_ref());
+                    a
+                }),
+            )
+        } else {
+            Err(())
+        };
+
+        let _ = self.inner.respond_in_request(request_id, response);
+    }
+}
+
+/// Response to an outgoing request.
+///
+/// See [`Event::RequestResult`̀].
+#[derive(Debug)]
+pub enum RequestResult {
+    Blocks(Result<Vec<protocol::BlockData>, BlocksRequestError>),
+    GrandpaWarpSync(Result<EncodedGrandpaWarpSyncResponse, GrandpaWarpSyncRequestError>),
+    State(Result<EncodedStateResponse, StateRequestError>),
+    StorageProof(Result<EncodedMerkleProof, StorageProofRequestError>),
+    CallProof(Result<EncodedMerkleProof, CallProofRequestError>),
+    KademliaFindNode(
+        Result<Vec<(peer_id::PeerId, Vec<multiaddr::Multiaddr>)>, KademliaFindNodeError>,
+    ),
+}
+
+/// Undecoded but valid block announce.
+#[derive(Clone)]
+pub struct EncodedBlockAnnounce {
+    message: Vec<u8>,
+    block_number_bytes: usize,
+}
+
+impl EncodedBlockAnnounce {
+    /// Returns the decoded version of the announcement.
+    pub fn decode(&self) -> protocol::BlockAnnounceRef {
+        protocol::decode_block_announce(&self.message, self.block_number_bytes).unwrap()
+    }
+}
+
+impl fmt::Debug for EncodedBlockAnnounce {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.decode(), f)
+    }
+}
+
+/// Undecoded but valid Merkle proof.
+#[derive(Clone)]
+pub struct EncodedMerkleProof(Vec<u8>, protocol::StorageOrCallProof);
+
+impl EncodedMerkleProof {
+    /// Returns the decoded version of the proof.
+    pub fn decode(&self) -> Vec<&[u8]> {
+        protocol::decode_storage_or_call_proof_response(self.1, &self.0).unwrap()
+    }
+}
+
+impl fmt::Debug for EncodedMerkleProof {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.decode(), f)
+    }
+}
+
+/// Undecoded but valid GrandPa warp sync response.
+#[derive(Clone)]
+pub struct EncodedGrandpaWarpSyncResponse {
+    message: Vec<u8>,
+    block_number_bytes: usize,
+}
+
+impl EncodedGrandpaWarpSyncResponse {
+    /// Returns the encoded bytes of the warp sync message.
+    pub fn as_encoded(&self) -> &[u8] {
+        &self.message
+    }
+
+    /// Returns the decoded version of the warp sync message.
+    pub fn decode(&self) -> protocol::GrandpaWarpSyncResponse {
+        match protocol::decode_grandpa_warp_sync_response(&self.message, self.block_number_bytes) {
+            Ok(msg) => msg,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl fmt::Debug for EncodedGrandpaWarpSyncResponse {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.decode(), f)
+    }
+}
+
+/// Undecoded but valid state response.
+#[derive(Clone)]
+pub struct EncodedStateResponse(Vec<u8>);
+
+impl EncodedStateResponse {
+    /// Returns the decoded version of the state response.
+    pub fn decode(&self) -> Vec<&[u8]> {
+        match protocol::decode_state_response(&self.0) {
+            Ok(r) => r,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+impl fmt::Debug for EncodedStateResponse {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.decode(), f)
+    }
+}
+
+/// Error during [`ChainNetwork::start_kademlia_discovery_round`].
+#[derive(Debug, derive_more::Display)]
+pub enum DiscoveryError {
+    /// Not currently connected to any other node.
+    NoPeer,
+    /// Error during the request.
+    #[display(fmt = "{}", _0)]
+    FindNode(KademliaFindNodeError),
+}
+
+/// Error during [`ChainNetwork::start_kademlia_find_node`].
+#[derive(Debug, derive_more::Display)]
+pub enum KademliaFindNodeError {
+    /// Error during the request.
+    #[display(fmt = "{}", _0)]
+    RequestFailed(peers::RequestError),
+    /// Failed to decode the response.
+    #[display(fmt = "Response decoding error: {}", _0)]
+    DecodeError(protocol::DecodeFindNodeResponseError),
+}
+
+/// Error returned by [`ChainNetwork::start_blocks_request`].
+#[derive(Debug, derive_more::Display)]
+pub enum BlocksRequestError {
+    /// Error while waiting for the response from the peer.
+    #[display(fmt = "{}", _0)]
+    Request(peers::RequestError),
+    /// Error while decoding the response returned by the peer.
+    #[display(fmt = "Response decoding error: {}", _0)]
+    Decode(protocol::DecodeBlockResponseError),
+    /// Block request doesn't request headers, and as such its validity cannot be verified.
+    NotVerifiable,
+    /// Response returned by the remote doesn't contain any entry.
+    EmptyResponse,
+    /// Start of the response doesn't correspond to the requested start.
+    InvalidStart,
+    /// Error at a specific index in the response.
+    #[display(fmt = "Error in response at offset {}: {}", index, error)]
+    Entry {
+        /// Index in the response where the problem happened.
+        index: usize,
+        /// Problem in question.
+        error: BlocksRequestResponseEntryError,
+    },
+}
+
+/// See [`BlocksRequestError`].
+#[derive(Debug, derive_more::Display)]
+pub enum BlocksRequestResponseEntryError {
+    /// One of the requested fields is missing from the block.
+    MissingField,
+    /// The header has an extrinsics root that doesn't match the body. Can only happen if both the
+    /// header and body were requested.
+    #[display(fmt = "The header has an extrinsics root that doesn't match the body")]
+    InvalidExtrinsicsRoot {
+        /// Extrinsics root that was calculated from the body.
+        calculated: [u8; 32],
+        /// Extrinsics root found in the header.
+        in_header: [u8; 32],
+    },
+    /// The header has an invalid format.
+    InvalidHeader,
+    /// The hash of the header doesn't match the hash provided by the remote.
+    InvalidHash,
+}
+
+/// Error returned by [`ChainNetwork::start_storage_proof_request`].
+#[derive(Debug, derive_more::Display, Clone)]
+pub enum StorageProofRequestError {
+    #[display(fmt = "{}", _0)]
+    Request(peers::RequestError),
+    #[display(fmt = "Response decoding error: {}", _0)]
+    Decode(protocol::DecodeStorageCallProofResponseError),
+}
+
+/// Error returned by [`ChainNetwork::start_call_proof_request`].
+#[derive(Debug, Clone, derive_more::Display)]
+pub enum CallProofRequestError {
+    #[display(fmt = "{}", _0)]
+    Request(peers::RequestError),
+    #[display(fmt = "Response decoding error: {}", _0)]
+    Decode(protocol::DecodeStorageCallProofResponseError),
+}
+
+impl CallProofRequestError {
+    /// Returns `true` if this is caused by networking issues, as opposed to a consensus-related
+    /// issue.
+    pub fn is_network_problem(&self) -> bool {
+        match self {
+            CallProofRequestError::Request(_) => true,
+            CallProofRequestError::Decode(_) => false,
+        }
+    }
+}
+
+/// Error returned by [`ChainNetwork::start_grandpa_warp_sync_request`].
+#[derive(Debug, derive_more::Display)]
+pub enum GrandpaWarpSyncRequestError {
+    #[display(fmt = "{}", _0)]
+    Request(peers::RequestError),
+    #[display(fmt = "Response decoding error: {}", _0)]
+    Decode(protocol::DecodeGrandpaWarpSyncResponseError),
+}
+
+/// Error returned by [`ChainNetwork::start_state_request`].
+#[derive(Debug, derive_more::Display)]
+pub enum StateRequestError {
+    #[display(fmt = "{}", _0)]
+    Request(peers::RequestError),
+    #[display(fmt = "Response decoding error: {}", _0)]
+    Decode(protocol::DecodeStateResponseError),
+}
+
+fn check_blocks_response(
+    block_number_bytes: usize,
+    config: protocol::BlocksRequestConfig,
+    result: &mut [protocol::BlockData],
+) -> Result<(), BlocksRequestError> {
+    if !config.fields.header {
+        return Err(BlocksRequestError::NotVerifiable);
+    }
+
+    if result.is_empty() {
+        return Err(BlocksRequestError::EmptyResponse);
+    }
+
+    // Verify validity of all the blocks.
+    for (block_index, block) in result.iter_mut().enumerate() {
+        if block.header.is_none() {
+            return Err(BlocksRequestError::Entry {
+                index: block_index,
+                error: BlocksRequestResponseEntryError::MissingField,
+            });
+        }
+
+        if block
+            .header
+            .as_ref()
+            .map_or(false, |h| header::decode(h, block_number_bytes).is_err())
+        {
+            return Err(BlocksRequestError::Entry {
+                index: block_index,
+                error: BlocksRequestResponseEntryError::InvalidHeader,
+            });
+        }
+
+        match (block.body.is_some(), config.fields.body) {
+            (false, true) => {
+                return Err(BlocksRequestError::Entry {
+                    index: block_index,
+                    error: BlocksRequestResponseEntryError::MissingField,
+                });
+            }
+            (true, false) => {
+                block.body = None;
+            }
+            _ => {}
+        }
+
+        // Note: the presence of a justification isn't checked and can't be checked, as not
+        // all blocks have a justification in the first place.
+
+        if block.header.as_ref().map_or(false, |h| {
+            header::hash_from_scale_encoded_header(&h) != block.hash
+        }) {
+            return Err(BlocksRequestError::Entry {
+                index: block_index,
+                error: BlocksRequestResponseEntryError::InvalidHash,
+            });
+        }
+
+        if let (Some(header), Some(body)) = (&block.header, &block.body) {
+            let decoded_header = header::decode(header, block_number_bytes).unwrap();
+            let expected = header::extrinsics_root(&body[..]);
+            if expected != *decoded_header.extrinsics_root {
+                return Err(BlocksRequestError::Entry {
+                    index: block_index,
+                    error: BlocksRequestResponseEntryError::InvalidExtrinsicsRoot {
+                        calculated: expected,
+                        in_header: *decoded_header.extrinsics_root,
+                    },
+                });
+            }
+        }
+    }
+
+    match config.start {
+        protocol::BlocksRequestConfigStart::Hash(hash) if result[0].hash != hash => {
+            return Err(BlocksRequestError::InvalidStart);
+        }
+        protocol::BlocksRequestConfigStart::Number(n)
+            if header::decode(result[0].header.as_ref().unwrap(), block_number_bytes)
+                .unwrap()
+                .number
+                != n =>
+        {
+            return Err(BlocksRequestError::InvalidStart)
+        }
+        _ => {}
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Extracts everything related to request-responses in a module, and everything related to notifications in another module.
This considerably cleans up the code of `service.rs`.

No logic has been altered.