### PR TITLE
Fix Merkle proof whose trie root node is inferior to 32 bytes being considered as invalid

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix Merkle proof whose trie root node is inferior to 32 bytes being considered as invalid.
+
 ## 0.7.9 - 2022-11-28
 
 ### Fixed

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix Merkle proof whose trie root node is inferior to 32 bytes being considered as invalid.
+- Fix Merkle proof whose trie root node is inferior to 32 bytes being considered as invalid. ([#3046](https://github.com/paritytech/smoldot/pull/3046))
 
 ## 0.7.9 - 2022-11-28
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix Merkle proof whose trie root node is inferior to 32 bytes being considered as invalid. ([#3046](https://github.com/paritytech/smoldot/pull/3046))
+- Fix Merkle proofs whose trie root node has a size inferior to 32 bytes being considered as invalid. ([#3046](https://github.com/paritytech/smoldot/pull/3046))
 
 ## 0.7.9 - 2022-11-28
 

--- a/src/trie/proof_decode.rs
+++ b/src/trie/proof_decode.rs
@@ -868,4 +868,21 @@ mod tests {
 
         assert_eq!(obtained, Some(&[80, 82, 127, 41, 119, 1, 0, 0][..]));
     }
+
+    #[test]
+    fn very_small_root_node_decodes() {
+        // Checks that a proof with one root node whose length is < 32 bytes properly verifies.
+        let proof = vec![
+            4, 64, 66, 3, 52, 120, 31, 215, 222, 245, 16, 76, 51, 181, 0, 245, 192, 194,
+        ];
+
+        super::decode_and_verify_proof(super::Config {
+            proof,
+            trie_root_hash: &[
+                83, 2, 191, 235, 8, 252, 233, 114, 129, 199, 229, 115, 221, 238, 15, 205, 193, 110,
+                145, 107, 12, 3, 10, 145, 117, 211, 203, 151, 182, 147, 221, 178,
+            ],
+        })
+        .unwrap();
+    }
 }

--- a/src/trie/proof_decode.rs
+++ b/src/trie/proof_decode.rs
@@ -608,7 +608,7 @@ pub enum Error {
     UnusedProofEntry,
     /// The same entry has been found multiple times in the proof.
     DuplicateProofEntry,
-    /// A node has been passed separately and refered to by its hash, while its length is inferior
+    /// A node has been passed separately and referred to by its hash, while its length is inferior
     /// to 32 bytes.
     UnexpectedHashedNode,
 }


### PR DESCRIPTION
Right now, we either hash each proof entry or take its inline value if it is too small.

This isn't correct, for two reasons:

- The root node is always hashed, meaning that right now if the root node of a proof is < 32 bytes, its hash won't be found in our array.
- Nodes that are < 32 bytes should be inlined. There's no situation where a node whose length is < 32 bytes has its own proof entry.

Consequently, we don't care about inline values and just hash the node entries.
We also check whether hashed nodes shouldn't have been inlined, although this is very secondary.
