### PR TITLE
camelCase transaction status to align with Substrate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     - uses: baptiste0928/cargo-install@v1  # This action ensures that the twiggy compilation is cached.
       with:
         crate: twiggy
-        version: 0.6
+        version: 0.7
     - run: git checkout ${{ github.event.pull_request.base.sha }}
     - run: cd bin/wasm-node/javascript && npm ci && npm run-script build
     - run: cp ./target/wasm32-wasi/min-size-release/smoldot_light_wasm.wasm ./.ci-parent-build.wasm  # TODO: maybe get the path from the `npm build` output or something?

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# DEPRECATED
+
+This repository is deprecated in favor of: <https://github.com/smol-dot/smoldot>
+
+
+
 Lightweight Substrate and Polkadot client.
 
 # Introduction

--- a/src/json_rpc/methods.rs
+++ b/src/json_rpc/methods.rs
@@ -1006,6 +1006,7 @@ pub enum SystemPeerRole {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub enum TransactionStatus {
     Future,
     Ready,


### PR DESCRIPTION
Hey! An error cropped up via Ink in trying to use Subxt to communicate with Smoldot:

```
error on call `wait_for_in_block`: Serialization(Error("unknown variant `Ready`, expected one of `future`, `ready`, `broadcast`, `inBlock`, `retracted`, `finalityTimeout`, `finalized`, `usurped`, `dropped`, `invalid`", line: 1, column: 8))', /Users/bruno/.cargo/git/checkouts/ink-1add513eda8f5a89/9c9215f/crates/e2e/src/xts.rs:270:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I believe the reason for the issue was that Smoldot's `author_submitAndWatchExtrinsic` returns transaction statuses whose variants aren't camelCased, whereas the Substrate RPC method does camelCase (see https://github.com/paritytech/substrate/blob/283106b19b85bc8deb232cfa624eed195f143541/client/transaction-pool/api/src/lib.rs#L106)

So I wonder whether you'd be open to applying the same camelCasing in Smoldot to align?