### PR TITLE
fix random

### DIFF
--- a/bin/wasm-node/javascript/src/instance/bindings-wasi.ts
+++ b/bin/wasm-node/javascript/src/instance/bindings-wasi.ts
@@ -66,10 +66,10 @@ export default (config: Config): WebAssembly.ModuleImports => {
             len >>>= 0;
 
             const baseBuffer = new Uint8Array(instance.exports.memory.buffer)
-                .slice(ptr, ptr + len);
+                .subarray(ptr, ptr + len);
             for (let iter = 0; iter < len; iter += 65536) {
-                // `baseBuffer.slice` automatically saturates at the end of the buffer
-                config.getRandomValues(baseBuffer.slice(iter, iter + 65536))
+                // `baseBuffer.subarray` automatically saturates at the end of the buffer
+                config.getRandomValues(baseBuffer.subarray(iter, iter + 65536))
             }
 
             return 0;


### PR DESCRIPTION
wasm smoldot node always started with same peer id  
because [`.slice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice) (clone) and [`.subarray()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/subarray) (mutable reference) were confused  
so randomness was not written back to wasm memory