### PR TITLE
Fix wrong Grandpa warp sync block being reported

### DIFF
--- a/bin/light-base/src/sync_service/standalone.rs
+++ b/bin/light-base/src/sync_service/standalone.rs
@@ -316,17 +316,21 @@ pub(super) async fn start_standalone_chain<TPlat: Platform>(
             () = &mut task.warp_sync_taking_long_time_warning => {
                 match task.sync.status() {
                     all::Status::Sync => {},
-                    all::Status::WarpSyncFragments { source: None } => {
-                        log::warn!(target: &task.log_target, "GrandPa warp sync idle");
+                    all::Status::WarpSyncFragments { source: None, finalized_block_hash, finalized_block_number } => {
+                        log::warn!(
+                            target: &task.log_target,
+                            "GrandPa warp sync idle at block #{} (0x{})",
+                            finalized_block_number,
+                            HashDisplay(&finalized_block_hash),
+                        );
                     }
-                    all::Status::WarpSyncFragments { source: Some((_, (peer_id, _))) } |
-                    all::Status::WarpSyncChainInformation { source: (_, (peer_id, _)) } => {
-                        let finalized_block = task.sync.finalized_block_header();
+                    all::Status::WarpSyncFragments { source: Some((_, (peer_id, _))), finalized_block_hash, finalized_block_number } |
+                    all::Status::WarpSyncChainInformation { source: (_, (peer_id, _)), finalized_block_hash, finalized_block_number } => {
                         log::warn!(
                             target: &task.log_target,
                             "GrandPa warp sync in progress. Block: #{} (0x{}). Peer attempt: {}.",
-                            finalized_block.number,
-                            HashDisplay(&finalized_block.hash(task.sync.block_number_bytes())),
+                            finalized_block_number,
+                            HashDisplay(&finalized_block_hash),
                             peer_id
                         );
                     },

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix wrong block being reported in the logs when printing the status of the Grandpa warp syncing, giving the impression that the warp syncing wasn't advancing. ([#3044](https://github.com/paritytech/smoldot/pull/3044))
+
 ## 0.7.8 - 2022-11-23
 
 ### Changed

--- a/src/sync/all.rs
+++ b/src/sync/all.rs
@@ -135,8 +135,8 @@ pub enum Status<'a, TSrc> {
         /// Hash of the highest block that is proven to be finalized.
         ///
         /// This isn't necessarily the same block as returned by
-        /// [`InProgressWarpSync::as_chain_information`], as this function first has to download
-        /// extra information compared to just the finalized block.
+        /// [`AllSync::as_chain_information`], as this function first has to download extra
+        /// information compared to just the finalized block.
         finalized_block_hash: [u8; 32],
         /// Height of the block indicated by [`Status::ChainInformation::finalized_block_hash`].
         finalized_block_number: u64,
@@ -149,8 +149,8 @@ pub enum Status<'a, TSrc> {
         /// Hash of the highest block that is proven to be finalized.
         ///
         /// This isn't necessarily the same block as returned by
-        /// [`InProgressWarpSync::as_chain_information`], as this function first has to download
-        /// extra information compared to just the finalized block.
+        /// [`AllSync::as_chain_information`], as this function first has to download extra
+        /// information compared to just the finalized block.
         finalized_block_hash: [u8; 32],
         /// Height of the block indicated by [`Status::ChainInformation::finalized_block_hash`].
         finalized_block_number: u64,


### PR DESCRIPTION
Fix https://github.com/paritytech/smoldot/issues/3015

We now properly report the block of the fragments which we've downloaded, as opposed to the block whose chain information we have.
