### PR TITLE
Use wrapping_sub in bandwidth calculation

### DIFF
--- a/bin/wasm-node/rust/src/init.rs
+++ b/bin/wasm-node/rust/src/init.rs
@@ -169,12 +169,18 @@ pub(crate) fn init<TPlat: smoldot_light::platform::Platform, TChain>(
                     // not fit in a `u64`, which as of 2021 is basically impossible.
                     let mem = u64::try_from(alloc::total_alloc_bytes()).unwrap();
 
+                    // Due to the way the calculation below is performed, sending or receiving
+                    // more than `type_of(TOTAL_BYTES_RECEIVED or TOTAL_BYTES_SENT)::max_value`
+                    // bytes within an interval will lead to an erroneous value being shown to the
+                    // user. We just assume that this can't happen. If it does happen, consider
+                    // increasing the size of `TOTAL_BYTES_RECEIVED` or `TOTAL_BYTES_SENT`.
+
                     let bytes_rx = platform::TOTAL_BYTES_RECEIVED.load(Ordering::Relaxed);
-                    let avg_dl = u64::try_from(bytes_rx - previous_read_bytes).unwrap() / interval;
+                    let avg_dl = u64::try_from(bytes_rx.wrapping_sub(previous_read_bytes)).unwrap() / interval;
                     previous_read_bytes = bytes_rx;
 
                     let bytes_tx = platform::TOTAL_BYTES_SENT.load(Ordering::Relaxed);
-                    let avg_up = u64::try_from(bytes_tx - previous_sent_bytes).unwrap() / interval;
+                    let avg_up = u64::try_from(bytes_tx.wrapping_sub(previous_sent_bytes)).unwrap() / interval;
                     previous_sent_bytes = bytes_tx;
 
                     // Note that we also print the version at every interval, in order to increase


### PR DESCRIPTION
It happened. I received more than 4 GiB while smoldot was running, and it lead to a panic in the memory printer because the total bytes transferred overflowed.
The fix is simple: just use `wrapping_sub`.

This panic only happens if debug_assertions are enabled, which is the case locally but not in the published version, so this panic isn't worth putting in the CHANGELOG.
