### PR TITLE
Clarify meaning of is_unreachable

### DIFF
--- a/bin/light-base/src/network_service/tasks.rs
+++ b/bin/light-base/src/network_service/tasks.rs
@@ -101,7 +101,7 @@ pub(super) async fn connection_task<TPlat: Platform>(
                 guarded.network.pending_outcome_err(
                     start_connect.id,
                     err.map_or(false, |err| err.is_bad_addr),
-                ); // TODO: should pass a proper value for `is_unreachable`, but an error is sometimes returned despite a timeout https://github.com/paritytech/smoldot/issues/1531
+                );
 
                 for chain_index in 0..guarded.network.num_chains() {
                     guarded

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -559,16 +559,15 @@ where
     /// See also [`ChainNetwork::pending_outcome_ok_single_stream`] and
     /// [`ChainNetwork::pending_outcome_ok_multi_stream`].
     ///
-    /// `is_unreachable` should be `true` if the address is invalid or unreachable and should
-    /// thus never be attempted again unless it is re-discovered. It should be `false` if the
-    /// address might only be temporarily unreachable, such as because of a timeout. If `false`
-    /// is passed, the address might be attempted again in the future.
+    /// `is_bad_address` should be `true` if the address is invalid or definitely unreachable and
+    /// should thus never be attempted again unless it is re-discovered. If `false` is passed, the
+    /// address might be attempted again in the future.
     ///
     /// # Panic
     ///
     /// Panics if the [`PendingId`] is invalid.
     ///
-    pub fn pending_outcome_err(&mut self, id: PendingId, is_unreachable: bool) {
+    pub fn pending_outcome_err(&mut self, id: PendingId, is_bad_address: bool) {
         let (expected_peer_id, multiaddr, _) = self.pending_ids.get(id.0).unwrap();
         let multiaddr = multiaddr.clone(); // Solves borrowck issues.
 
@@ -604,7 +603,7 @@ where
         // Updates the addresses book.
         if let Some(KBucketsPeer { addresses, .. }) = self.kbuckets_peers.get_mut(&expected_peer_id)
         {
-            if is_unreachable {
+            if is_bad_address {
                 // Do not remove last remaining address, in order to prevent the addresses
                 // list from ever becoming empty.
                 debug_assert!(!addresses.is_empty());

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -560,8 +560,8 @@ where
     /// [`ChainNetwork::pending_outcome_ok_multi_stream`].
     ///
     /// `is_bad_address` should be `true` if the address is invalid or definitely unreachable and
-    /// should thus never be attempted again unless it is re-discovered. If `false` is passed, the
-    /// address might be attempted again in the future.
+    /// should thus not be attempted again. If `false` is passed, the address might be attempted
+    /// again.
     ///
     /// # Panic
     ///


### PR DESCRIPTION
Close https://github.com/paritytech/smoldot/issues/1531
cc https://github.com/paritytech/smoldot/issues/2746

This PR renames `is_unreachable` to `is_bad_address`.
It is generally not possible to know whether an address is definitely unreachable or not. The only situation where we can affirm that an address is definitely unreachable is if our implementation doesn't support a certain protocol that it uses.

This matches what the browser node already does anyway.
