### PR TITLE
Move statement dedup from network layer to per-subscription JSON-RPC layer

### DIFF
--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -1093,7 +1093,6 @@ pub enum SystemPeerRole {
 #[serde(tag = "status", rename_all = "camelCase")]
 pub enum StatementSubmitResult {
     New,
-    Known,
     Invalid { reason: String },
     InternalError { error: String },
 }
@@ -1488,12 +1487,6 @@ mod tests {
     fn statement_submit_result_serialization() {
         let new = super::StatementSubmitResult::New;
         assert_eq!(serde_json::to_string(&new).unwrap(), r#"{"status":"new"}"#);
-
-        let known = super::StatementSubmitResult::Known;
-        assert_eq!(
-            serde_json::to_string(&known).unwrap(),
-            r#"{"status":"known"}"#
-        );
 
         let invalid = super::StatementSubmitResult::Invalid {
             reason: "bad encoding".into(),

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -116,6 +116,8 @@ pub struct Config<TPlat: PlatformRef> {
     /// Hash of the genesis block of the chain.
     pub genesis_block_hash: [u8; 32],
 
+    /// Maximum number of seen statement hashes tracked per subscription for dedup.
+    /// `None` if the statement protocol is disabled.
     pub max_seen_statements: Option<NonZero<usize>>,
 }
 

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -115,6 +115,8 @@ pub struct Config<TPlat: PlatformRef> {
 
     /// Hash of the genesis block of the chain.
     pub genesis_block_hash: [u8; 32],
+
+    pub max_seen_statements: Option<NonZero<usize>>,
 }
 
 /// Creates a new JSON-RPC service with the given configuration.
@@ -153,6 +155,7 @@ pub fn service<TPlat: PlatformRef>(config: Config<TPlat>) -> Frontend<TPlat> {
                 system_name: config.system_name,
                 system_version: config.system_version,
                 genesis_block_hash: config.genesis_block_hash,
+                max_seen_statements: config.max_seen_statements,
             },
             requests_rx,
             responses_tx,

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -607,7 +607,7 @@ pub(super) async fn run<TPlat: PlatformRef>(
             StartStorageSubscriptionsUpdates,
             NotifyFinalizedHeads,
             NotifyNewHeadsRuntimeSubscriptions(Option<[u8; 32]>),
-            NetworkStatementsReceived(Vec<codec::Statement>),
+            NetworkStatementsReceived(Vec<([u8; 32], codec::Statement)>),
             MustSubscribeNetworkEvents,
         }
 
@@ -755,8 +755,8 @@ pub(super) async fn run<TPlat: PlatformRef>(
                 for (sub_id, topic_filter) in &me.statement_subscriptions {
                     let matching: Vec<methods::HexString> = statements
                         .iter()
-                        .filter(|s| topic_filter.matches(&s.topics))
-                        .map(|s| {
+                        .filter(|(_hash, s)| topic_filter.matches(&s.topics))
+                        .map(|(_hash, s)| {
                             methods::HexString(
                                 codec::encode_statement(s)
                                     .expect("re-encoding a decoded statement always succeeds; qed"),
@@ -2843,9 +2843,7 @@ pub(super) async fn run<TPlat: PlatformRef>(
                                     .clone()
                                     .broadcast_statement(encoded.0)
                                     .await;
-                                if broadcasted.is_known {
-                                    methods::StatementSubmitResult::Known
-                                } else if broadcasted.total == 0 {
+                                if broadcasted.total == 0 {
                                     methods::StatementSubmitResult::InternalError {
                                         error: "No connected peers".into(),
                                     }

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -87,6 +87,8 @@ pub(super) struct Config<TPlat: PlatformRef> {
     /// Hash of the genesis block of the chain.
     pub genesis_block_hash: [u8; 32],
 
+    /// Maximum number of seen statement hashes tracked per subscription for dedup.
+    /// `None` if the statement protocol is disabled.
     pub max_seen_statements: Option<NonZero<usize>>,
 }
 
@@ -494,12 +496,24 @@ struct StatementSubscription {
 
 impl StatementSubscription {
     fn new(topic_filter: methods::TopicFilter, max_seen: Option<NonZero<usize>>) -> Self {
-        StatementSubscription {
+        Self {
             topic_filter,
             seen: max_seen.map(|cap| {
                 lru::LruCache::with_hasher(cap, fnv::FnvBuildHasher::default())
             }),
         }
+    }
+
+    fn should_deliver(&mut self, hash: &[u8; 32], statement: &codec::Statement) -> bool {
+        if !self.topic_filter.matches(&statement.topics) {
+            return false;
+        }
+        if let Some(seen) = &mut self.seen {
+            if seen.put(*hash, ()).is_some() {
+                return false;
+            }
+        }
+        true
     }
 }
 
@@ -779,14 +793,8 @@ pub(super) async fn run<TPlat: PlatformRef>(
                     let matching: Vec<methods::HexString> = statements
                         .iter()
                         .filter_map(|(hash, s)| {
-                            if !sub.topic_filter.matches(&s.topics) {
+                            if !sub.should_deliver(hash, s) {
                                 return None;
-                            }
-                            if let Some(seen) = &mut sub.seen {
-                                if seen.contains(hash) {
-                                    return None;
-                                }
-                                seen.push(*hash, ());
                             }
                             Some(methods::HexString(
                                 codec::encode_statement(s)

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -86,6 +86,8 @@ pub(super) struct Config<TPlat: PlatformRef> {
 
     /// Hash of the genesis block of the chain.
     pub genesis_block_hash: [u8; 32],
+
+    pub max_seen_statements: Option<NonZero<usize>>,
 }
 
 /// Fields used to process JSON-RPC requests in the background.
@@ -220,9 +222,13 @@ struct Background<TPlat: PlatformRef> {
     state_get_keys_paged_cache:
         lru::LruCache<GetKeysPagedCacheKey, Vec<Vec<u8>>, util::SipHasherBuild>,
 
-    /// Active statement subscriptions. Maps subscription ID to topic filter.
+    /// Maximum number of seen statement hashes tracked per subscription for dedup.
+    /// `None` if the statement protocol is disabled.
+    max_seen_statements: Option<NonZero<usize>>,
+
+    /// Active statement subscriptions. Maps subscription ID to subscription state.
     statement_subscriptions:
-        hashbrown::HashMap<String, smoldot::json_rpc::methods::TopicFilter, fnv::FnvBuildHasher>,
+        hashbrown::HashMap<String, StatementSubscription, fnv::FnvBuildHasher>,
 
     /// Receiver for network events (statements from peers).
     network_events_rx: Option<async_channel::Receiver<network_service::Event>>,
@@ -481,6 +487,22 @@ enum TransactionWatchTy {
     NewApiWatch,
 }
 
+struct StatementSubscription {
+    topic_filter: methods::TopicFilter,
+    seen: Option<lru::LruCache<[u8; 32], (), fnv::FnvBuildHasher>>,
+}
+
+impl StatementSubscription {
+    fn new(topic_filter: methods::TopicFilter, max_seen: Option<NonZero<usize>>) -> Self {
+        StatementSubscription {
+            topic_filter,
+            seen: max_seen.map(|cap| {
+                lru::LruCache::with_hasher(cap, fnv::FnvBuildHasher::default())
+            }),
+        }
+    }
+}
+
 /// See [`Background::state_get_keys_paged_cache`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct GetKeysPagedCacheKey {
@@ -569,6 +591,7 @@ pub(super) async fn run<TPlat: PlatformRef>(
         ),
         genesis_block_hash: config.genesis_block_hash,
         printed_legacy_json_rpc_warning: false,
+        max_seen_statements: config.max_seen_statements,
         statement_subscriptions: hashbrown::HashMap::with_capacity_and_hasher(
             16,
             Default::default(),
@@ -752,15 +775,23 @@ pub(super) async fn run<TPlat: PlatformRef>(
 
                 // TODO: O(n_statements * n_subscriptions * n_topics_in_filter * n_topics_in_statement) complexity.
                 // Create a reverse index `topic` -> `subscription` for adequate complexity.
-                for (sub_id, topic_filter) in &me.statement_subscriptions {
+                for (sub_id, sub) in me.statement_subscriptions.iter_mut() {
                     let matching: Vec<methods::HexString> = statements
                         .iter()
-                        .filter(|(_hash, s)| topic_filter.matches(&s.topics))
-                        .map(|(_hash, s)| {
-                            methods::HexString(
+                        .filter_map(|(hash, s)| {
+                            if !sub.topic_filter.matches(&s.topics) {
+                                return None;
+                            }
+                            if let Some(seen) = &mut sub.seen {
+                                if seen.contains(hash) {
+                                    return None;
+                                }
+                                seen.push(*hash, ());
+                            }
+                            Some(methods::HexString(
                                 codec::encode_statement(s)
                                     .expect("re-encoding a decoded statement always succeeds; qed"),
-                            )
+                            ))
                         })
                         .collect();
 
@@ -2868,8 +2899,10 @@ pub(super) async fn run<TPlat: PlatformRef>(
                             hex::encode(id)
                         };
 
-                        me.statement_subscriptions
-                            .insert(subscription_id.clone(), filter);
+                        me.statement_subscriptions.insert(
+                            subscription_id.clone(),
+                            StatementSubscription::new(filter, me.max_seen_statements),
+                        );
 
                         let _ = me
                             .responses_tx

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -502,7 +502,7 @@ impl StatementSubscription {
         }
     }
 
-    fn should_deliver(&mut self, hash: &[u8; 32], statement: &codec::Statement) -> bool {
+    fn accept(&mut self, hash: &[u8; 32], statement: &codec::Statement) -> bool {
         if !self.topic_filter.matches(&statement.topics) {
             return false;
         }
@@ -791,7 +791,7 @@ pub(super) async fn run<TPlat: PlatformRef>(
                     let matching: Vec<methods::HexString> = statements
                         .iter()
                         .filter_map(|(hash, s)| {
-                            if !sub.should_deliver(hash, s) {
+                            if !sub.accept(hash, s) {
                                 return None;
                             }
                             Some(methods::HexString(codec::encode_statement(s).expect(

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -229,8 +229,7 @@ struct Background<TPlat: PlatformRef> {
     max_seen_statements: Option<NonZero<usize>>,
 
     /// Active statement subscriptions. Maps subscription ID to subscription state.
-    statement_subscriptions:
-        hashbrown::HashMap<String, StatementSubscription, fnv::FnvBuildHasher>,
+    statement_subscriptions: hashbrown::HashMap<String, StatementSubscription, fnv::FnvBuildHasher>,
 
     /// Receiver for network events (statements from peers).
     network_events_rx: Option<async_channel::Receiver<network_service::Event>>,
@@ -498,9 +497,8 @@ impl StatementSubscription {
     fn new(topic_filter: methods::TopicFilter, max_seen: Option<NonZero<usize>>) -> Self {
         Self {
             topic_filter,
-            seen: max_seen.map(|cap| {
-                lru::LruCache::with_hasher(cap, fnv::FnvBuildHasher::default())
-            }),
+            seen: max_seen
+                .map(|cap| lru::LruCache::with_hasher(cap, fnv::FnvBuildHasher::default())),
         }
     }
 
@@ -796,10 +794,9 @@ pub(super) async fn run<TPlat: PlatformRef>(
                             if !sub.should_deliver(hash, s) {
                                 return None;
                             }
-                            Some(methods::HexString(
-                                codec::encode_statement(s)
-                                    .expect("re-encoding a decoded statement always succeeds; qed"),
-                            ))
+                            Some(methods::HexString(codec::encode_statement(s).expect(
+                                "re-encoding a decoded statement always succeeds; qed",
+                            )))
                         })
                         .collect();
 

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -672,6 +672,11 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
             }
         };
 
+        let max_seen_statements = config
+            .statement_protocol_config
+            .as_ref()
+            .map(|c| c.max_seen_statements());
+
         // Start the services of the chain to add, or grab the services if they already exist.
         let (services, log_name) = match chains_by_key.entry(new_chain_key.clone()) {
             Entry::Occupied(mut entry) => {
@@ -936,6 +941,7 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                 system_name: self.platform.client_name().into_owned(),
                 system_version: self.platform.client_version().into_owned(),
                 genesis_block_hash,
+                max_seen_statements,
             });
 
             Some(frontend)

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -78,6 +78,7 @@ pub use service::{ChainId, EncodedMerkleProof, PeerId, QueueNotificationError};
 /// Configuration for the Statement Store protocol.
 #[derive(Debug, Clone)]
 pub struct StatementProtocolConfig {
+    /// Per-subscription LRU cache size used for deduplicating delivered statements.
     max_seen_statements: NonZeroUsize,
 }
 

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -96,7 +96,7 @@ impl StatementProtocolConfig {
 impl Default for StatementProtocolConfig {
     fn default() -> Self {
         StatementProtocolConfig {
-            max_seen_statements: NonZeroUsize::new(65536).expect("65536 is not zero; qed"),
+            max_seen_statements: NonZeroUsize::new(512).expect("512 is not zero; qed"),
         }
     }
 }
@@ -256,16 +256,6 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
 
         // TODO: this code is hacky because we don't want to make `add_chain` async at the moment, because it's not convenient for lib.rs
         self.platform.spawn_task("add-chain-message-send".into(), {
-            let seen_statements =
-                config
-                    .statement_protocol_config
-                    .as_ref()
-                    .map(|spc: &StatementProtocolConfig| {
-                        lru::LruCache::with_hasher(
-                            spc.max_seen_statements(),
-                            fnv::FnvBuildHasher::default(),
-                        )
-                    });
             let config = service::ChainConfig {
                 grandpa_protocol_config: config.grandpa_protocol_finalized_block_height.map(
                     |commit_finalized_height| service::GrandpaState {
@@ -289,7 +279,6 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
                     num_references: NonZero::<usize>::new(1).unwrap(),
                     next_discovery_period: Duration::from_secs(2),
                     next_discovery_when: self.platform.now(),
-                    seen_statements,
                 },
             };
 
@@ -674,7 +663,6 @@ impl<TPlat: PlatformRef> NetworkServiceChain<TPlat> {
 pub struct BroadcastStatementResult {
     pub sent: usize,
     pub total: usize,
-    pub is_known: bool,
 }
 
 /// Event that can happen on the network service.
@@ -705,7 +693,7 @@ pub enum Event {
     /// Received a statement notification from the network.
     StatementsNotification {
         peer_id: PeerId,
-        statements: Vec<codec::Statement>,
+        statements: Vec<([u8; 32], codec::Statement)>,
     },
 }
 
@@ -1009,7 +997,6 @@ struct Chain<TPlat: PlatformRef> {
     /// the given duration.
     next_discovery_period: Duration,
 
-    seen_statements: Option<lru::LruCache<[u8; 32], (), fnv::FnvBuildHasher>>,
 }
 
 #[derive(Clone)]
@@ -1794,59 +1781,38 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                 chain_id,
                 ToBackgroundChain::BroadcastStatement { statement, result },
             ) => {
-                let is_known =
-                    task.network[chain_id]
-                        .seen_statements
-                        .as_mut()
-                        .map_or(false, |cache| {
-                            let hash = codec::statement_hash(&statement);
-                            let already_known = cache.contains(&hash);
-                            cache.push(hash, ());
-                            already_known
-                        });
+                let peers_to_send = task
+                    .network
+                    .gossip_connected_peers(
+                        chain_id,
+                        service::GossipKind::ConsensusTransactions,
+                    )
+                    .cloned()
+                    .collect::<Vec<_>>();
 
-                let (sent, total) = if is_known {
-                    (0, 0)
-                } else {
-                    let peers_to_send = task
+                let total = peers_to_send.len();
+                let mut sent = 0;
+                for peer in &peers_to_send {
+                    if task
                         .network
-                        .gossip_connected_peers(
-                            chain_id,
-                            service::GossipKind::ConsensusTransactions,
-                        )
-                        .cloned()
-                        .collect::<Vec<_>>();
-
-                    let total = peers_to_send.len();
-                    let mut sent = 0;
-                    for peer in &peers_to_send {
-                        if task
-                            .network
-                            .gossip_send_statement(peer, chain_id, statement.clone())
-                            .is_ok()
-                        {
-                            sent += 1;
-                        }
+                        .gossip_send_statement(peer, chain_id, statement.clone())
+                        .is_ok()
+                    {
+                        sent += 1;
                     }
+                }
 
-                    log!(
-                        &task.platform,
-                        Debug,
-                        "network",
-                        "statement-broadcast",
-                        chain = task.network[chain_id].log_name,
-                        sent,
-                        total,
-                    );
-
-                    (sent, total)
-                };
-
-                let _ = result.send(BroadcastStatementResult {
+                log!(
+                    &task.platform,
+                    Debug,
+                    "network",
+                    "statement-broadcast",
+                    chain = task.network[chain_id].log_name,
                     sent,
                     total,
-                    is_known,
-                });
+                );
+
+                let _ = result.send(BroadcastStatementResult { sent, total });
             }
             WakeUpReason::MessageForChain(
                 chain_id,
@@ -2752,22 +2718,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
             }) => {
                 debug_assert!(task.event_pending_send.is_none());
 
-                let chain = &mut task.network[chain_id];
-                let non_duplicates: Vec<codec::Statement> = statements
-                    .into_iter()
-                    .filter_map(|(hash, statement)| {
-                        let Some(cache) = &mut chain.seen_statements else {
-                            return Some(statement);
-                        };
-                        if cache.contains(&hash) {
-                            return None;
-                        }
-                        cache.push(hash, ());
-                        Some(statement)
-                    })
-                    .collect();
-
-                if non_duplicates.is_empty() {
+                if statements.is_empty() {
                     continue;
                 }
 
@@ -2775,7 +2726,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     chain_id,
                     Event::StatementsNotification {
                         peer_id,
-                        statements: non_duplicates,
+                        statements,
                     },
                 ));
             }

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -97,7 +97,7 @@ impl StatementProtocolConfig {
 impl Default for StatementProtocolConfig {
     fn default() -> Self {
         StatementProtocolConfig {
-            max_seen_statements: NonZeroUsize::new(512).expect("512 is not zero; qed"),
+            max_seen_statements: NonZeroUsize::new(4096).expect("4096 is not zero; qed"),
         }
     }
 }

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -997,7 +997,6 @@ struct Chain<TPlat: PlatformRef> {
     /// After [`Chain::next_discovery_when`] is reached, the following discovery happens after
     /// the given duration.
     next_discovery_period: Duration,
-
 }
 
 #[derive(Clone)]
@@ -1784,10 +1783,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
             ) => {
                 let peers_to_send = task
                     .network
-                    .gossip_connected_peers(
-                        chain_id,
-                        service::GossipKind::ConsensusTransactions,
-                    )
+                    .gossip_connected_peers(chain_id, service::GossipKind::ConsensusTransactions)
                     .cloned()
                     .collect::<Vec<_>>();
 


### PR DESCRIPTION
Global seen_statements LRU in the network layer prevented new subscriptions from receiving statements already seen by previous subscriptions. Moved dedup to per-subscription LRU caches in the JSON-RPC layer so each subscription tracks delivered statements independently. Removed StatementSubmitResult::Known since dedup is no longer tracked at the broadcast level.