### PR TITLE
Modify Merkle proofs to be a single Vec

### DIFF
--- a/bin/light-base/src/network_service.rs
+++ b/bin/light-base/src/network_service.rs
@@ -628,11 +628,10 @@ impl<TPlat: Platform> NetworkService<TPlat> {
                 let decoded = items.decode();
                 log::debug!(
                     target: "network",
-                    "Connection({}) => StorageProofRequest(chain={}, num_elems={}, total_size={})",
+                    "Connection({}) => StorageProofRequest(chain={}, total_size={})",
                     target,
                     self.shared.log_chain_names[chain_index],
-                    decoded.len(),
-                    BytesDisplay(decoded.iter().fold(0, |a, b| a + u64::try_from(b.len()).unwrap()))
+                    BytesDisplay(u64::try_from(decoded.len()).unwrap()),
                 );
             }
             Err(err) => {
@@ -699,11 +698,10 @@ impl<TPlat: Platform> NetworkService<TPlat> {
                 let decoded = items.decode();
                 log::debug!(
                     target: "network",
-                    "Connection({}) => CallProofRequest({}, num_elems: {}, total_size: {})",
+                    "Connection({}) => CallProofRequest({}, total_size: {})",
                     target,
                     self.shared.log_chain_names[chain_index],
-                    decoded.len(),
-                    BytesDisplay(decoded.iter().fold(0, |a, b| a + u64::try_from(b.len()).unwrap()))
+                    BytesDisplay(u64::try_from(decoded.len()).unwrap())
                 );
             }
             Err(err) => {

--- a/bin/light-base/src/runtime_service.rs
+++ b/bin/light-base/src/runtime_service.rs
@@ -806,7 +806,7 @@ impl<'a, TPlat: Platform> RuntimeLock<'a, TPlat> {
 
         let call_proof = call_proof.and_then(|call_proof| {
             proof_decode::decode_and_verify_proof(proof_decode::Config {
-                proof: call_proof.decode().into_iter().map(|v| v.to_owned()), // TODO: to_owned() inefficiency, need some help from the networking to obtain the owned data
+                proof: call_proof.decode().to_owned(), // TODO: to_owned() inefficiency, need some help from the networking to obtain the owned data
                 trie_root_hash: &self.block_state_root_hash,
             })
             .map_err(RuntimeCallError::StorageRetrieval)

--- a/bin/light-base/src/sync_service.rs
+++ b/bin/light-base/src/sync_service.rs
@@ -430,7 +430,7 @@ impl<TPlat: Platform> SyncService<TPlat> {
                 .and_then(|outcome| {
                     let decoded = outcome.decode();
                     let decoded = proof_decode::decode_and_verify_proof(proof_decode::Config {
-                        proof: decoded.iter().copied(),
+                        proof: decoded,
                         trie_root_hash: &storage_trie_root,
                     })
                     .map_err(StorageQueryErrorDetail::ProofVerification)?;
@@ -507,8 +507,7 @@ impl<TPlat: Platform> SyncService<TPlat> {
 
                 match result {
                     Ok(proof) => {
-                        let decoded_proof = proof.decode();
-                        match prefix_scan.resume(decoded_proof.iter().map(|v| &v[..])) {
+                        match prefix_scan.resume(proof.decode()) {
                             Ok(prefix_proof::ResumeOutcome::InProgress(scan)) => {
                                 // Continue next step of the proof.
                                 prefix_scan = scan;

--- a/bin/light-base/src/sync_service/standalone.rs
+++ b/bin/light-base/src/sync_service/standalone.rs
@@ -301,7 +301,7 @@ pub(super) async fn start_standalone_chain<TPlat: Platform>(
                     task.sync.call_proof_response(
                         request_id,
                         match result {
-                            Ok(ref r) => Ok(r.decode().into_iter()),
+                            Ok(ref r) => Ok(r.decode().to_owned()), // TODO: need help from networking service to avoid this to_owned
                             Err(err) => Err(err),
                         }
                     ).1
@@ -578,10 +578,9 @@ impl<TPlat: Platform> Task<TPlat> {
                     if let Ok(outcome) = storage_request.await {
                         // TODO: lots of copying around
                         // TODO: log what happens
-                        let decoded = outcome.decode();
                         if let Ok(decoded) =
                             proof_decode::decode_and_verify_proof(proof_decode::Config {
-                                proof: decoded.iter().copied(),
+                                proof: outcome.decode(),
                                 trie_root_hash: &state_trie_root,
                             })
                         {

--- a/src/network/service/requests_responses.rs
+++ b/src/network/service/requests_responses.rs
@@ -907,8 +907,8 @@ impl fmt::Debug for EncodedBlockAnnounce {
 pub struct EncodedMerkleProof(Vec<u8>, protocol::StorageOrCallProof);
 
 impl EncodedMerkleProof {
-    /// Returns the decoded version of the proof.
-    pub fn decode(&self) -> Vec<&[u8]> {
+    /// Returns the SCALE-encoded Merkle proof.
+    pub fn decode(&self) -> &[u8] {
         protocol::decode_storage_or_call_proof_response(self.1, &self.0)
             .unwrap()
             .unwrap()

--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -1610,7 +1610,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     pub fn call_proof_response(
         &mut self,
         request_id: RequestId,
-        response: Result<impl Iterator<Item = impl AsRef<[u8]>>, ()>,
+        response: Result<Vec<u8>, ()>,
     ) -> (TRq, ResponseOutcome) {
         debug_assert!(self.shared.requests.contains(request_id.0));
         let request = self.shared.requests.remove(request_id.0);

--- a/src/sync/warp_sync.rs
+++ b/src/sync/warp_sync.rs
@@ -325,7 +325,7 @@ enum Phase {
         /// downloaded yet.
         calls: hashbrown::HashMap<
             chain_information::build::RuntimeCall,
-            Option<Vec<Vec<u8>>>,
+            Option<Vec<u8>>,
             fnv::FnvBuildHasher,
         >,
     },
@@ -790,7 +790,7 @@ impl<TSrc, TRq> InProgressWarpSync<TSrc, TRq> {
     pub fn runtime_call_merkle_proof_success(
         &mut self,
         request_id: RequestId,
-        response: impl Iterator<Item = impl AsRef<[u8]>>,
+        response: Vec<u8>,
     ) -> TRq {
         match (
             self.in_progress_requests.remove(request_id.0),
@@ -816,7 +816,7 @@ impl<TSrc, TRq> InProgressWarpSync<TSrc, TRq> {
                     if function_name == call.function_name()
                         && parameters_equal(&parameter_vectored, call.parameter_vectored())
                     {
-                        *value = Some(response.map(|e| e.as_ref().to_vec()).collect());
+                        *value = Some(response);
                         break;
                     }
                 }

--- a/src/trie/prefix_proof.rs
+++ b/src/trie/prefix_proof.rs
@@ -72,10 +72,7 @@ impl PrefixScan {
     /// Injects the proof presumably containing the keys returned by [`PrefixScan::requested_keys`].
     ///
     /// Returns an error if the proof is invalid. In that case, `self` isn't modified.
-    pub fn resume<'a>(
-        mut self,
-        proof: impl Iterator<Item = &'a [u8]> + Clone + 'a,
-    ) -> Result<ResumeOutcome, (Self, Error)> {
+    pub fn resume(mut self, proof: &[u8]) -> Result<ResumeOutcome, (Self, Error)> {
         let decoded_proof = match proof_decode::decode_and_verify_proof(proof_decode::Config {
             proof,
             trie_root_hash: &self.trie_root_hash,

--- a/src/trie/proof_decode.rs
+++ b/src/trie/proof_decode.rs
@@ -59,7 +59,7 @@ pub struct Config<'a, I> {
 ///
 /// The proof is then stored within the [`DecodedTrieProof`].
 ///
-/// Due to the genesis nature of this function, the proof can be either a `Vec<u8>` or a `&[u8]`.
+/// Due to the generic nature of this function, the proof can be either a `Vec<u8>` or a `&[u8]`.
 ///
 /// Returns an error if the proof is invalid, or if the proof contains entries that are
 /// disconnected from the root node of the trie.

--- a/src/trie/proof_decode.rs
+++ b/src/trie/proof_decode.rs
@@ -59,22 +59,21 @@ pub struct Config<'a, I> {
 ///
 /// The proof is then stored within the [`DecodedTrieProof`].
 ///
-/// Due to the genesis nature of this function, the proof can be either an iterator yielding
-/// `Vec<u8>`s or an iterator yielding `&[u8]`s.
+/// Due to the genesis nature of this function, the proof can be either a `Vec<u8>` or a `&[u8]`.
 ///
 /// Returns an error if the proof is invalid, or if the proof contains entries that are
 /// disconnected from the root node of the trie.
-// TODO: maybe rethink the whole API of the proof thing and consider accepting as parameter a single Vec<u8> or &[u8] containing the SCALE-encoded proof
-pub fn decode_and_verify_proof<'a, T>(
-    config: Config<'a, impl Iterator<Item = T> + Clone>,
-) -> Result<DecodedTrieProof<T>, Error>
+pub fn decode_and_verify_proof<'a, T>(config: Config<'a, T>) -> Result<DecodedTrieProof<T>, Error>
 where
     T: AsRef<[u8]>,
 {
-    // Collect the proof into a vec.
-    let proof = config.proof.collect::<Vec<_>>();
+    // Call `as_ref()` once at the beginning in order to guarantee stability of the memory
+    // location.
+    let proof_as_ref = config.proof.as_ref();
 
-    // A proof contains two types of items: trie node values, and standalone storage items. In
+    // A Merkle proof is a SCALE-encoded `Vec<Vec<u8>>`.
+    //
+    // This `Vec` contains two types of items: trie node values, and standalone storage items. In
     // both cases, we will later need a hashed version of them. Create a list of hashes, one per
     // entry in `proof`.
     //
@@ -84,30 +83,53 @@ where
     // we assume it isn't). So while an attacker can slightly increase the time that this function
     // takes, it is always cause this function to return an error and is actually likely to make
     // the function actually take less time than if it was a legitimate proof.
-    let merkle_values = proof
-        .iter()
-        .map(|proof_entry| -> arrayvec::ArrayVec<u8, 32> {
-            let proof_entry = proof_entry.as_ref();
-            if proof_entry.len() >= 32 {
-                blake2_rfc::blake2b::blake2b(32, &[], proof_entry)
-                    .as_bytes()
-                    .iter()
-                    .copied()
-                    .collect()
-            } else {
-                proof_entry.iter().copied().collect()
-            }
-        })
-        .enumerate()
-        .map(|(num, hash)| (hash, num))
-        .collect::<hashbrown::HashMap<_, _, fnv::FnvBuildHasher>>();
+    let merkle_values = {
+        // TODO: don't use a Vec?
+        let (_, decoded_proof) = nom::combinator::all_consuming(nom::combinator::flat_map(
+            crate::util::nom_scale_compact_usize,
+            |num_elems| nom::multi::many_m_n(num_elems, num_elems, crate::util::nom_bytes_decode),
+        ))(config.proof.as_ref())
+        .map_err(|_: nom::Err<nom::error::Error<&[u8]>>| Error::InvalidFormat)?;
 
-    // Using a hashmap has the consequence that if multiple proof entries were identical, only
-    // one would be tracked. For this reason, we make sure that the proof doesn't contain
-    // multiple identical entries.
-    if merkle_values.len() != proof.len() {
-        return Err(Error::DuplicateProofEntry);
-    }
+        let merkle_values = decoded_proof
+            .iter()
+            .copied()
+            .enumerate()
+            .map(
+                |(proof_entry_num, proof_entry)| -> (arrayvec::ArrayVec<u8, 32>, (usize, ops::Range<usize>)) {
+                    let hash = if proof_entry.len() >= 32 {
+                        blake2_rfc::blake2b::blake2b(32, &[], proof_entry)
+                            .as_bytes()
+                            .iter()
+                            .copied()
+                            .collect()
+                    } else {
+                        proof_entry.iter().copied().collect()
+                    };
+
+                    let proof_entry_offset = if proof_entry.len() == 0 {
+                        0
+                    } else {
+                        proof_entry.as_ptr() as usize - proof_as_ref.as_ptr() as usize
+                    };
+
+                    (
+                        hash,
+                        (proof_entry_num, proof_entry_offset..(proof_entry_offset + proof_entry.len())),
+                    )
+                },
+            )
+            .collect::<hashbrown::HashMap<_, _, fnv::FnvBuildHasher>>();
+
+        // Using a hashmap has the consequence that if multiple proof entries were identical, only
+        // one would be tracked. For this reason, we make sure that the proof doesn't contain
+        // multiple identical entries.
+        if merkle_values.len() != decoded_proof.len() {
+            return Err(Error::DuplicateProofEntry);
+        }
+
+        merkle_values
+    };
 
     // The implementation below iterates down the tree of nodes represented by this proof, keeping
     // note of the traversed elements.
@@ -118,15 +140,12 @@ where
 
     // Find the expected trie root in the proof. This is the starting point of the verification.
     let mut remain_iterate = {
-        let root_position = *merkle_values
+        let (root_position, root_range) = merkle_values
             .get(&config.trie_root_hash[..])
-            .ok_or(Error::TrieRootNotFound)?;
+            .ok_or(Error::TrieRootNotFound)?
+            .clone();
         let _ = unvisited_proof_entries.remove(&root_position);
-        vec![(
-            root_position,
-            0..proof[root_position].as_ref().len(),
-            Vec::new(),
-        )]
+        vec![(root_range, Vec::new())]
     };
 
     // Keep track of all the entries found in the proof.
@@ -135,11 +154,11 @@ where
     while !remain_iterate.is_empty() {
         // Iterate through each entry in `remain_iterate`.
         // This clears `remain_iterate` so that we can add new entries to it during the iteration.
-        for (proof_entry_index, proof_entry_range, storage_key_before_partial) in
+        for (proof_entry_range, storage_key_before_partial) in
             mem::replace(&mut remain_iterate, Vec::with_capacity(merkle_values.len()))
         {
             // Decodes the proof entry.
-            let proof_entry = &proof[proof_entry_index].as_ref()[proof_entry_range.clone()];
+            let proof_entry = &proof_as_ref[proof_entry_range.clone()];
             let decoded_node_value =
                 proof_node_codec::decode(proof_entry).map_err(Error::InvalidNodeValue)?;
             let decoded_node_value_children_bitmap = decoded_node_value.children_bitmap();
@@ -184,7 +203,6 @@ where
                         };
                     debug_assert!(offset <= (proof_entry_range.start + proof_entry.len()));
                     remain_iterate.push((
-                        proof_entry_index,
                         offset..(offset + child_node_value.len()),
                         child_storage_key_before_partial,
                     ));
@@ -192,7 +210,9 @@ where
                     // The decoding API guarantees that the child value is never larger than
                     // 32 bytes.
                     debug_assert_eq!(child_node_value.len(), 32);
-                    if let Some(child_position) = merkle_values.get(child_node_value) {
+                    if let Some((child_position, child_entry_range)) =
+                        merkle_values.get(child_node_value)
+                    {
                         // Remove the entry from `unvisited_proof_entries`.
                         // Note that it is questionable what to do if the same entry is visited
                         // multiple times. In case where multiple storage branches are identical,
@@ -200,11 +220,8 @@ where
                         // this reason, it could be legitimate for the same proof entry to be
                         // visited multiple times.
                         let _ = unvisited_proof_entries.remove(child_position);
-                        remain_iterate.push((
-                            *child_position,
-                            0..proof[*child_position].as_ref().len(),
-                            child_storage_key_before_partial,
-                        ));
+                        remain_iterate
+                            .push((child_entry_range.clone(), child_storage_key_before_partial));
                     }
                 }
             }
@@ -215,32 +232,31 @@ where
                 let storage_value = match decoded_node_value.storage_value {
                     proof_node_codec::StorageValue::None => StorageValueInner::None,
                     proof_node_codec::StorageValue::Hashed(value_hash) => {
-                        if let Some(value_position) = merkle_values.get(&value_hash[..]) {
+                        if let Some((value_position, value_entry_range)) =
+                            merkle_values.get(&value_hash[..])
+                        {
+                            let _ = unvisited_proof_entries.remove(value_position);
                             StorageValueInner::Known {
-                                entry_num: *value_position,
-                                offset: 0,
-                                len: proof[*value_position].as_ref().len(),
+                                offset: value_entry_range.start,
+                                len: value_entry_range.end,
                             }
                         } else {
-                            let offset = proof_entry_range.start
-                                + (value_hash.as_ptr() as usize - proof_entry.as_ptr() as usize);
+                            let offset =
+                                value_hash.as_ptr() as usize - proof_as_ref.as_ptr() as usize;
+                            debug_assert!(offset >= proof_entry_range.start);
                             debug_assert!(offset <= (proof_entry_range.start + proof_entry.len()));
-                            StorageValueInner::HashKnownValueMissing {
-                                entry_num: proof_entry_index,
-                                offset,
-                            }
+                            StorageValueInner::HashKnownValueMissing { offset }
                         }
                     }
                     proof_node_codec::StorageValue::Unhashed(v) => {
-                        let offset = proof_entry_range.start
-                            + if !v.is_empty() {
-                                v.as_ptr() as usize - proof_entry.as_ptr() as usize
-                            } else {
-                                0
-                            };
+                        let offset = if !v.is_empty() {
+                            v.as_ptr() as usize - proof_as_ref.as_ptr() as usize
+                        } else {
+                            0
+                        };
+                        debug_assert!(offset >= proof_entry_range.start);
                         debug_assert!(offset <= (proof_entry_range.start + proof_entry.len()));
                         StorageValueInner::Known {
-                            entry_num: proof_entry_index,
                             offset,
                             len: v.len(),
                         }
@@ -259,20 +275,19 @@ where
         return Err(Error::UnusedProofEntry);
     }
 
-    Ok(DecodedTrieProof { proof, entries })
+    Ok(DecodedTrieProof {
+        proof: config.proof,
+        entries,
+    })
 }
 
 /// Equivalent to [`StorageValue`] but contains offsets indexing [`DecodedTrieProof::proof`].
 #[derive(Debug, Copy, Clone)]
 enum StorageValueInner {
     /// Equivalent to [`StorageValue::Known`].
-    Known {
-        entry_num: usize,
-        offset: usize,
-        len: usize,
-    },
+    Known { offset: usize, len: usize },
     /// Equivalent to [`StorageValue::HashKnownValueMissing`].
-    HashKnownValueMissing { entry_num: usize, offset: usize },
+    HashKnownValueMissing { offset: usize },
     /// Equivalent to [`StorageValue::None`].
     None,
 }
@@ -281,7 +296,7 @@ enum StorageValueInner {
 // TODO: implement Debug
 pub struct DecodedTrieProof<T> {
     /// The proof itself.
-    proof: Vec<T>,
+    proof: T,
 
     /// For each storage key, contains the entry found in the proof and the children bitmap.
     // TODO: a BTreeMap is actually kind of stupid since `proof` is itself in a tree format
@@ -323,20 +338,14 @@ impl<T: AsRef<[u8]>> DecodedTrieProof<T> {
                     // Found exact match. Returning.
                     return Some(TrieNodeInfo {
                         storage_value: match storage_value {
-                            StorageValueInner::Known {
-                                entry_num,
-                                offset,
-                                len,
-                            } => StorageValue::Known(
-                                &self.proof[*entry_num].as_ref()[*offset..][..*len],
-                            ),
+                            StorageValueInner::Known { offset, len } => {
+                                StorageValue::Known(&self.proof.as_ref()[*offset..][..*len])
+                            }
                             StorageValueInner::None => StorageValue::None,
-                            StorageValueInner::HashKnownValueMissing { entry_num, offset } => {
+                            StorageValueInner::HashKnownValueMissing { offset } => {
                                 StorageValue::HashKnownValueMissing(
-                                    <&[u8; 32]>::try_from(
-                                        &self.proof[*entry_num].as_ref()[*offset..][..32],
-                                    )
-                                    .unwrap(),
+                                    <&[u8; 32]>::try_from(&self.proof.as_ref()[*offset..][..32])
+                                        .unwrap(),
                                 )
                             }
                         },
@@ -438,6 +447,8 @@ pub enum StorageValue<'a> {
 /// Possible error returned by [`decode_and_verify_proof`].
 #[derive(Debug, Clone, derive_more::Display)]
 pub enum Error {
+    /// Proof is in an invalid format.
+    InvalidFormat,
     /// Trie root wasn't found in the proof.
     TrieRootNotFound,
     /// One of the node values in the proof has an invalid format.
@@ -501,12 +512,100 @@ mod tests {
         // Key/value taken from the Polkadot genesis block.
 
         let proof = vec![
-            hex::decode("7d01542596adb05d6140c170ac479edf7cfd5aa35357590acfe5d11a804d944e500d1456fdda7b8ec7f9e5c794cd83194f0593e4ea").unwrap(),
-            hex::decode("803f93804e4c6c4222b747e507008ef1def063bb0d2deeadf17ef4b10e71624d3a0cf81c80241f2c06f22ec58968fb68d432319e25e6c8faa3ad2c5ca9ee48f2e8ed158e2480ad8a68234932269846bc40240a47cfd8d8857b1d81e167bfb24c947a4cdad9e680c84590e39f8b79a2694ad2bf7e7258af686b472f38b064bbce7d08404931a430805c72f25b1b6304d16667e2766fa1a906cb081788eb4502787df7c3597412b17b806e21c5f1a24a196615b4e5b36d21280cdcc80098c1e2bce8eeaf301e9951767480424f1acd80ba074a2ce8d180bf3488a5ca91cb81fba96c8c3c1d33eacbb18160805e849d5c148ca361a55a2c9b384e17ce919e936ccb8011a4f72504e9f93db8cd80edd005a1495c70250d77f81c24c15a9919f034f7983df8e505e53a5af7b402138012a0dd90497b65312bda67ea15996578eeb3891bca8666951a326612418e3143").unwrap(),
-            hex::decode("80555d8043fb497c1b2a7b9e4feb59f410c1a29e28b2a628ff9c6003e080f6b9fadd95f9806e8d911b6818038eb7c8534af8e78e9920a1ab8d939c36d3e69b0a1e5928110b80ba4d3f543957f422b40c8e74af9de00acbeba8154afca57a7f80fbbcfebb1e4a803d1b8f5cf1788b294537b8fd2d34acec4646a7627c6cd3d2039af64ff5d1976d80e7620f21cf13964f29d34ba708c3b44ea45ea11c58fbbedda29d13470bc80ca080f98aae4f83d81bf15d88019e5c303d7c19d0524e84c714e05f61517cde0b138280d518faf566fdc4d045094abe372bb3bbecd4753f76db8c41ba9fc015558bf23a80908f991126d12ce7acd55508ff1e7dffa56f742401e1814fc1469658a78c7a7f8001b0a08da0c83253d5c0cb877286c062da2f530ae424fe2545377941fd016913").unwrap(),
-            hex::decode("80b3a780a29fac7f7dfae21d05d9506e7da6515b7fa1ad970ff876de35f1bec2599ec002805b6772dc6a4e7604c8d0652479f95b343607c2d9138c59eeb799d85bf43b6bbf803d12becb6a4b9919ddc7c5973d04eed7696c834f90c779fc1fcf7350ccc28d6b805f33ebcf191fddcf3b3f346ec336c105c74b40a4d35dfda0c592f2bea00084e980f764c733d6e35771a9b26a1fa86b9bec59742b046f698be6c140af1073897d3d80cd3bc8c3ce3cf8359f7371a13316f02fd22b02a3d327684a2b61f4a47e0022b880da752afaeb925d5300e45b851052c5f8a9c5aae884f15d64764edf961b8b22c880bf1fa9c7e4c94340dbafd75cbe016c980d0e5d5b4e76823fa11e61629014c34b804f54a15e5d51d02b84e8cae94c9833ae81e56b8f0b684d257f6f722ee66cadf98094833fb2dce8c78d443cd6786e0c01d8974a4b779c178ef5e66b49e021dd7f1a").unwrap(),
-            hex::decode("9f0c5d795d0297be56027a4b2464e33397609280f332ff556abf5daf0d34523df7c8cd1369bcb6adbb23a48093bf070a9711bf3480382934134aa919b59c16ff8de8d97a7fdcc2448ea327b26f44005d756d1785878081d634140b36ce031c4b6c6266e2a7c19d9a88e38fdd8ad23abd3db20e714f6980fde17041f22f09609d79dbe38dcccefcaac139c7a10fb23bd284c1c492b004fd80d287ad1d0ade65e64d3969f4ab85a37076816031438cea0bf8c33b7b2bc6c330").unwrap(),
-            hex::decode("9f03e6d3c1fb15805edfd024172ea4817dffff80152833e34a852e9751cfc0f954aeb835e1f843936ba9979853a40e439937255f806a36e0ad23fb3224fff6e6db62048463a7f27ccb92f65b4e348acd5a7aa3a0688027b6e099c11581fb2e8acf3b6b94eaed442277b9a74ce7f922f6e3bf2959867b80fd0cc2c846db6a9ed19a715d6c3cd46a48b7f409883c70b2d4c978b306de379e80ab008a78c340f5cc75d99cdb905951936686445c834719be21f7620b950dcd5c806d86af54d5dfb1c06f3fefdd5a430861c0d19e25fad4bad07c6e70d4a679f0b880f35edc5400b6661fb1e6fba7c599c8ba891458d14400030fa506999a1972369f80746cdaa0b7da2e9c3864971f50f12d9b4281f804d5a2dba6ebe06959b2a9fb47802ecfde11456423c87fed8068f414a5ba44ebe3ae91b06d14cc231a78d4aba68e80f655291833a49cf23d057bb15c42d377c55d50f5885329060b0aaab22283cbb1808c95fb2b62baf30718b8330ef68a527c97c1bc9960304353224d8a8ae88a79d58045c1b6d9904ae171d573bdcebaa05142d81648bdbeb16ceeddc54a0ed15d3e2b80a8ea193282fe85b6481707091c77c9218ea19de914e75950925fe86400fb0cb080c222ceab5355eaa41da807146f2e2df7ff648c3e8bbb6d8ee23274ba724551b18008f142dc3c59bf1151c829ecefea35919e80453db5e9669f5a73899aaa5166ee804f1d21fbdc0180c4de886bf40f91dfc2202b3eb6d42548d476908041dd617bb8").unwrap(),
+            24, 212, 125, 1, 84, 37, 150, 173, 176, 93, 97, 64, 193, 112, 172, 71, 158, 223, 124,
+            253, 90, 163, 83, 87, 89, 10, 207, 229, 209, 26, 128, 77, 148, 78, 80, 13, 20, 86, 253,
+            218, 123, 142, 199, 249, 229, 199, 148, 205, 131, 25, 79, 5, 147, 228, 234, 53, 5, 128,
+            63, 147, 128, 78, 76, 108, 66, 34, 183, 71, 229, 7, 0, 142, 241, 222, 240, 99, 187, 13,
+            45, 238, 173, 241, 126, 244, 177, 14, 113, 98, 77, 58, 12, 248, 28, 128, 36, 31, 44, 6,
+            242, 46, 197, 137, 104, 251, 104, 212, 50, 49, 158, 37, 230, 200, 250, 163, 173, 44,
+            92, 169, 238, 72, 242, 232, 237, 21, 142, 36, 128, 173, 138, 104, 35, 73, 50, 38, 152,
+            70, 188, 64, 36, 10, 71, 207, 216, 216, 133, 123, 29, 129, 225, 103, 191, 178, 76, 148,
+            122, 76, 218, 217, 230, 128, 200, 69, 144, 227, 159, 139, 121, 162, 105, 74, 210, 191,
+            126, 114, 88, 175, 104, 107, 71, 47, 56, 176, 100, 187, 206, 125, 8, 64, 73, 49, 164,
+            48, 128, 92, 114, 242, 91, 27, 99, 4, 209, 102, 103, 226, 118, 111, 161, 169, 6, 203,
+            8, 23, 136, 235, 69, 2, 120, 125, 247, 195, 89, 116, 18, 177, 123, 128, 110, 33, 197,
+            241, 162, 74, 25, 102, 21, 180, 229, 179, 109, 33, 40, 12, 220, 200, 0, 152, 193, 226,
+            188, 232, 238, 175, 48, 30, 153, 81, 118, 116, 128, 66, 79, 26, 205, 128, 186, 7, 74,
+            44, 232, 209, 128, 191, 52, 136, 165, 202, 145, 203, 129, 251, 169, 108, 140, 60, 29,
+            51, 234, 203, 177, 129, 96, 128, 94, 132, 157, 92, 20, 140, 163, 97, 165, 90, 44, 155,
+            56, 78, 23, 206, 145, 158, 147, 108, 203, 128, 17, 164, 247, 37, 4, 233, 249, 61, 184,
+            205, 128, 237, 208, 5, 161, 73, 92, 112, 37, 13, 119, 248, 28, 36, 193, 90, 153, 25,
+            240, 52, 247, 152, 61, 248, 229, 5, 229, 58, 90, 247, 180, 2, 19, 128, 18, 160, 221,
+            144, 73, 123, 101, 49, 43, 218, 103, 234, 21, 153, 101, 120, 238, 179, 137, 27, 202,
+            134, 102, 149, 26, 50, 102, 18, 65, 142, 49, 67, 177, 4, 128, 85, 93, 128, 67, 251, 73,
+            124, 27, 42, 123, 158, 79, 235, 89, 244, 16, 193, 162, 158, 40, 178, 166, 40, 255, 156,
+            96, 3, 224, 128, 246, 185, 250, 221, 149, 249, 128, 110, 141, 145, 27, 104, 24, 3, 142,
+            183, 200, 83, 74, 248, 231, 142, 153, 32, 161, 171, 141, 147, 156, 54, 211, 230, 155,
+            10, 30, 89, 40, 17, 11, 128, 186, 77, 63, 84, 57, 87, 244, 34, 180, 12, 142, 116, 175,
+            157, 224, 10, 203, 235, 168, 21, 74, 252, 165, 122, 127, 128, 251, 188, 254, 187, 30,
+            74, 128, 61, 27, 143, 92, 241, 120, 139, 41, 69, 55, 184, 253, 45, 52, 172, 236, 70,
+            70, 167, 98, 124, 108, 211, 210, 3, 154, 246, 79, 245, 209, 151, 109, 128, 231, 98, 15,
+            33, 207, 19, 150, 79, 41, 211, 75, 167, 8, 195, 180, 78, 164, 94, 161, 28, 88, 251,
+            190, 221, 162, 157, 19, 71, 11, 200, 12, 160, 128, 249, 138, 174, 79, 131, 216, 27,
+            241, 93, 136, 1, 158, 92, 48, 61, 124, 25, 208, 82, 78, 132, 199, 20, 224, 95, 97, 81,
+            124, 222, 11, 19, 130, 128, 213, 24, 250, 245, 102, 253, 196, 208, 69, 9, 74, 190, 55,
+            43, 179, 187, 236, 212, 117, 63, 118, 219, 140, 65, 186, 159, 192, 21, 85, 139, 242,
+            58, 128, 144, 143, 153, 17, 38, 209, 44, 231, 172, 213, 85, 8, 255, 30, 125, 255, 165,
+            111, 116, 36, 1, 225, 129, 79, 193, 70, 150, 88, 167, 140, 122, 127, 128, 1, 176, 160,
+            141, 160, 200, 50, 83, 213, 192, 203, 135, 114, 134, 192, 98, 218, 47, 83, 10, 228, 36,
+            254, 37, 69, 55, 121, 65, 253, 1, 105, 19, 53, 5, 128, 179, 167, 128, 162, 159, 172,
+            127, 125, 250, 226, 29, 5, 217, 80, 110, 125, 166, 81, 91, 127, 161, 173, 151, 15, 248,
+            118, 222, 53, 241, 190, 194, 89, 158, 192, 2, 128, 91, 103, 114, 220, 106, 78, 118, 4,
+            200, 208, 101, 36, 121, 249, 91, 52, 54, 7, 194, 217, 19, 140, 89, 238, 183, 153, 216,
+            91, 244, 59, 107, 191, 128, 61, 18, 190, 203, 106, 75, 153, 25, 221, 199, 197, 151, 61,
+            4, 238, 215, 105, 108, 131, 79, 144, 199, 121, 252, 31, 207, 115, 80, 204, 194, 141,
+            107, 128, 95, 51, 235, 207, 25, 31, 221, 207, 59, 63, 52, 110, 195, 54, 193, 5, 199,
+            75, 64, 164, 211, 93, 253, 160, 197, 146, 242, 190, 160, 0, 132, 233, 128, 247, 100,
+            199, 51, 214, 227, 87, 113, 169, 178, 106, 31, 168, 107, 155, 236, 89, 116, 43, 4, 111,
+            105, 139, 230, 193, 64, 175, 16, 115, 137, 125, 61, 128, 205, 59, 200, 195, 206, 60,
+            248, 53, 159, 115, 113, 161, 51, 22, 240, 47, 210, 43, 2, 163, 211, 39, 104, 74, 43,
+            97, 244, 164, 126, 0, 34, 184, 128, 218, 117, 42, 250, 235, 146, 93, 83, 0, 228, 91,
+            133, 16, 82, 197, 248, 169, 197, 170, 232, 132, 241, 93, 100, 118, 78, 223, 150, 27,
+            139, 34, 200, 128, 191, 31, 169, 199, 228, 201, 67, 64, 219, 175, 215, 92, 190, 1, 108,
+            152, 13, 14, 93, 91, 78, 118, 130, 63, 161, 30, 97, 98, 144, 20, 195, 75, 128, 79, 84,
+            161, 94, 93, 81, 208, 43, 132, 232, 202, 233, 76, 152, 51, 174, 129, 229, 107, 143, 11,
+            104, 77, 37, 127, 111, 114, 46, 230, 108, 173, 249, 128, 148, 131, 63, 178, 220, 232,
+            199, 141, 68, 60, 214, 120, 110, 12, 1, 216, 151, 74, 75, 119, 156, 23, 142, 245, 230,
+            107, 73, 224, 33, 221, 127, 26, 225, 2, 159, 12, 93, 121, 93, 2, 151, 190, 86, 2, 122,
+            75, 36, 100, 227, 51, 151, 96, 146, 128, 243, 50, 255, 85, 106, 191, 93, 175, 13, 52,
+            82, 61, 247, 200, 205, 19, 105, 188, 182, 173, 187, 35, 164, 128, 147, 191, 7, 10, 151,
+            17, 191, 52, 128, 56, 41, 52, 19, 74, 169, 25, 181, 156, 22, 255, 141, 232, 217, 122,
+            127, 220, 194, 68, 142, 163, 39, 178, 111, 68, 0, 93, 117, 109, 23, 133, 135, 128, 129,
+            214, 52, 20, 11, 54, 206, 3, 28, 75, 108, 98, 102, 226, 167, 193, 157, 154, 136, 227,
+            143, 221, 138, 210, 58, 189, 61, 178, 14, 113, 79, 105, 128, 253, 225, 112, 65, 242,
+            47, 9, 96, 157, 121, 219, 227, 141, 204, 206, 252, 170, 193, 57, 199, 161, 15, 178, 59,
+            210, 132, 193, 196, 146, 176, 4, 253, 128, 210, 135, 173, 29, 10, 222, 101, 230, 77,
+            57, 105, 244, 171, 133, 163, 112, 118, 129, 96, 49, 67, 140, 234, 11, 248, 195, 59,
+            123, 43, 198, 195, 48, 141, 8, 159, 3, 230, 211, 193, 251, 21, 128, 94, 223, 208, 36,
+            23, 46, 164, 129, 125, 255, 255, 128, 21, 40, 51, 227, 74, 133, 46, 151, 81, 207, 192,
+            249, 84, 174, 184, 53, 225, 248, 67, 147, 107, 169, 151, 152, 83, 164, 14, 67, 153, 55,
+            37, 95, 128, 106, 54, 224, 173, 35, 251, 50, 36, 255, 246, 230, 219, 98, 4, 132, 99,
+            167, 242, 124, 203, 146, 246, 91, 78, 52, 138, 205, 90, 122, 163, 160, 104, 128, 39,
+            182, 224, 153, 193, 21, 129, 251, 46, 138, 207, 59, 107, 148, 234, 237, 68, 34, 119,
+            185, 167, 76, 231, 249, 34, 246, 227, 191, 41, 89, 134, 123, 128, 253, 12, 194, 200,
+            70, 219, 106, 158, 209, 154, 113, 93, 108, 60, 212, 106, 72, 183, 244, 9, 136, 60, 112,
+            178, 212, 201, 120, 179, 6, 222, 55, 158, 128, 171, 0, 138, 120, 195, 64, 245, 204,
+            117, 217, 156, 219, 144, 89, 81, 147, 102, 134, 68, 92, 131, 71, 25, 190, 33, 247, 98,
+            11, 149, 13, 205, 92, 128, 109, 134, 175, 84, 213, 223, 177, 192, 111, 63, 239, 221,
+            90, 67, 8, 97, 192, 209, 158, 37, 250, 212, 186, 208, 124, 110, 112, 212, 166, 121,
+            240, 184, 128, 243, 94, 220, 84, 0, 182, 102, 31, 177, 230, 251, 167, 197, 153, 200,
+            186, 137, 20, 88, 209, 68, 0, 3, 15, 165, 6, 153, 154, 25, 114, 54, 159, 128, 116, 108,
+            218, 160, 183, 218, 46, 156, 56, 100, 151, 31, 80, 241, 45, 155, 66, 129, 248, 4, 213,
+            162, 219, 166, 235, 224, 105, 89, 178, 169, 251, 71, 128, 46, 207, 222, 17, 69, 100,
+            35, 200, 127, 237, 128, 104, 244, 20, 165, 186, 68, 235, 227, 174, 145, 176, 109, 20,
+            204, 35, 26, 120, 212, 171, 166, 142, 128, 246, 85, 41, 24, 51, 164, 156, 242, 61, 5,
+            123, 177, 92, 66, 211, 119, 197, 93, 80, 245, 136, 83, 41, 6, 11, 10, 170, 178, 34,
+            131, 203, 177, 128, 140, 149, 251, 43, 98, 186, 243, 7, 24, 184, 51, 14, 246, 138, 82,
+            124, 151, 193, 188, 153, 96, 48, 67, 83, 34, 77, 138, 138, 232, 138, 121, 213, 128, 69,
+            193, 182, 217, 144, 74, 225, 113, 213, 115, 189, 206, 186, 160, 81, 66, 216, 22, 72,
+            189, 190, 177, 108, 238, 221, 197, 74, 14, 209, 93, 62, 43, 128, 168, 234, 25, 50, 130,
+            254, 133, 182, 72, 23, 7, 9, 28, 119, 201, 33, 142, 161, 157, 233, 20, 231, 89, 80,
+            146, 95, 232, 100, 0, 251, 12, 176, 128, 194, 34, 206, 171, 83, 85, 234, 164, 29, 168,
+            7, 20, 111, 46, 45, 247, 255, 100, 140, 62, 139, 187, 109, 142, 226, 50, 116, 186, 114,
+            69, 81, 177, 128, 8, 241, 66, 220, 60, 89, 191, 17, 81, 200, 41, 236, 239, 234, 53,
+            145, 158, 128, 69, 61, 181, 233, 102, 159, 90, 115, 137, 154, 170, 81, 102, 238, 128,
+            79, 29, 33, 251, 220, 1, 128, 196, 222, 136, 107, 244, 15, 145, 223, 194, 32, 43, 62,
+            182, 212, 37, 72, 212, 118, 144, 128, 65, 221, 97, 123, 184,
         ];
 
         let trie_root = {
@@ -518,7 +617,7 @@ mod tests {
 
         let decoded = super::decode_and_verify_proof(super::Config {
             trie_root_hash: &trie_root,
-            proof: proof.iter().map(|p| &p[..]),
+            proof,
         })
         .unwrap();
 
@@ -534,41 +633,33 @@ mod tests {
     #[test]
     fn node_values_smaller_than_32bytes() {
         let proof = vec![
-            vec![
-                158, 195, 101, 195, 207, 89, 214, 113, 235, 114, 218, 14, 122, 65, 19, 196, 0, 3,
-                88, 95, 7, 141, 67, 77, 97, 37, 180, 4, 67, 254, 17, 253, 41, 45, 19, 164, 16, 2,
-                0, 0, 0, 104, 95, 15, 31, 5, 21, 244, 98, 205, 207, 132, 224, 241, 214, 4, 93, 252,
-                187, 32, 80, 82, 127, 41, 119, 1, 0, 0,
-            ],
-            vec![
-                128, 175, 188, 128, 15, 126, 137, 9, 189, 204, 29, 117, 244, 124, 194, 9, 181, 214,
-                119, 106, 91, 55, 85, 146, 101, 112, 37, 46, 31, 42, 133, 72, 101, 38, 60, 66, 128,
-                28, 186, 118, 76, 106, 111, 232, 204, 106, 88, 52, 218, 113, 2, 76, 119, 132, 172,
-                202, 215, 130, 198, 184, 230, 206, 134, 44, 171, 25, 86, 243, 121, 128, 233, 10,
-                145, 50, 95, 100, 17, 213, 147, 28, 9, 142, 56, 95, 33, 40, 56, 9, 39, 3, 193, 79,
-                169, 207, 115, 80, 61, 217, 4, 106, 172, 152, 128, 12, 255, 241, 157, 249, 219,
-                101, 33, 139, 178, 174, 121, 165, 33, 175, 0, 232, 230, 129, 23, 89, 219, 21, 35,
-                23, 48, 18, 153, 124, 96, 81, 66, 128, 30, 174, 194, 227, 100, 149, 97, 237, 23,
-                238, 114, 178, 106, 158, 238, 48, 166, 82, 19, 210, 129, 122, 70, 165, 94, 186, 31,
-                28, 80, 29, 73, 252, 128, 16, 56, 19, 158, 188, 178, 192, 234, 12, 251, 221, 107,
-                119, 243, 74, 155, 111, 53, 36, 107, 183, 204, 174, 253, 183, 67, 77, 199, 47, 121,
-                185, 162, 128, 17, 217, 226, 195, 240, 113, 144, 201, 129, 184, 240, 237, 204, 79,
-                68, 191, 165, 29, 219, 170, 152, 134, 160, 153, 245, 38, 181, 131, 83, 209, 245,
-                194, 128, 137, 217, 3, 84, 1, 224, 52, 199, 112, 213, 150, 42, 51, 214, 103, 194,
-                225, 224, 210, 84, 84, 53, 31, 159, 82, 201, 3, 104, 118, 212, 110, 7, 128, 240,
-                251, 81, 190, 126, 80, 60, 139, 88, 152, 39, 153, 231, 178, 31, 184, 56, 44, 133,
-                31, 47, 98, 234, 107, 15, 248, 64, 78, 36, 89, 9, 149, 128, 233, 75, 238, 120, 212,
-                149, 223, 135, 48, 174, 211, 219, 223, 217, 20, 172, 212, 172, 3, 234, 54, 130, 55,
-                225, 63, 17, 255, 217, 150, 252, 93, 15, 128, 89, 54, 254, 99, 202, 80, 50, 27, 92,
-                48, 57, 174, 8, 211, 44, 58, 108, 207, 129, 245, 129, 80, 170, 57, 130, 80, 166,
-                250, 214, 40, 156, 181,
-            ],
-            vec![
-                128, 65, 0, 128, 182, 204, 71, 61, 83, 76, 85, 166, 19, 22, 212, 242, 236, 229, 51,
-                88, 16, 191, 227, 125, 217, 54, 7, 31, 36, 176, 211, 111, 72, 220, 181, 241, 128,
-                149, 2, 12, 26, 95, 9, 193, 115, 207, 253, 90, 218, 0, 41, 140, 119, 189, 166, 101,
-                244, 74, 171, 53, 248, 82, 113, 79, 110, 25, 72, 62, 65,
-            ],
+            12, 17, 1, 158, 195, 101, 195, 207, 89, 214, 113, 235, 114, 218, 14, 122, 65, 19, 196,
+            0, 3, 88, 95, 7, 141, 67, 77, 97, 37, 180, 4, 67, 254, 17, 253, 41, 45, 19, 164, 16, 2,
+            0, 0, 0, 104, 95, 15, 31, 5, 21, 244, 98, 205, 207, 132, 224, 241, 214, 4, 93, 252,
+            187, 32, 80, 82, 127, 41, 119, 1, 0, 0, 185, 5, 128, 175, 188, 128, 15, 126, 137, 9,
+            189, 204, 29, 117, 244, 124, 194, 9, 181, 214, 119, 106, 91, 55, 85, 146, 101, 112, 37,
+            46, 31, 42, 133, 72, 101, 38, 60, 66, 128, 28, 186, 118, 76, 106, 111, 232, 204, 106,
+            88, 52, 218, 113, 2, 76, 119, 132, 172, 202, 215, 130, 198, 184, 230, 206, 134, 44,
+            171, 25, 86, 243, 121, 128, 233, 10, 145, 50, 95, 100, 17, 213, 147, 28, 9, 142, 56,
+            95, 33, 40, 56, 9, 39, 3, 193, 79, 169, 207, 115, 80, 61, 217, 4, 106, 172, 152, 128,
+            12, 255, 241, 157, 249, 219, 101, 33, 139, 178, 174, 121, 165, 33, 175, 0, 232, 230,
+            129, 23, 89, 219, 21, 35, 23, 48, 18, 153, 124, 96, 81, 66, 128, 30, 174, 194, 227,
+            100, 149, 97, 237, 23, 238, 114, 178, 106, 158, 238, 48, 166, 82, 19, 210, 129, 122,
+            70, 165, 94, 186, 31, 28, 80, 29, 73, 252, 128, 16, 56, 19, 158, 188, 178, 192, 234,
+            12, 251, 221, 107, 119, 243, 74, 155, 111, 53, 36, 107, 183, 204, 174, 253, 183, 67,
+            77, 199, 47, 121, 185, 162, 128, 17, 217, 226, 195, 240, 113, 144, 201, 129, 184, 240,
+            237, 204, 79, 68, 191, 165, 29, 219, 170, 152, 134, 160, 153, 245, 38, 181, 131, 83,
+            209, 245, 194, 128, 137, 217, 3, 84, 1, 224, 52, 199, 112, 213, 150, 42, 51, 214, 103,
+            194, 225, 224, 210, 84, 84, 53, 31, 159, 82, 201, 3, 104, 118, 212, 110, 7, 128, 240,
+            251, 81, 190, 126, 80, 60, 139, 88, 152, 39, 153, 231, 178, 31, 184, 56, 44, 133, 31,
+            47, 98, 234, 107, 15, 248, 64, 78, 36, 89, 9, 149, 128, 233, 75, 238, 120, 212, 149,
+            223, 135, 48, 174, 211, 219, 223, 217, 20, 172, 212, 172, 3, 234, 54, 130, 55, 225, 63,
+            17, 255, 217, 150, 252, 93, 15, 128, 89, 54, 254, 99, 202, 80, 50, 27, 92, 48, 57, 174,
+            8, 211, 44, 58, 108, 207, 129, 245, 129, 80, 170, 57, 130, 80, 166, 250, 214, 40, 156,
+            181, 21, 1, 128, 65, 0, 128, 182, 204, 71, 61, 83, 76, 85, 166, 19, 22, 212, 242, 236,
+            229, 51, 88, 16, 191, 227, 125, 217, 54, 7, 31, 36, 176, 211, 111, 72, 220, 181, 241,
+            128, 149, 2, 12, 26, 95, 9, 193, 115, 207, 253, 90, 218, 0, 41, 140, 119, 189, 166,
+            101, 244, 74, 171, 53, 248, 82, 113, 79, 110, 25, 72, 62, 65,
         ];
 
         let trie_root = [
@@ -578,7 +669,7 @@ mod tests {
 
         let decoded = super::decode_and_verify_proof(super::Config {
             trie_root_hash: &trie_root,
-            proof: proof.iter().map(|p| &p[..]),
+            proof,
         })
         .unwrap();
 


### PR DESCRIPTION
This PR modifies the way Merkle proofs are passed around in the source code.

Before this PR, the networking code turns the networking response into a `Vec<Vec<u8>>`, which is then passed around smoldot. The inner `Vec<u8>` are still encoded, which means that the networking code decodes the proof a bit but not completely, which is kind of weird.

After this PR, the networking code returns the completely undecoded proof, and the decoding is now entirely done in the `proof_decode` module.

This should make everything easier to understand.