### PR TITLE
Speed-up loading from the database

### DIFF
--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -198,8 +198,6 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                     .download_all_chain_information_storage_proofs,
                 code_trie_node_hint: config.code_trie_node_hint,
                 num_download_ahead_fragments: 128, // TODO: make configurable?
-                // TODO: make configurable?
-                warp_sync_minimum_gap: 32,
                 download_block_body: config.download_bodies,
             })
             .ok(),
@@ -962,7 +960,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         }) = self.ready_to_transition.take()
         {
             let (Some(all_forks), Some(warp_sync)) =
-                (self.all_forks.as_mut(), self.warp_sync.as_mut())
+                (self.all_forks.as_mut(), self.warp_sync.take())
             else {
                 unreachable!()
             };

--- a/lib/src/sync/warp_sync.rs
+++ b/lib/src/sync/warp_sync.rs
@@ -148,17 +148,6 @@ pub struct Config {
     /// risk of wasting more bandwidth in case the downloaded fragments need to be thrown away.
     pub num_download_ahead_fragments: usize,
 
-    /// If the height of the current local finalized block is `N`, the warp sync state machine
-    /// will not attempt to warp sync to blocks whose height inferior or equal to `N + k` where
-    /// `k` is the value in this field.
-    ///
-    /// Because warp syncing is a relatively expensive process, it is not worth performing it
-    /// between two blocks that are too close to each other.
-    ///
-    /// The ideal value of this field depends on the block production rate and the time it takes
-    /// to answer requests.
-    pub warp_sync_minimum_gap: usize,
-
     /// If `true`, the body of the warp sync target will be downloaded before the warp sync
     /// finishes.
     /// Determines whether [`RuntimeInformation::finalized_body`] is `Some`.
@@ -245,7 +234,6 @@ pub fn start_warp_sync<TSrc, TRq>(
         verified_chain_information: config.start_chain_information,
         code_trie_node_hint: config.code_trie_node_hint,
         num_download_ahead_fragments: config.num_download_ahead_fragments,
-        warp_sync_minimum_gap: config.warp_sync_minimum_gap,
         block_number_bytes: config.block_number_bytes,
         download_all_chain_information_storage_proofs: config
             .download_all_chain_information_storage_proofs,
@@ -345,8 +333,6 @@ pub struct WarpSync<TSrc, TRq> {
     verified_chain_information: ValidChainInformation,
     /// See [`Config::num_download_ahead_fragments`].
     num_download_ahead_fragments: usize,
-    /// See [`Config::warp_sync_minimum_gap`].
-    warp_sync_minimum_gap: usize,
     /// See [`Config::block_number_bytes`].
     block_number_bytes: usize,
     /// See [`Config::download_all_chain_information_storage_proofs`].
@@ -836,16 +822,9 @@ impl<TSrc, TRq> WarpSync<TSrc, TRq> {
                             .map(|header| header.number)
                     })
                     .unwrap_or(Some(self.warped_header_number));
-                let warp_sync_minimum_gap = self.warp_sync_minimum_gap;
-
                 if let Some(verify_queue_tail_block_number) = verify_queue_tail_block_number {
-                    // Combine the request with every single available source.
                     either::Left(self.sources.iter().filter_map(move |(src_id, src)| {
-                        if src.finalized_block_height
-                            <= verify_queue_tail_block_number.saturating_add(
-                                u64::try_from(warp_sync_minimum_gap).unwrap_or(u64::MAX),
-                            )
-                        {
+                        if src.finalized_block_height <= verify_queue_tail_block_number {
                             return None;
                         }
 

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -941,15 +941,17 @@ async fn run_background<TPlat: PlatformRef>(
                 loop {
                     // There might be a new runtime download to start.
                     // Don't download more than 2 runtimes at a time.
-                    let wait = if num_runtime_downloads < 2 {
-                        // Grab what to download. If there's nothing more to download, do nothing.
+                    // When the finalized block runtime is unknown, don't try to download
+                    // it independently. The sync service will provide it either through
+                    // warp sync (via subscribe_all after subscription reset) or through
+                    // the initial subscription. Downloading here would fail because peers
+                    // might not be connected yet, hitting a 10-second retry delay.
+                    let wait = if num_runtime_downloads < 2 && finalized_block_known {
                         let async_op = match &mut background.tree {
                             Tree::FinalizedBlockRuntimeKnown { tree, .. } => {
                                 tree.next_necessary_async_op(&background.platform.now())
                             }
-                            Tree::FinalizedBlockRuntimeUnknown { tree, .. } => {
-                                tree.next_necessary_async_op(&background.platform.now())
-                            }
+                            Tree::FinalizedBlockRuntimeUnknown { .. } => unreachable!(),
                         };
 
                         match async_op {


### PR DESCRIPTION
This fixes the loading times of smoldot when using the database. The problem basically was that it tried at startup to load the runtime,
 failed because of missing peers. The moment it finished the warp sync, it was still in the 10s cooldown after a failed runtime download. This is now fixed by this pull request.

This pull request also ensures to stop the warp sync after it is done. Also the `warp_sync_minimum_gap` is removed, because it should actually be faster to warp sync `X` blocks than downloading them one by one.

Should help with: https://github.com/paritytech/smoldot/issues/3153