### PR TITLE
fix: retain parachain finalized runtime for subscribe_all

### DIFF
--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -78,7 +78,8 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
             &effective_chain_info,
             block_number_bytes,
         )
-        .await {
+        .await
+        {
             Ok(bootstrapped) => break bootstrapped,
             Err(err) => {
                 log!(
@@ -1303,8 +1304,7 @@ async fn bootstrap_parachain_consensus<TPlat: PlatformRef>(
     let (code, _) = decoded_proof
         .storage_value(&state_root, b":code")
         .map_err(|_| String::from("Proof doesn't contain :code"))?
-        .ok_or_else(|| String::from("Runtime :code not found in storage"))?
-        ;
+        .ok_or_else(|| String::from("Runtime :code not found in storage"))?;
     let code = code.to_vec();
 
     let heap_pages_raw = decoded_proof
@@ -1314,7 +1314,10 @@ async fn bootstrap_parachain_consensus<TPlat: PlatformRef>(
     let heap_pages = executor::storage_heap_pages_to_value(heap_pages_raw.map(|(v, _)| v))
         .map_err(|e| format!("Invalid :heappages value: {e}"))?;
     let closest_ancestor_excluding = decoded_proof
-        .closest_ancestor_in_proof(&state_root, trie::bytes_to_nibbles(b":code".iter().copied()))
+        .closest_ancestor_in_proof(
+            &state_root,
+            trie::bytes_to_nibbles(b":code".iter().copied()),
+        )
         .map_err(|_| String::from("Proof missing :code closest ancestor"))?
         .map(|ancestor| ancestor.collect::<Vec<_>>());
 

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -70,7 +70,7 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
 
     // Phase 2: Download the parachain runtime from a P2P peer and determine Aura
     // consensus parameters. Retries indefinitely until successful.
-    let effective_chain_info = loop {
+    let bootstrapped = loop {
         match bootstrap_parachain_consensus(
             &log_target,
             &platform,
@@ -78,9 +78,8 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
             &effective_chain_info,
             block_number_bytes,
         )
-        .await
-        {
-            Ok(ci) => break ci,
+        .await {
+            Ok(bootstrapped) => break bootstrapped,
             Err(err) => {
                 log!(
                     &platform,
@@ -92,6 +91,7 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
             }
         }
     };
+    let effective_chain_info = bootstrapped.chain_info;
 
     // Phase 3: Spawn the paraheads background service that tracks relay chain
     // finalization and reports finalized parachain blocks.
@@ -168,7 +168,7 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
         paraheads_notifications: None,
         pending_parachain_finalization: None,
         network_up_to_date_best: true,
-        known_finalized_runtime: None,
+        known_finalized_runtime: Some(bootstrapped.finalized_runtime),
         pending_requests: stream::FuturesUnordered::new(),
         all_notifications: Vec::<async_channel::Sender<Notification>>::new(),
         log_target,
@@ -1228,13 +1228,18 @@ async fn fetch_parachain_head_from_relay<TPlat: PlatformRef>(
 }
 
 /// Downloads the parachain runtime from a P2P peer and determines Aura consensus parameters.
+struct BootstrappedParachainConsensus {
+    chain_info: chain::chain_information::ValidChainInformation,
+    finalized_runtime: FinalizedBlockRuntime,
+}
+
 async fn bootstrap_parachain_consensus<TPlat: PlatformRef>(
     log_target: &str,
     platform: &TPlat,
     network_service: &Arc<network_service::NetworkServiceChain<TPlat>>,
     chain_info: &chain::chain_information::ValidChainInformation,
     block_number_bytes: usize,
-) -> Result<chain::chain_information::ValidChainInformation, String> {
+) -> Result<BootstrappedParachainConsensus, String> {
     let ci_ref = chain_info.as_ref();
     let state_root = *ci_ref.finalized_block_header.state_root;
     let block_hash = ci_ref.finalized_block_header.hash(block_number_bytes);
@@ -1295,12 +1300,12 @@ async fn bootstrap_parachain_consensus<TPlat: PlatformRef>(
     })
     .map_err(|e| format!("Failed to decode storage proof: {e}"))?;
 
-    let code = decoded_proof
+    let (code, _) = decoded_proof
         .storage_value(&state_root, b":code")
         .map_err(|_| String::from("Proof doesn't contain :code"))?
         .ok_or_else(|| String::from("Runtime :code not found in storage"))?
-        .0
-        .to_vec();
+        ;
+    let code = code.to_vec();
 
     let heap_pages_raw = decoded_proof
         .storage_value(&state_root, b":heappages")
@@ -1308,6 +1313,10 @@ async fn bootstrap_parachain_consensus<TPlat: PlatformRef>(
 
     let heap_pages = executor::storage_heap_pages_to_value(heap_pages_raw.map(|(v, _)| v))
         .map_err(|e| format!("Invalid :heappages value: {e}"))?;
+    let closest_ancestor_excluding = decoded_proof
+        .closest_ancestor_in_proof(&state_root, trie::bytes_to_nibbles(b":code".iter().copied()))
+        .map_err(|_| String::from("Proof missing :code closest ancestor"))?
+        .map(|ancestor| ancestor.collect::<Vec<_>>());
 
     log!(
         platform,
@@ -1384,8 +1393,12 @@ async fn bootstrap_parachain_consensus<TPlat: PlatformRef>(
             })
             .map_err(|e| format!("Failed to decode authorities call proof: {e}"))?;
 
-        let output =
-            run_single_runtime_call(vm, "AuraApi_authorities", &decoded_call_proof, &state_root)?;
+        let output = run_single_runtime_call(
+            vm.clone(),
+            "AuraApi_authorities",
+            &decoded_call_proof,
+            &state_root,
+        )?;
 
         header::AuraAuthoritiesIter::decode(&output)
             .map_err(|_| String::from("Failed to decode AuraApi_authorities output"))?
@@ -1413,8 +1426,19 @@ async fn bootstrap_parachain_consensus<TPlat: PlatformRef>(
         finality: chain::chain_information::ChainInformationFinality::Outsourced,
     };
 
-    chain::chain_information::ValidChainInformation::try_from(new_chain_info)
-        .map_err(|e| format!("Invalid chain information: {e}"))
+    let chain_info = chain::chain_information::ValidChainInformation::try_from(new_chain_info)
+        .map_err(|e| format!("Invalid chain information: {e}"))?;
+
+    Ok(BootstrappedParachainConsensus {
+        chain_info,
+        finalized_runtime: FinalizedBlockRuntime {
+            virtual_machine: vm,
+            storage_code: Some(code),
+            storage_heap_pages: heap_pages_raw.map(|(value, _)| value.to_vec()),
+            code_merkle_value: None,
+            closest_ancestor_excluding,
+        },
+    })
 }
 
 /// Runs a single runtime call, serving storage reads from the given proof.


### PR DESCRIPTION
## Summary
- retain the bootstrapped finalized parachain runtime in the parachain sync service
- return that runtime from sync-service subscribe_all when runtime interest is requested
- unblock ordinary parachain browser RPCs that depend on runtime_service.subscribe_all()

## Why
On the browser path, parachain sync bootstrapped and compiled the finalized runtime, but discarded it instead of storing it in known_finalized_runtime. That meant sync_service.subscribe_all(..., true) returned finalized_block_runtime: None for parachains, so the parachain runtime service never reached its initial finalized-runtime-known state.

In practice this left ordinary parachain RPCs stalled while chainHead_unstable_finalizedDatabase still worked. In the host-sdk stripped-down browser repro, this manifested as chain_getFinalizedHead and state_getStorage timing out repeatedly with the para side stuck before live best-block updates.

## Validation
- cargo check -p parity-smoldot-light
- cargo check -p smoldot-light-wasm
- rebuilt the JS package tarball and reran the host-sdk stripped-down browser repro

Post-fix repro results:
- cold first state_getStorage: ~1.33s
- cold second state_getStorage: ~165ms
- restored first chain_getFinalizedHead: ~297ms
- restored first state_getStorage: ~575ms
- restored second state_getStorage: ~167ms