### PR TITLE
fix(json-rpc): tolerate chainHead subscription / operation removal races

### DIFF
--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -4582,18 +4582,18 @@ pub(super) async fn run<TPlat: PlatformRef>(
             }) => {
                 // A `chainHead_call` operation has finished.
 
+                // The JSON-RPC client might have unfollowed the subscription or stopped
+                // the operation while this event was queued. In that case, drop the event.
                 let Some(subscription_info) =
                     me.chain_head_follow_subscriptions.get_mut(&subscription_id)
                 else {
-                    unreachable!()
+                    continue;
                 };
                 let Some(operation_info) = subscription_info
                     .operations_in_progress
                     .remove(&operation_id)
                 else {
-                    // If the operation was cancelled, then a `ChainHeadOperationCancelled`
-                    // event should have been generated instead.
-                    unreachable!()
+                    continue;
                 };
 
                 subscription_info.available_operation_slots += operation_info.occupied_slots;
@@ -4661,18 +4661,18 @@ pub(super) async fn run<TPlat: PlatformRef>(
             }) => {
                 // A `chainHead_body` operation has finished.
 
+                // The JSON-RPC client might have unfollowed the subscription or stopped
+                // the operation while this event was queued. In that case, drop the event.
                 let Some(subscription_info) =
                     me.chain_head_follow_subscriptions.get_mut(&subscription_id)
                 else {
-                    unreachable!()
+                    continue;
                 };
                 let Some(operation_info) = subscription_info
                     .operations_in_progress
                     .remove(&operation_id)
                 else {
-                    // If the operation was cancelled, then a `ChainHeadOperationCancelled`
-                    // event should have been generated instead.
-                    unreachable!()
+                    continue;
                 };
 
                 subscription_info.available_operation_slots += operation_info.occupied_slots;
@@ -4824,16 +4824,20 @@ pub(super) async fn run<TPlat: PlatformRef>(
 
                 // TODO: generate a waitingForContinue here and wait for user to continue
 
-                // Re-queue the operation for the follow-up items.
-                let on_interrupt = me
-                    .chain_head_follow_subscriptions
-                    .get(&subscription_id)
-                    .unwrap_or_else(|| unreachable!())
-                    .operations_in_progress
-                    .get(&operation_id)
-                    .unwrap_or_else(|| unreachable!())
-                    .interrupt
-                    .listen();
+                // Re-queue the operation for the follow-up items. The JSON-RPC client
+                // might have unfollowed the subscription or stopped the operation while
+                // this event was queued. In that case, drop the event.
+                let Some(subscription_info) =
+                    me.chain_head_follow_subscriptions.get(&subscription_id)
+                else {
+                    continue;
+                };
+                let Some(operation_info) =
+                    subscription_info.operations_in_progress.get(&operation_id)
+                else {
+                    continue;
+                };
+                let on_interrupt = operation_info.interrupt.listen();
                 me.background_tasks.push(Box::pin(async move {
                     async {
                         on_interrupt.await;
@@ -4859,18 +4863,18 @@ pub(super) async fn run<TPlat: PlatformRef>(
             }) => {
                 // A `chainHead_storage` operation has finished successfully.
 
+                // The JSON-RPC client might have unfollowed the subscription or stopped
+                // the operation while this event was queued. In that case, drop the event.
                 let Some(subscription_info) =
                     me.chain_head_follow_subscriptions.get_mut(&subscription_id)
                 else {
-                    unreachable!()
+                    continue;
                 };
                 let Some(operation_info) = subscription_info
                     .operations_in_progress
                     .remove(&operation_id)
                 else {
-                    // If the operation was cancelled, then a `ChainHeadOperationCancelled`
-                    // event should have been generated instead.
-                    unreachable!()
+                    continue;
                 };
 
                 subscription_info.available_operation_slots += operation_info.occupied_slots;
@@ -4896,18 +4900,18 @@ pub(super) async fn run<TPlat: PlatformRef>(
             }) => {
                 // A `chainHead_storage` operation has finished failed.
 
+                // The JSON-RPC client might have unfollowed the subscription or stopped
+                // the operation while this event was queued. In that case, drop the event.
                 let Some(subscription_info) =
                     me.chain_head_follow_subscriptions.get_mut(&subscription_id)
                 else {
-                    unreachable!()
+                    continue;
                 };
                 let Some(operation_info) = subscription_info
                     .operations_in_progress
                     .remove(&operation_id)
                 else {
-                    // If the operation was cancelled, then a `ChainHeadOperationCancelled`
-                    // event should have been generated instead.
-                    unreachable!()
+                    continue;
                 };
 
                 subscription_info.available_operation_slots += operation_info.occupied_slots;


### PR DESCRIPTION
## Summary

Fix #3190 (reported by @leonardocustodio).

`chainHead_v1_follow` can panic in `light-base/src/json_rpc_service/background.rs` when the JSON-RPC client unfollows a subscription or stops an operation while a background event for it is still queued. Five handlers assume the subscription / operation lookup always succeeds:

- `ChainHeadCallOperationDone`
- `ChainHeadBodyOperationDone`
- `ChainHeadStorageOperationProgress::Progress` (Leo's panic site: re-queue path via `chain_head_follow_subscriptions.get(...).unwrap_or_else(|| unreachable!()).operations_in_progress.get(...).unwrap_or_else(|| unreachable!())`)
- `ChainHeadStorageOperationProgress::Finished`
- `ChainHeadStorageOperationProgress::Error`

Leo's report on smoldot 3.0.0:

```
panicked at /__w/smoldot/smoldot/light-base/src/json_rpc_service/background.rs:4713:38:
called `Option::unwrap()` on a `None` value
```

## Root cause

Operations progress asynchronously via `background_tasks` (`FuturesUnordered`). Each background task contains an `.or()` combinator:
- Left side: waits on `on_interrupt` (fired by `chainHead_v1_stopOperation` or `chainHead_v1_unfollow`)
- Right side: awaits the actual operation (storage query, runtime call, body download)

When a client calls `chainHead_v1_unfollow` or `chainHead_v1_stopOperation`:
1. The subscription / operation entry is synchronously `.remove()`d from the map.
2. `operation.interrupt.notify(usize::MAX)` wakes any background task listeners.
3. But a background task that already completed and emitted an event (before the interrupt was observed) is still sitting in the event queue.
4. When the queued event is dequeued, the map lookup returns `None` → panic.

The interrupt mechanism prevents **live** background tasks from producing new events, but does not retroactively drain **already-queued** events. That is the gap.

## Fix

Replace the `unreachable!()` (and the `unwrap_or_else(|| unreachable!())` chain in the Progress handler) with `continue;` on `None`. This is the pattern **already used** by @niclas-parity (originally @niclas-niclas) in commit `978f907f6` (2024-03-11) for the analogous `ChainHeadSubscriptionWithRuntimeNotification` handler at `background.rs:4212-4222`, which comments *"It might be that the JSON-RPC client has unsubscribed"*. This PR extends that defensive pattern to the five operation-lifecycle handlers that were missed.

## Code review: correctness of the fix

### Slot accounting is preserved

`available_operation_slots` is decremented when an operation starts and incremented when it ends. All three termination paths are balanced:

| Termination | Where slots are returned |
|---|---|
| Normal completion (Call/Body/Storage Done) | `available_operation_slots += operation_info.occupied_slots` in the event handler |
| Client `stopOperation` | Synchronously at removal (line 2342) |
| Subscription removed (`unfollow` / dead) | Whole `ChainHeadFollow` struct is dropped; slot counter is irrelevant |

The `continue` path only fires when the operation or subscription is already gone from the map. If gone via `stopOperation`, slots were already returned. If gone via `unfollow`, the struct was dropped. No double-count, no leak.

### No resource leaks

- **Progress handler** uses `.get()` (not `.remove()`) — correct, because the operation is still in progress. The `operations_in_progress` map still owns the entry.
- **Finished/Error/Call/Body handlers** use `.remove()` — correct, because the operation is complete and must be cleaned up.
- When we `continue`, no `responses_tx.send()` is called — correct, because the client already unfollowed or stopped the operation. Sending further events on a dead subscription would violate the chainHead_v1 spec.

### No event-listener race in Progress handler

The Progress handler uses `.get()` + `.listen()` to re-register for interrupts. If `stopOperation` calls `notify(usize::MAX)` between our `.get()` and `.listen()`, the next `EventListener` created by `.listen()` will immediately see the notification (this is `event_listener::Event`'s documented semantic). The resulting `.await` resolves instantly to `ChainHeadOperationCancelled`, which is a no-op at line 4857. Clean.

### Comprehensive panic-site audit

All remaining `unreachable!()` and `.unwrap()` calls in `background.rs` were reviewed. None depend on subscription/operation state surviving client-initiated lifecycle events:
- `NonZero` constructors with known-nonzero literals (lines 585, 592, 2418, 3214, 3374, 3737, 4960)
- Closed-enum exhaustion (lines 2668, 2759, 3261, 3353, 3727, 4015, 4066)
- Protocol-level shape guarantees (line 4692: `MerkleProof` variant impossible in chainHead_v1)
- The three subscription notification handlers (`WithRuntimeReady`, `WithRuntimeNotification`, `WithoutRuntimeNotification`) already use `continue;` on missing subscriptions

No other sites need the same fix.

## Anticipated reviewer questions

### Q: Why drop events silently instead of draining `background_tasks` on removal?

`background_tasks` is a `FuturesUnordered` of heterogeneous `Box<dyn Future>`. It cannot be filtered by `(subscription_id, operation_id)` without rewriting the queue shape. The existing design uses the interrupt mechanism as cleanup for live tasks. The race only affects already-emitted events sitting in the queue — those are spent work, and dropping them is the correct semantic.

### Q: Should the handlers send `OperationInaccessible` / `OperationError` before dropping?

No. If the subscription is gone, the client called `unfollow` — the subscription ID is no longer valid per the chainHead_v1 spec. If the operation is gone, the client called `stopOperation` — it explicitly indicated it doesn't want more output. Sending further events in either case would violate the spec.

### Q: How confident are we this is the panic @leonardocustodio hit?

High — but not certain. The five fixed sites are the only panic candidates in the chainHead code path. No bare `.unwrap()` exists anywhere in `background.rs` that could fire on normal client behavior in this area. The `line 4713 / col 38 / "Option::unwrap()"` string is inconsistent with direct source inspection (all sites use `unwrap_or_else(|| unreachable!())`), but async state-machine desugaring in Rust release builds produces notoriously skewed debug info. If @leonardocustodio can run a patched build and the crash stops, that's confirmation.

## Validation

```text
cargo fmt --check
cargo check -p smoldot-light
cargo test -p smoldot-light
```

All green. No tests added: the fix mirrors an already-correct nearby handler that also ships without tests, and testing the race would require full scaffolding of `json_rpc_service::run` with a mock platform.
