### PR TITLE
Log when statement protocol substream opens

### DIFF
--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -3161,6 +3161,16 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                 chain_id,
                 version,
             }) => {
+                log!(
+                    &task.platform,
+                    Trace,
+                    "network",
+                    "statement-protocol-open-success",
+                    chain = &task.network[chain_id].log_name,
+                    peer_id,
+                    ?version,
+                );
+
                 if matches!(version, codec::StatementProtocolVersion::V2) {
                     task.v2_statement_peers
                         .entry(chain_id)


### PR DESCRIPTION
### Problem
When a JSON-RPC client has an active statement subscription, there is no observable signal telling us whether smoldot is actually connected to any `/statement/1` peer. If none are connected, the subscription silently receives no data.

### Solution
Add a `Trace` log on `StatementProtocolConnected` in the network service. This gives operators a way to confirm statement substreams are actually opening, without adding new API surface or blocking the JSON-RPC thread.

Replaces the previous approach (`statement_peers_list` / `statement_connected_peers` + warning) after review feedback that those changes were overkill and the broadcast-filtering justification was invalid (peers without the statement store never accept a statement substream in the first place).