### PR TITLE
statement-store: Add unit tests for statement submission and reception

### DIFF
--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -1095,7 +1095,7 @@ pub enum SystemPeerRole {
 /// Result of submitting a statement.
 ///
 /// JSON format is compatible with polkadot-sdk's `SubmitResult`.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "status", rename_all = "camelCase")]
 pub enum StatementSubmitResult {
     New,
@@ -1635,5 +1635,28 @@ mod tests {
         assert!(!filter.matches(&[t2]));
         assert!(!filter.matches(&[t3]));
         assert!(!filter.matches(&[]));
+    }
+
+    #[test]
+    fn topic_filter_match_all_empty_matches_everything() {
+        let filter = super::TopicFilter::match_all(Vec::new()).unwrap();
+        assert!(filter.matches(&[]));
+        assert!(filter.matches(&[[1u8; 32]]));
+    }
+
+    #[test]
+    fn topic_filter_match_all_rejects_too_many_topics() {
+        let topics: Vec<[u8; 32]> = (0..=crate::network::codec::MAX_TOPICS)
+            .map(|i| [i as u8; 32])
+            .collect();
+        assert!(super::TopicFilter::match_all(topics).is_err());
+    }
+
+    #[test]
+    fn topic_filter_match_any_rejects_too_many_topics() {
+        let topics: Vec<[u8; 32]> = (0..=crate::network::codec::MAX_ANY_TOPICS)
+            .map(|i| [i as u8; 32])
+            .collect();
+        assert!(super::TopicFilter::match_any(topics).is_err());
     }
 }

--- a/lib/src/network/codec/affinity.rs
+++ b/lib/src/network/codec/affinity.rs
@@ -414,4 +414,32 @@ mod tests {
         filter.insert(&inserted);
         assert!(filter.matches_statement(&[&missing, &inserted]));
     }
+
+    #[test]
+    fn decode_rejects_truncated_bits_body() {
+        // The compact length claims 2 u64 words (16 bytes of bits) but only 8 bytes follow;
+        // `EncodedBloomFilter::decode` guards against this via the `rest.len() != bits_len * 8`
+        // check. polkadot-sdk delegates to `codec::Decode` which handles incomplete input
+        // automatically; smoldot parses peer bytes by hand and needs explicit coverage.
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&TEST_SEED.to_le_bytes());
+        bytes.extend_from_slice(&1u32.to_le_bytes());
+        bytes.extend_from_slice(crate::util::encode_scale_compact_usize(2).as_ref());
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+        assert!(AffinityFilter::decode(&bytes).is_err());
+    }
+
+    #[test]
+    fn from_topics_empty_is_not_match_all() {
+        // `from_topics` is smoldot-only (no polkadot-sdk equivalent) and the empty-iterator path
+        // must not silently behave like the explicit `match_all` broadcast filter.
+        let filter = AffinityFilter::from_topics(
+            core::iter::empty::<&[u8; 32]>(),
+            TEST_SEED,
+            BLOOM_FALSE_POS_RATE,
+        );
+        assert!(!filter.matches_statement(&[&[0x01; 32]]));
+        // Broadcast statements (no topics) always match.
+        assert!(filter.matches_statement(&[]));
+    }
 }

--- a/lib/src/network/codec/affinity.rs
+++ b/lib/src/network/codec/affinity.rs
@@ -431,15 +431,12 @@ mod tests {
 
     #[test]
     fn from_topics_empty_is_not_match_all() {
-        // `from_topics` is smoldot-only (no polkadot-sdk equivalent) and the empty-iterator path
-        // must not silently behave like the explicit `match_all` broadcast filter.
         let filter = AffinityFilter::from_topics(
             core::iter::empty::<&[u8; 32]>(),
             TEST_SEED,
             BLOOM_FALSE_POS_RATE,
         );
         assert!(!filter.matches_statement(&[&[0x01; 32]]));
-        // Broadcast statements (no topics) always match.
         assert!(filter.matches_statement(&[]));
     }
 }

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -38,6 +38,7 @@
 // TODO: re-review this once finished
 
 mod background;
+mod statement;
 
 use crate::{
     bitswap_service, log, network_service, platform::PlatformRef, runtime_service, sync_service,

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -2969,25 +2969,12 @@ pub(super) async fn run<TPlat: PlatformRef>(
                     }
 
                     methods::MethodCall::statement_submit { encoded } => {
-                        let result =
-                            if smoldot::network::codec::decode_statement(&encoded.0).is_err() {
-                                methods::StatementSubmitResult::Invalid {
-                                    reason: "Invalid statement encoding".into(),
-                                }
-                            } else {
-                                let broadcasted = me
-                                    .network_service
-                                    .clone()
-                                    .broadcast_statement(encoded.0)
-                                    .await;
-                                if broadcasted.total == 0 {
-                                    methods::StatementSubmitResult::InternalError {
-                                        error: "No connected peers".into(),
-                                    }
-                                } else {
-                                    methods::StatementSubmitResult::New
-                                }
-                            };
+                        let network = me.network_service.clone();
+                        let result = super::statement::validate_and_broadcast_statement(
+                            &encoded.0,
+                            |bytes| async move { network.broadcast_statement(bytes).await },
+                        )
+                        .await;
 
                         let _ = me
                             .responses_tx

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -6142,4 +6142,3 @@ fn convert_runtime_version(
             .collect(),
     }
 }
-

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -239,7 +239,8 @@ struct Background<TPlat: PlatformRef> {
     max_seen_statements: Option<NonZero<usize>>,
 
     /// Active statement subscriptions. Maps subscription ID to subscription state.
-    statement_subscriptions: hashbrown::HashMap<String, StatementSubscription, fnv::FnvBuildHasher>,
+    statement_subscriptions:
+        hashbrown::HashMap<String, super::statement::StatementSubscription, fnv::FnvBuildHasher>,
 
     statement_affinity_stale: bool,
     next_statement_affinity_update: Option<Pin<Box<TPlat::Delay>>>,
@@ -532,33 +533,6 @@ enum TransactionWatchTy {
     NewApiWatch,
 }
 
-struct StatementSubscription {
-    topic_filter: methods::TopicFilter,
-    seen: Option<lru::LruCache<[u8; 32], (), fnv::FnvBuildHasher>>,
-}
-
-impl StatementSubscription {
-    fn new(topic_filter: methods::TopicFilter, max_seen: Option<NonZero<usize>>) -> Self {
-        Self {
-            topic_filter,
-            seen: max_seen
-                .map(|cap| lru::LruCache::with_hasher(cap, fnv::FnvBuildHasher::default())),
-        }
-    }
-
-    fn accept(&mut self, hash: &[u8; 32], statement: &codec::Statement) -> bool {
-        if !self.topic_filter.matches(&statement.topics) {
-            return false;
-        }
-        if let Some(seen) = &mut self.seen {
-            if seen.put(*hash, ()).is_some() {
-                return false;
-            }
-        }
-        true
-    }
-}
-
 /// See [`Background::state_get_keys_paged_cache`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct GetKeysPagedCacheKey {
@@ -840,7 +814,7 @@ pub(super) async fn run<TPlat: PlatformRef>(
                 me.statement_affinity_stale = false;
                 me.last_statement_affinity_update = Some(me.platform.now());
 
-                let combined_filter = build_combined_affinity_filter(
+                let combined_filter = super::statement::build_combined_affinity_filter(
                     &me.statement_subscriptions,
                     me.statement_protocol_config
                         .as_ref()
@@ -2994,7 +2968,10 @@ pub(super) async fn run<TPlat: PlatformRef>(
 
                         me.statement_subscriptions.insert(
                             subscription_id.clone(),
-                            StatementSubscription::new(filter, me.max_seen_statements),
+                            super::statement::StatementSubscription::new(
+                                filter,
+                                me.max_seen_statements,
+                            ),
                         );
 
                         me.schedule_statement_affinity_update();
@@ -6166,28 +6143,3 @@ fn convert_runtime_version(
     }
 }
 
-fn build_combined_affinity_filter(
-    subscriptions: &hashbrown::HashMap<String, StatementSubscription, fnv::FnvBuildHasher>,
-    config: &network_service::StatementProtocolConfig,
-) -> network_service::AffinityFilter {
-    use smoldot::json_rpc::methods::TopicFilter;
-
-    let mut all_topics: Vec<&[u8; 32]> = Vec::new();
-
-    for sub in subscriptions.values() {
-        match &sub.topic_filter {
-            TopicFilter::Any => {
-                return network_service::AffinityFilter::match_all(config.bloom_seed());
-            }
-            TopicFilter::MatchAll(topics) | TopicFilter::MatchAny(topics) => {
-                all_topics.extend(topics.iter());
-            }
-        }
-    }
-
-    network_service::AffinityFilter::from_topics(
-        all_topics.into_iter(),
-        config.bloom_seed(),
-        config.false_positive_rate(),
-    )
-}

--- a/light-base/src/json_rpc_service/statement.rs
+++ b/light-base/src/json_rpc_service/statement.rs
@@ -1,0 +1,107 @@
+// Smoldot
+// Copyright (C) 2019-2022  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::network_service::BroadcastStatementResult;
+use alloc::vec::Vec;
+use smoldot::json_rpc::methods::StatementSubmitResult;
+use smoldot::network::codec;
+
+/// Validates a SCALE-encoded statement and broadcasts it to the network.
+///
+/// Returns the appropriate [`StatementSubmitResult`] based on the decode and broadcast outcome.
+/// The `broadcast` closure is only called if the statement is valid.
+pub async fn validate_and_broadcast_statement<F, Fut>(
+    encoded: &[u8],
+    broadcast: F,
+) -> StatementSubmitResult
+where
+    F: FnOnce(Vec<u8>) -> Fut,
+    Fut: core::future::Future<Output = BroadcastStatementResult>,
+{
+    if codec::decode_statement(encoded).is_err() {
+        return StatementSubmitResult::Invalid {
+            reason: "Invalid statement encoding".into(),
+        };
+    }
+
+    let broadcasted = broadcast(encoded.to_vec()).await;
+    if broadcasted.total == 0 {
+        StatementSubmitResult::InternalError {
+            error: "No connected peers".into(),
+        }
+    } else {
+        StatementSubmitResult::New
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_lite::future::block_on;
+
+    fn valid_statement() -> Vec<u8> {
+        codec::encode_statement(&codec::Statement {
+            proof: None,
+            decryption_key: None,
+            expiry: 42,
+            channel: None,
+            topics: Vec::new(),
+            data: None,
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn validate_and_broadcast_invalid_encoding() {
+        let result = block_on(validate_and_broadcast_statement(&[0xff, 0xff], |_| async {
+            unreachable!()
+        }));
+        assert_eq!(
+            result,
+            StatementSubmitResult::Invalid {
+                reason: "Invalid statement encoding".into()
+            }
+        );
+    }
+
+    #[test]
+    fn validate_and_broadcast_no_peers() {
+        let result = block_on(validate_and_broadcast_statement(
+            &valid_statement(),
+            |_| async {
+                BroadcastStatementResult { sent: 0, total: 0 }
+            },
+        ));
+        assert_eq!(
+            result,
+            StatementSubmitResult::InternalError {
+                error: "No connected peers".into()
+            }
+        );
+    }
+
+    #[test]
+    fn validate_and_broadcast_new() {
+        let result = block_on(validate_and_broadcast_statement(
+            &valid_statement(),
+            |_| async {
+                BroadcastStatementResult { sent: 3, total: 5 }
+            },
+        ));
+        assert_eq!(result, StatementSubmitResult::New);
+    }
+}

--- a/light-base/src/json_rpc_service/statement.rs
+++ b/light-base/src/json_rpc_service/statement.rs
@@ -15,9 +15,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::network_service::BroadcastStatementResult;
-use alloc::vec::Vec;
-use smoldot::json_rpc::methods::StatementSubmitResult;
+use crate::network_service::{self, BroadcastStatementResult};
+use alloc::{string::String, vec::Vec};
+use core::num::NonZero;
+use smoldot::json_rpc::methods::{StatementSubmitResult, TopicFilter};
 use smoldot::network::codec;
 
 /// Validates a SCALE-encoded statement and broadcasts it to the network.
@@ -46,6 +47,57 @@ where
     } else {
         StatementSubmitResult::New
     }
+}
+
+pub(super) struct StatementSubscription {
+    topic_filter: TopicFilter,
+    seen: Option<lru::LruCache<[u8; 32], (), fnv::FnvBuildHasher>>,
+}
+
+impl StatementSubscription {
+    pub(super) fn new(topic_filter: TopicFilter, max_seen: Option<NonZero<usize>>) -> Self {
+        Self {
+            topic_filter,
+            seen: max_seen
+                .map(|cap| lru::LruCache::with_hasher(cap, fnv::FnvBuildHasher::default())),
+        }
+    }
+
+    pub(super) fn accept(&mut self, hash: &[u8; 32], statement: &codec::Statement) -> bool {
+        if !self.topic_filter.matches(&statement.topics) {
+            return false;
+        }
+        if let Some(seen) = &mut self.seen {
+            if seen.put(*hash, ()).is_some() {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+pub(super) fn build_combined_affinity_filter(
+    subscriptions: &hashbrown::HashMap<String, StatementSubscription, fnv::FnvBuildHasher>,
+    config: &network_service::StatementProtocolConfig,
+) -> network_service::AffinityFilter {
+    let mut all_topics: Vec<&[u8; 32]> = Vec::new();
+
+    for sub in subscriptions.values() {
+        match &sub.topic_filter {
+            TopicFilter::Any => {
+                return network_service::AffinityFilter::match_all(config.bloom_seed());
+            }
+            TopicFilter::MatchAll(topics) | TopicFilter::MatchAny(topics) => {
+                all_topics.extend(topics.iter());
+            }
+        }
+    }
+
+    network_service::AffinityFilter::from_topics(
+        all_topics.into_iter(),
+        config.bloom_seed(),
+        config.false_positive_rate(),
+    )
 }
 
 #[cfg(test)]
@@ -103,5 +155,139 @@ mod tests {
             },
         ));
         assert_eq!(result, StatementSubmitResult::New);
+    }
+
+    use alloc::string::ToString as _;
+    use core::time::Duration;
+
+    const SEED: u128 = 0x5EED_5EED_5EED_5EED_5EED_5EED_5EED_5EED;
+    const FPR: f64 = 0.01;
+
+    fn test_config() -> network_service::StatementProtocolConfig {
+        network_service::StatementProtocolConfig::new(
+            NonZero::new(128).unwrap(),
+            FPR,
+            SEED,
+            Duration::from_secs(1),
+        )
+    }
+
+    fn make_subscriptions(
+        entries: Vec<(&str, TopicFilter, Option<NonZero<usize>>)>,
+    ) -> hashbrown::HashMap<String, StatementSubscription, fnv::FnvBuildHasher> {
+        let mut map = hashbrown::HashMap::with_hasher(fnv::FnvBuildHasher::default());
+        for (id, filter, max_seen) in entries {
+            map.insert(id.to_string(), StatementSubscription::new(filter, max_seen));
+        }
+        map
+    }
+
+    fn statement_with_topics(topics: Vec<[u8; 32]>) -> codec::Statement {
+        codec::Statement {
+            proof: None,
+            decryption_key: None,
+            expiry: 42,
+            channel: None,
+            topics,
+            data: None,
+        }
+    }
+
+    // --- build_combined_affinity_filter: bloom filter construction ---
+
+    #[test]
+    fn build_combined_affinity_empty_subscriptions() {
+        let config = test_config();
+        let subs = make_subscriptions(vec![]);
+        let filter = build_combined_affinity_filter(&subs, &config);
+
+        // Empty subscription set: no topics are ever in the filter.
+        assert!(!filter.contains(&[1u8; 32]));
+        // A statement with no topics (broadcast) still matches.
+        let broadcast: &[&[u8; 32]] = &[];
+        assert!(filter.matches_statement(broadcast));
+    }
+
+    #[test]
+    fn build_combined_affinity_any_filter_matches_everything() {
+        let config = test_config();
+        let subs = make_subscriptions(vec![("s", TopicFilter::Any, None)]);
+        let filter = build_combined_affinity_filter(&subs, &config);
+
+        // TopicFilter::Any returns the broadcast `match_all` filter: every topic matches.
+        assert!(filter.contains(&[1u8; 32]));
+        assert!(filter.contains(&[99u8; 32]));
+        let t = [7u8; 32];
+        assert!(filter.matches_statement(&[&t]));
+    }
+
+    #[test]
+    fn build_combined_affinity_match_any_union() {
+        let config = test_config();
+        let t1 = [1u8; 32];
+        let t2 = [2u8; 32];
+        let subs = make_subscriptions(vec![
+            ("a", TopicFilter::match_any(vec![t1]).unwrap(), None),
+            ("b", TopicFilter::match_any(vec![t2]).unwrap(), None),
+        ]);
+        let filter = build_combined_affinity_filter(&subs, &config);
+
+        assert!(filter.contains(&t1));
+        assert!(filter.contains(&t2));
+    }
+
+    // --- StatementSubscription::accept: false-positive discard + dedup ---
+
+    #[test]
+    fn accept_fresh_statement_passes() {
+        let t1 = [1u8; 32];
+        let mut sub = StatementSubscription::new(
+            TopicFilter::match_any(vec![t1]).unwrap(),
+            NonZero::new(8),
+        );
+        let stmt = statement_with_topics(vec![t1]);
+        assert!(sub.accept(&[0xbb; 32], &stmt));
+    }
+
+    #[test]
+    fn accept_duplicate_returns_false() {
+        let mut sub =
+            StatementSubscription::new(TopicFilter::Any, NonZero::new(8));
+        let stmt = statement_with_topics(vec![]);
+        let hash = [0xcc; 32];
+        assert!(sub.accept(&hash, &stmt));
+        assert!(!sub.accept(&hash, &stmt));
+    }
+
+    #[test]
+    fn accept_lru_eviction_allows_resubmit() {
+        let mut sub =
+            StatementSubscription::new(TopicFilter::Any, NonZero::new(2));
+        let stmt = statement_with_topics(vec![]);
+        let h_a = [0xa; 32];
+        let h_b = [0xb; 32];
+        let h_c = [0xc; 32];
+
+        assert!(sub.accept(&h_a, &stmt));
+        assert!(sub.accept(&h_b, &stmt));
+        // Inserting a third eviction-capacity 2 item evicts h_a (oldest).
+        assert!(sub.accept(&h_c, &stmt));
+        // h_a was evicted: it is accepted again as if fresh.
+        assert!(sub.accept(&h_a, &stmt));
+    }
+
+    #[test]
+    fn dedup_is_per_subscription() {
+        let mut sub_a =
+            StatementSubscription::new(TopicFilter::Any, NonZero::new(8));
+        let mut sub_b =
+            StatementSubscription::new(TopicFilter::Any, NonZero::new(8));
+        let stmt = statement_with_topics(vec![]);
+        let hash = [0xee; 32];
+
+        assert!(sub_a.accept(&hash, &stmt));
+        assert!(!sub_a.accept(&hash, &stmt));
+        // Same hash on a different subscription is still fresh: caches are independent.
+        assert!(sub_b.accept(&hash, &stmt));
     }
 }

--- a/light-base/src/json_rpc_service/statement.rs
+++ b/light-base/src/json_rpc_service/statement.rs
@@ -103,7 +103,42 @@ pub(super) fn build_combined_affinity_filter(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::string::ToString as _;
+    use core::time::Duration;
     use futures_lite::future::block_on;
+
+    const SEED: u128 = 0x5EED_5EED_5EED_5EED_5EED_5EED_5EED_5EED;
+    const FPR: f64 = 0.01;
+
+    fn test_config() -> network_service::StatementProtocolConfig {
+        network_service::StatementProtocolConfig::new(
+            NonZero::new(128).unwrap(),
+            FPR,
+            SEED,
+            Duration::from_secs(1),
+        )
+    }
+
+    fn make_subscriptions(
+        entries: Vec<(&str, TopicFilter, Option<NonZero<usize>>)>,
+    ) -> hashbrown::HashMap<String, StatementSubscription, fnv::FnvBuildHasher> {
+        let mut map = hashbrown::HashMap::with_hasher(fnv::FnvBuildHasher::default());
+        for (id, filter, max_seen) in entries {
+            map.insert(id.to_string(), StatementSubscription::new(filter, max_seen));
+        }
+        map
+    }
+
+    fn statement_with_topics(topics: Vec<[u8; 32]>) -> codec::Statement {
+        codec::Statement {
+            proof: None,
+            decryption_key: None,
+            expiry: 42,
+            channel: None,
+            topics,
+            data: None,
+        }
+    }
 
     fn valid_statement() -> Vec<u8> {
         codec::encode_statement(&codec::Statement {
@@ -153,44 +188,6 @@ mod tests {
         assert_eq!(result, StatementSubmitResult::New);
     }
 
-    use alloc::string::ToString as _;
-    use core::time::Duration;
-
-    const SEED: u128 = 0x5EED_5EED_5EED_5EED_5EED_5EED_5EED_5EED;
-    const FPR: f64 = 0.01;
-
-    fn test_config() -> network_service::StatementProtocolConfig {
-        network_service::StatementProtocolConfig::new(
-            NonZero::new(128).unwrap(),
-            FPR,
-            SEED,
-            Duration::from_secs(1),
-        )
-    }
-
-    fn make_subscriptions(
-        entries: Vec<(&str, TopicFilter, Option<NonZero<usize>>)>,
-    ) -> hashbrown::HashMap<String, StatementSubscription, fnv::FnvBuildHasher> {
-        let mut map = hashbrown::HashMap::with_hasher(fnv::FnvBuildHasher::default());
-        for (id, filter, max_seen) in entries {
-            map.insert(id.to_string(), StatementSubscription::new(filter, max_seen));
-        }
-        map
-    }
-
-    fn statement_with_topics(topics: Vec<[u8; 32]>) -> codec::Statement {
-        codec::Statement {
-            proof: None,
-            decryption_key: None,
-            expiry: 42,
-            channel: None,
-            topics,
-            data: None,
-        }
-    }
-
-    // --- build_combined_affinity_filter: bloom filter construction ---
-
     #[test]
     fn build_combined_affinity_empty_subscriptions() {
         let config = test_config();
@@ -231,8 +228,6 @@ mod tests {
         assert!(filter.contains(&t1));
         assert!(filter.contains(&t2));
     }
-
-    // --- StatementSubscription::accept: false-positive discard + dedup ---
 
     #[test]
     fn accept_fresh_statement_passes() {

--- a/light-base/src/json_rpc_service/statement.rs
+++ b/light-base/src/json_rpc_service/statement.rs
@@ -134,9 +134,7 @@ mod tests {
     fn validate_and_broadcast_no_peers() {
         let result = block_on(validate_and_broadcast_statement(
             &valid_statement(),
-            |_| async {
-                BroadcastStatementResult { sent: 0, total: 0 }
-            },
+            |_| async { BroadcastStatementResult { sent: 0, total: 0 } },
         ));
         assert_eq!(
             result,
@@ -150,9 +148,7 @@ mod tests {
     fn validate_and_broadcast_new() {
         let result = block_on(validate_and_broadcast_statement(
             &valid_statement(),
-            |_| async {
-                BroadcastStatementResult { sent: 3, total: 5 }
-            },
+            |_| async { BroadcastStatementResult { sent: 3, total: 5 } },
         ));
         assert_eq!(result, StatementSubmitResult::New);
     }
@@ -241,18 +237,15 @@ mod tests {
     #[test]
     fn accept_fresh_statement_passes() {
         let t1 = [1u8; 32];
-        let mut sub = StatementSubscription::new(
-            TopicFilter::match_any(vec![t1]).unwrap(),
-            NonZero::new(8),
-        );
+        let mut sub =
+            StatementSubscription::new(TopicFilter::match_any(vec![t1]).unwrap(), NonZero::new(8));
         let stmt = statement_with_topics(vec![t1]);
         assert!(sub.accept(&[0xbb; 32], &stmt));
     }
 
     #[test]
     fn accept_duplicate_returns_false() {
-        let mut sub =
-            StatementSubscription::new(TopicFilter::Any, NonZero::new(8));
+        let mut sub = StatementSubscription::new(TopicFilter::Any, NonZero::new(8));
         let stmt = statement_with_topics(vec![]);
         let hash = [0xcc; 32];
         assert!(sub.accept(&hash, &stmt));
@@ -261,8 +254,7 @@ mod tests {
 
     #[test]
     fn accept_lru_eviction_allows_resubmit() {
-        let mut sub =
-            StatementSubscription::new(TopicFilter::Any, NonZero::new(2));
+        let mut sub = StatementSubscription::new(TopicFilter::Any, NonZero::new(2));
         let stmt = statement_with_topics(vec![]);
         let h_a = [0xa; 32];
         let h_b = [0xb; 32];
@@ -278,10 +270,8 @@ mod tests {
 
     #[test]
     fn dedup_is_per_subscription() {
-        let mut sub_a =
-            StatementSubscription::new(TopicFilter::Any, NonZero::new(8));
-        let mut sub_b =
-            StatementSubscription::new(TopicFilter::Any, NonZero::new(8));
+        let mut sub_a = StatementSubscription::new(TopicFilter::Any, NonZero::new(8));
+        let mut sub_b = StatementSubscription::new(TopicFilter::Any, NonZero::new(8));
         let stmt = statement_with_topics(vec![]);
         let hash = [0xee; 32];
 


### PR DESCRIPTION
Part of https://github.com/paritytech/smoldot/issues/3142

## Summary
* Extracts `validate_and_broadcast_statement` into `light-base/src/json_rpc_service/statement.rs` with unit tests covering invalid encoding, no-peers, and new-statement result mapping.
* Adds `TopicFilter` edge-case tests to `lib/src/json_rpc/methods.rs`: empty `match_all` matches everything, oversized `match_all` / `match_any` are rejected at construction.
* Moves `StatementSubscription` and `build_combined_affinity_filter` into `statement.rs` and adds reception-path unit tests:
  * **Bloom filter construction** via `build_combined_affinity_filter` — empty subscriptions, `TopicFilter::Any` broadcast, `match_any` union across subscriptions.
  * **Per-subscription dedup** via `StatementSubscription::accept` — fresh acceptance, duplicate hash rejection, LRU eviction allows resubmit, independent per-subscription caches.
* Adds two targeted bloom filter tests in `lib/src/network/codec/affinity.rs` with no polkadot-sdk equivalent:
  * **`decode_rejects_truncated_bits_body`** — guards the explicit `rest.len() != bits_len * 8` check. polkadot-sdk uses derived `codec::Decode`; smoldot parses peer bytes by hand and needs explicit coverage.
  * **`from_topics_empty_is_not_match_all`** — documents that an empty topic iterator produces an *empty* filter, not the `match_all` broadcast filter.
