### PR TITLE
Implement encoding Merkle proofs

### DIFF
--- a/src/trie.rs
+++ b/src/trie.rs
@@ -94,6 +94,7 @@ pub mod calculate_root;
 pub mod node_value;
 pub mod prefix_proof;
 pub mod proof_decode;
+pub mod proof_encode;
 pub mod proof_node_codec;
 pub mod trie_structure;
 

--- a/src/trie/proof_encode.rs
+++ b/src/trie/proof_encode.rs
@@ -221,7 +221,7 @@ impl ProofBuilder {
     ///
     /// # Panic
     ///
-    /// Panics if the iterator returned by [`ProofBuilder::missing_merkle_values`] is not empty.
+    /// Panics if the iterator returned by [`ProofBuilder::missing_node_values`] is not empty.
     ///
     pub fn build(mut self) -> impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone {
         // As documented, panic if any node value is missing.

--- a/src/trie/proof_encode.rs
+++ b/src/trie/proof_encode.rs
@@ -16,6 +16,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::{proof_node_codec, trie_structure};
+
+use alloc::{borrow::ToOwned as _, vec::Vec};
 use core::iter;
 
 pub use super::nibble::Nibble;

--- a/src/trie/proof_encode.rs
+++ b/src/trie/proof_encode.rs
@@ -20,6 +20,7 @@ use core::iter;
 
 pub use super::nibble::Nibble;
 
+/// Prototype for a Merkle proof whose building is in progress.
 pub struct ProofBuilder {
     /// Contains a subset of the trie. Each node is associated with its node value if it is known,
     /// or `None` if it isn't known.
@@ -27,31 +28,37 @@ pub struct ProofBuilder {
     /// The `TrieStructure` data structure is very explicit in its usage. Nodes such as branch
     /// nodes are not implicitly but explicitly created. However, the trie structure is normally
     /// not meant to contain branch nodes without any children. In order to bypass this
-    /// restriction, we pretend
-    // TODO: finish comment
+    /// restriction, we pretend that nodes have a storage value when necessary even if this is
+    /// not the case.
     trie_structure: trie_structure::TrieStructure<Option<Node>>,
 
     /// List of keys of the nodes in [`ProofBuilder::trie_structure`] whose user data is `None`.
     missing_node_values: hashbrown::HashSet<Vec<Nibble>, fnv::FnvBuildHasher>,
+
+    /// Total number of entries that are going to be in the proof.
+    num_proof_entries: usize,
 }
 
 #[derive(Debug, Clone)]
 struct Node {
+    /// Value passed as `node_value` by the API user.
     node_value: Vec<u8>,
-    unhashed_storage_value: Option<Vec<u8>>,
+    /// Node containing the storage value associated with this node.
+    storage_value_node: Option<Vec<u8>>,
 }
 
 impl ProofBuilder {
+    /// Initializes a new empty proof builder.
+    ///
+    /// This is equivalent to calling [`ProofBuilder::with_nodes_capacity`] with a value of 0.
     pub fn new() -> Self {
-        ProofBuilder {
-            trie_structure: trie_structure::TrieStructure::new(),
-            missing_node_values: hashbrown::HashSet::with_capacity_and_hasher(
-                0,
-                Default::default(),
-            ),
-        }
+        Self::with_nodes_capacity(0)
     }
 
+    /// Initializes a new empty proof builder.
+    ///
+    /// Memory is allocated to store `capacity` nodes, in other words the number of nodes added
+    /// using [`ProofBuilder::set_node_value`].
     pub fn with_nodes_capacity(capacity: usize) -> Self {
         ProofBuilder {
             trie_structure: trie_structure::TrieStructure::with_capacity(capacity),
@@ -59,22 +66,25 @@ impl ProofBuilder {
                 capacity,
                 Default::default(),
             ),
+            num_proof_entries: 0,
         }
     }
 
     /// Inserts the node value of a given trie node into the builder.
     ///
-    /// Overwrites any previously set value for this key.
+    /// Overwrites any previously-set value for this key.
     ///
     /// The `node_value` is decoded in order for the proof builder to determine the hierarchy of
     /// the trie and know which node values are missing.
     ///
-    /// If the `node_value`.
+    /// If the `node_value` contains a storage value as a hash, then a `unhashed_storage_value`
+    /// can optionally be provided in order to provide the unhashed version of this value.
     ///
     /// # Panic
     ///
     /// Panics if `node_value` is not a valid node value.
-    /// Panics in case of mismatch between `unhashed_storage_value` and `node_value`.
+    /// Panics in case `node_value` indicates no storage value, but `unhashed_storage_value`
+    /// is `Some`.
     ///
     pub fn set_node_value(
         &mut self,
@@ -82,41 +92,67 @@ impl ProofBuilder {
         node_value: &[u8],
         unhashed_storage_value: Option<&[u8]>,
     ) {
-        let decoded = match proof_node_codec::decode(node_value) {
+        // The first thing to do is decode the node value, in order to detect invalid node values
+        // first things first.
+        let decoded_node_value = match proof_node_codec::decode(node_value) {
             Ok(d) => d,
             Err(err) => panic!("failed to decode node value: {:?}", err),
         };
 
-        match (&decoded.storage_value, &unhashed_storage_value) {
+        // Check consistency between `node_value` and `unhashed_storage_value` and determine
+        // whether a separate storage node should be included in the proof.
+        let storage_value_node = match (&decoded_node_value.storage_value, &unhashed_storage_value)
+        {
             (
                 proof_node_codec::StorageValue::Unhashed(ref in_node_value),
                 Some(ref user_provided),
-            ) => assert_eq!(in_node_value, user_provided),
+            ) => {
+                assert_eq!(in_node_value, user_provided);
+                None
+            }
             (proof_node_codec::StorageValue::Hashed(ref hash), Some(ref value)) => {
                 debug_assert_eq!(
                     blake2_rfc::blake2b::blake2b(32, b"", value).as_bytes(),
                     &hash[..]
                 );
+                Some(value.to_vec())
             }
             (proof_node_codec::StorageValue::None, Some(_)) => panic!(),
-            (_, None) => {}
-        }
+            (_, None) => None,
+        };
 
+        // Value that is going to be inserted in the trie.
         let trie_structure_value = Node {
             node_value: node_value.to_owned(),
-            unhashed_storage_value: unhashed_storage_value.map(|s| s.to_owned()),
+            storage_value_node,
+        };
+
+        // Update `num_proof_entries`.
+        self.num_proof_entries += 1 + if trie_structure_value.storage_value_node.is_some() {
+            1
+        } else {
+            0
         };
 
         match self.trie_structure.node(key.iter().copied()) {
             trie_structure::Entry::Occupied(mut entry) => {
+                // Update the value in the trie structure, and cancel out the previous change
+                // to `num_proof_entries`.
+                if let Some(prev_entry) = entry.user_data() {
+                    self.num_proof_entries -= 1 + if prev_entry.storage_value_node.is_some() {
+                        1
+                    } else {
+                        0
+                    };
+                }
                 let _was_in = self.missing_node_values.remove(key);
                 debug_assert_eq!(_was_in, entry.user_data().is_none());
                 *entry.user_data() = Some(trie_structure_value);
             }
             trie_structure::Entry::Vacant(entry) => {
                 // We insert a storage value for the given node, even though the node might be
-                // a branch node. This is necessary in order for the trie structure to keep our
-                // node, as otherwise the node wouldn't exist.
+                // a branch node. This is necessary in order for the trie structure to store our
+                // node, as otherwise the node possibly wouldn't exist.
                 match entry.insert_storage_value() {
                     trie_structure::PrepareInsert::One(insert) => {
                         insert.insert(Some(trie_structure_value));
@@ -133,9 +169,9 @@ impl ProofBuilder {
         }
 
         // We must also make sure that the parent of the node is in the proof. Insert the parent
-        // in the trie structure as well. This doesn't need to be done if the parent of the node
-        // is `[]`.
-        let partial_key_len = decoded.partial_key.count();
+        // in the trie structure as well.
+        // This shouldn't be done if the node is the root node of the trie.
+        let partial_key_len = decoded_node_value.partial_key.count();
         if key.len() != partial_key_len {
             let parent_key = &key[..(key.len() - partial_key_len - 1)];
             match self.trie_structure.node(parent_key.iter().copied()) {
@@ -186,14 +222,13 @@ impl ProofBuilder {
     /// Panics if the iterator returned by [`ProofBuilder::missing_merkle_values`] is not empty.
     ///
     pub fn build(mut self) -> impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone {
-        // As documented, we panic if any node value is missing.
+        // As documented, panic if any node value is missing.
         assert!(self.missing_node_values.is_empty());
 
         // The first bytes of the proof contain the number of entries in the proof.
-        // TODO: wrong, doesn't handle separate storage values
-        let num_entries_encoded =
-            crate::util::encode_scale_compact_usize(self.trie_structure.len());
+        let num_entries_encoded = crate::util::encode_scale_compact_usize(self.num_proof_entries);
 
+        // Iterator to the entries in the proof.
         // TODO: we need to collect the indices into a Vec due to the API of trie_structure not allowing non-mutable access to nodes
         let entries = self
             .trie_structure
@@ -208,13 +243,27 @@ impl ProofBuilder {
                     .user_data()
                     .take()
                     .expect("missing node value");
-                let length =
-                    crate::util::encode_scale_compact_usize(trie_structure_value.node_value.len());
+
+                // For each node, there are either two things or four things to output: the
+                // length of the node value and the node value, and optionally the length of the
+                // storage value and storage value
+                let node_value_length = Some(crate::util::encode_scale_compact_usize(
+                    trie_structure_value.node_value.len(),
+                ));
+                let node_value = Some(trie_structure_value.node_value);
+                let storage_value = trie_structure_value.storage_value_node;
+                let storage_value_length = storage_value
+                    .as_ref()
+                    .map(|v| crate::util::encode_scale_compact_usize(v.len()));
+
                 [
-                    either::Left(length),
-                    either::Right(trie_structure_value.node_value),
+                    node_value_length.map(either::Left),
+                    node_value.map(either::Right),
+                    storage_value_length.map(either::Left),
+                    storage_value.map(either::Right),
                 ]
                 .into_iter()
+                .flat_map(|v| v.into_iter())
             });
 
         iter::once(either::Left(num_entries_encoded)).chain(entries.map(either::Right))
@@ -233,10 +282,72 @@ impl ProofBuilder {
 
 #[cfg(test)]
 mod tests {
+    use super::super::nibble;
+
     #[test]
     fn empty_works() {
-        let proof = super::ProofBuilder::new();
-        assert_eq!(proof.missing_node_values().count(), 0);
-        assert_eq!(proof.build_to_vec(), &[0]);
+        let proof_builder = super::ProofBuilder::new();
+        assert_eq!(proof_builder.missing_node_values().count(), 0);
+        assert_eq!(proof_builder.build_to_vec(), &[0]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn invalid_node_value_detected() {
+        let mut proof_builder = super::ProofBuilder::new();
+        proof_builder.set_node_value(
+            &nibble::bytes_to_nibbles([1, 2, 3, 4].into_iter()).collect::<Vec<_>>(),
+            b"foobar",
+            None,
+        );
+    }
+
+    #[test]
+    fn one_root_node_works() {
+        let mut proof_builder = super::ProofBuilder::new();
+
+        proof_builder.set_node_value(
+            &nibble::bytes_to_nibbles([1, 2, 3, 4].into_iter()).collect::<Vec<_>>(),
+            &[72, 1, 2, 3, 4, 20, 104, 101, 108, 108, 111],
+            None,
+        );
+
+        assert_eq!(proof_builder.missing_node_values().count(), 0);
+        assert_eq!(
+            proof_builder.build_to_vec(),
+            &[4, 44, 72, 1, 2, 3, 4, 20, 104, 101, 108, 108, 111]
+        );
+    }
+
+    #[test]
+    fn one_node_non_root_detects_root_node() {
+        let mut proof_builder = super::ProofBuilder::new();
+
+        proof_builder.set_node_value(
+            &nibble::bytes_to_nibbles([1, 2, 3, 4].into_iter()).collect::<Vec<_>>(),
+            &[68, 3, 4, 20, 104, 101, 108, 108, 111],
+            None,
+        );
+
+        assert_eq!(
+            proof_builder.missing_node_values().collect::<Vec<_>>(),
+            vec![&[
+                nibble::Nibble::try_from(0).unwrap(),
+                nibble::Nibble::try_from(1).unwrap(),
+                nibble::Nibble::try_from(0).unwrap()
+            ]]
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn build_panics_if_missing_node() {
+        let mut proof_builder = super::ProofBuilder::new();
+        proof_builder.set_node_value(
+            &nibble::bytes_to_nibbles([1, 2, 3, 4].into_iter()).collect::<Vec<_>>(),
+            &[68, 3, 4, 20, 104, 101, 108, 108, 111],
+            None,
+        );
+        let _ = proof_builder.build();
     }
 }

--- a/src/trie/proof_encode.rs
+++ b/src/trie/proof_encode.rs
@@ -77,10 +77,17 @@ impl ProofBuilder {
     /// Overwrites any previously-set value for this key.
     ///
     /// The `node_value` is decoded in order for the proof builder to determine the hierarchy of
-    /// the trie and know which node values are missing.
+    /// the trie and know which node values are missing. If the `node_value` is invalid, this
+    /// function panics.
     ///
     /// If the `node_value` contains a storage value as a hash, then a `unhashed_storage_value`
     /// can optionally be provided in order to provide the unhashed version of this value.
+    ///
+    /// The validity of the `node_value` in the context of the other node values that have been
+    /// stored in this proof builder isn't verified. For example, a node value can indicate no
+    /// children while the node value of a child has been added, or a node value can indicate a
+    /// child with a specific hash, while the child in question has a different hash. This will
+    /// lead to an invalid proof being generated.
     ///
     /// # Panic
     ///

--- a/src/trie/proof_encode.rs
+++ b/src/trie/proof_encode.rs
@@ -202,8 +202,8 @@ impl ProofBuilder {
         }
     }
 
-    /// Returns a list of keys for which the node value must be known in order for the proof to be
-    /// buildable.
+    /// Returns a list of keys for which the node value must be known in order to be able to build
+    /// the proof.
     ///
     /// For each entry returned by this iterator, [`ProofBuilder::set_node_value`] must be called.
     ///

--- a/src/trie/proof_encode.rs
+++ b/src/trie/proof_encode.rs
@@ -1,0 +1,242 @@
+// Smoldot
+// Copyright (C) 2019-2022  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::{proof_node_codec, trie_structure};
+use core::iter;
+
+pub use super::nibble::Nibble;
+
+pub struct ProofBuilder {
+    /// Contains a subset of the trie. Each node is associated with its node value if it is known,
+    /// or `None` if it isn't known.
+    ///
+    /// The `TrieStructure` data structure is very explicit in its usage. Nodes such as branch
+    /// nodes are not implicitly but explicitly created. However, the trie structure is normally
+    /// not meant to contain branch nodes without any children. In order to bypass this
+    /// restriction, we pretend
+    // TODO: finish comment
+    trie_structure: trie_structure::TrieStructure<Option<Node>>,
+
+    /// List of keys of the nodes in [`ProofBuilder::trie_structure`] whose user data is `None`.
+    missing_node_values: hashbrown::HashSet<Vec<Nibble>, fnv::FnvBuildHasher>,
+}
+
+#[derive(Debug, Clone)]
+struct Node {
+    node_value: Vec<u8>,
+    unhashed_storage_value: Option<Vec<u8>>,
+}
+
+impl ProofBuilder {
+    pub fn new() -> Self {
+        ProofBuilder {
+            trie_structure: trie_structure::TrieStructure::new(),
+            missing_node_values: hashbrown::HashSet::with_capacity_and_hasher(
+                0,
+                Default::default(),
+            ),
+        }
+    }
+
+    pub fn with_nodes_capacity(capacity: usize) -> Self {
+        ProofBuilder {
+            trie_structure: trie_structure::TrieStructure::with_capacity(capacity),
+            missing_node_values: hashbrown::HashSet::with_capacity_and_hasher(
+                capacity,
+                Default::default(),
+            ),
+        }
+    }
+
+    /// Inserts the node value of a given trie node into the builder.
+    ///
+    /// Overwrites any previously set value for this key.
+    ///
+    /// The `node_value` is decoded in order for the proof builder to determine the hierarchy of
+    /// the trie and know which node values are missing.
+    ///
+    /// If the `node_value`.
+    ///
+    /// # Panic
+    ///
+    /// Panics if `node_value` is not a valid node value.
+    /// Panics in case of mismatch between `unhashed_storage_value` and `node_value`.
+    ///
+    pub fn set_node_value(
+        &mut self,
+        key: &[Nibble],
+        node_value: &[u8],
+        unhashed_storage_value: Option<&[u8]>,
+    ) {
+        let decoded = match proof_node_codec::decode(node_value) {
+            Ok(d) => d,
+            Err(err) => panic!("failed to decode node value: {:?}", err),
+        };
+
+        match (&decoded.storage_value, &unhashed_storage_value) {
+            (
+                proof_node_codec::StorageValue::Unhashed(ref in_node_value),
+                Some(ref user_provided),
+            ) => assert_eq!(in_node_value, user_provided),
+            (proof_node_codec::StorageValue::Hashed(ref hash), Some(ref value)) => {
+                debug_assert_eq!(
+                    blake2_rfc::blake2b::blake2b(32, b"", value).as_bytes(),
+                    &hash[..]
+                );
+            }
+            (proof_node_codec::StorageValue::None, Some(_)) => panic!(),
+            (_, None) => {}
+        }
+
+        let trie_structure_value = Node {
+            node_value: node_value.to_owned(),
+            unhashed_storage_value: unhashed_storage_value.map(|s| s.to_owned()),
+        };
+
+        match self.trie_structure.node(key.iter().copied()) {
+            trie_structure::Entry::Occupied(mut entry) => {
+                let _was_in = self.missing_node_values.remove(key);
+                debug_assert_eq!(_was_in, entry.user_data().is_none());
+                *entry.user_data() = Some(trie_structure_value);
+            }
+            trie_structure::Entry::Vacant(entry) => {
+                // We insert a storage value for the given node, even though the node might be
+                // a branch node. This is necessary in order for the trie structure to keep our
+                // node, as otherwise the node wouldn't exist.
+                match entry.insert_storage_value() {
+                    trie_structure::PrepareInsert::One(insert) => {
+                        insert.insert(Some(trie_structure_value));
+                    }
+                    trie_structure::PrepareInsert::Two(insert) => {
+                        let _was_inserted = self
+                            .missing_node_values
+                            .insert(insert.branch_node_key().collect());
+                        debug_assert!(_was_inserted);
+                        insert.insert(Some(trie_structure_value), None);
+                    }
+                }
+            }
+        }
+
+        // We must also make sure that the parent of the node is in the proof. Insert the parent
+        // in the trie structure as well. This doesn't need to be done if the parent of the node
+        // is `[]`.
+        let partial_key_len = decoded.partial_key.count();
+        if key.len() != partial_key_len {
+            let parent_key = &key[..(key.len() - partial_key_len - 1)];
+            match self.trie_structure.node(parent_key.iter().copied()) {
+                trie_structure::Entry::Occupied(_) => {
+                    // The parent is already in the structure. Nothing to do.
+                }
+                trie_structure::Entry::Vacant(entry) => match entry.insert_storage_value() {
+                    trie_structure::PrepareInsert::One(insert) => {
+                        let _was_inserted = self.missing_node_values.insert(parent_key.to_owned());
+                        debug_assert!(_was_inserted);
+                        insert.insert(None);
+                    }
+                    trie_structure::PrepareInsert::Two(insert) => {
+                        let _was_inserted = self.missing_node_values.insert(parent_key.to_owned());
+                        debug_assert!(_was_inserted);
+
+                        let _was_inserted = self
+                            .missing_node_values
+                            .insert(insert.branch_node_key().collect());
+                        debug_assert!(_was_inserted);
+
+                        insert.insert(None, None);
+                    }
+                },
+            }
+        }
+    }
+
+    /// Returns a list of keys for which the node value must be known in order for the proof to be
+    /// buildable.
+    ///
+    /// For each entry returned by this iterator, [`ProofBuilder::set_node_value`] must be called.
+    ///
+    /// This function has a complexity of `O(1)` and thus can be called repeatedly.
+    pub fn missing_node_values(&self) -> impl Iterator<Item = &[Nibble]> {
+        self.missing_node_values.iter().map(|v| &v[..])
+    }
+
+    /// Builds the Merkle proof.
+    ///
+    /// This function returns an iterator of buffers. The actual Merkle proof consists in the
+    /// concatenation of all the buffers.
+    ///
+    /// This function will succeed if no entry at all has been inserted in the [`ProofBuilder`].
+    ///
+    /// # Panic
+    ///
+    /// Panics if the iterator returned by [`ProofBuilder::missing_merkle_values`] is not empty.
+    ///
+    pub fn build(mut self) -> impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone {
+        // As documented, we panic if any node value is missing.
+        assert!(self.missing_node_values.is_empty());
+
+        // The first bytes of the proof contain the number of entries in the proof.
+        // TODO: wrong, doesn't handle separate storage values
+        let num_entries_encoded =
+            crate::util::encode_scale_compact_usize(self.trie_structure.len());
+
+        // TODO: we need to collect the indices into a Vec due to the API of trie_structure not allowing non-mutable access to nodes
+        let entries = self
+            .trie_structure
+            .iter_unordered()
+            .collect::<Vec<_>>()
+            .into_iter()
+            .flat_map(move |node_index| {
+                let trie_structure_value = self
+                    .trie_structure
+                    .node_by_index(node_index)
+                    .unwrap()
+                    .user_data()
+                    .take()
+                    .expect("missing node value");
+                let length =
+                    crate::util::encode_scale_compact_usize(trie_structure_value.node_value.len());
+                [
+                    either::Left(length),
+                    either::Right(trie_structure_value.node_value),
+                ]
+                .into_iter()
+            });
+
+        iter::once(either::Left(num_entries_encoded)).chain(entries.map(either::Right))
+    }
+
+    /// Similar to [`ProofBuilder::build`], but returns a `Vec`.
+    ///
+    /// This is a convenience wrapper around [`ProofBuilder::build`].
+    pub fn build_to_vec(self) -> Vec<u8> {
+        self.build().fold(Vec::new(), |mut a, b| {
+            a.extend_from_slice(b.as_ref());
+            a
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn empty_works() {
+        let proof = super::ProofBuilder::new();
+        assert_eq!(proof.missing_node_values().count(), 0);
+        assert_eq!(proof.build_to_vec(), &[0]);
+    }
+}

--- a/src/trie/trie_structure.rs
+++ b/src/trie/trie_structure.rs
@@ -35,6 +35,7 @@ mod tests;
 ///
 /// This struct doesn't represent a complete trie. It only manages the structure of the trie, and
 /// the storage values have to be maintained in parallel of this.
+#[derive(Clone)]
 pub struct TrieStructure<TUd> {
     /// List of nodes. Using a [`Slab`] guarantees that the node indices never change.
     nodes: Slab<Node<TUd>>,
@@ -43,7 +44,7 @@ pub struct TrieStructure<TUd> {
 }
 
 /// Entry in the structure.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Node<TUd> {
     /// Index of the parent within [`TrieStructure::nodes`]. `None` if this is the root.
     parent: Option<(usize, Nibble)>,
@@ -158,6 +159,11 @@ impl<TUd> TrieStructure<TUd> {
     /// See [`Vec::shrink_to_fit`].
     pub fn shrink_to_fit(&mut self) {
         self.nodes.shrink_to_fit();
+    }
+
+    /// Returns a list of all nodes in the structure, without any specific order.
+    pub fn iter_unordered(&'_ self) -> impl Iterator<Item = NodeIndex> + '_ {
+        self.nodes.iter().map(|(k, _)| NodeIndex(k))
     }
 
     /// Returns the root node of the trie, or `None` if the trie is empty.


### PR DESCRIPTION
cc https://github.com/paritytech/smoldot/issues/2973

I went for an API where the user provides already-existing node values in order to encode the proof. I went for this, as the main point of building a proof is to extract information from the trie, and when doing that you normally already know node values.

I also think that this API is very easy to understand compared to other APIs that I could have gone for.
