### PR TITLE
Fix wrong check in network_service

### DIFF
--- a/bin/full-node/src/run/network_service.rs
+++ b/bin/full-node/src/run/network_service.rs
@@ -554,8 +554,10 @@ impl NetworkService {
         let mut guarded = self.inner.guarded.lock().await;
 
         // The call to `send_block_announce` below panics if we have no active connection.
-        // TODO: not the correct check; must make sure that we have a substream open
-        if !guarded.network.can_start_requests(target) {
+        if !guarded
+            .network
+            .can_send_block_announces(target, chain_index)
+        {
             return Err(QueueNotificationError::NoConnection);
         }
 


### PR DESCRIPTION
The wrong check was being done, because the `can_send_block_announces` function didn't exist until recently.