### PR TITLE
fix(sync): don't ban peers for non-advancing warp sync fragments

### DIFF
--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -2520,15 +2520,20 @@ impl SyncBackground {
                         );
                     }
                     Err(err) => {
-                        if let Some(sender) = &sender {
-                            self.network_service
-                                .ban_and_disconnect(
-                                    sender.clone(),
-                                    self.network_chain_id,
-                                    network_service::BanSeverity::High,
-                                    "bad-warp-sync-fragment",
-                                )
-                                .await;
+                        // BlockNumberNotIncrementing means the chain gap is too small
+                        // for warp sync to make progress. This is legitimate on
+                        // short/fresh chains (e.g. zombienet) and is not misbehavior.
+                        if !matches!(err, all::VerifyFragmentError::BlockNumberNotIncrementing) {
+                            if let Some(sender) = &sender {
+                                self.network_service
+                                    .ban_and_disconnect(
+                                        sender.clone(),
+                                        self.network_chain_id,
+                                        network_service::BanSeverity::High,
+                                        "bad-warp-sync-fragment",
+                                    )
+                                    .await;
+                            }
                         }
 
                         self.log_callback.log(

--- a/lib/src/sync/warp_sync.rs
+++ b/lib/src/sync/warp_sync.rs
@@ -1346,12 +1346,23 @@ impl<TSrc, TRq> WarpSync<TSrc, TRq> {
         if self.warp_sync_fragments_download == Some(request_id) {
             self.warp_sync_fragments_download = None;
 
-            self.verify_queue.push_back(PendingVerify {
-                final_set_of_fragments,
-                downloaded_source: Some(rq_source_id),
-                fragments,
-                next_fragment_to_verify_index: 0,
-            });
+            // When the peer responds with zero fragments and indicates this is its
+            // final response, it means there are no GrandPa authority set changes
+            // between our current position and the peer's finalized block. This is
+            // legitimate on fresh/short chains (e.g. zombienet) where no authority
+            // rotation has occurred yet. Skip the queue push (which would just
+            // produce an EmptyProof error) and demote the source's finalized height
+            // so that desired_requests() does not re-select it for warp sync.
+            if fragments.is_empty() && final_set_of_fragments {
+                self.set_source_finality_state(rq_source_id, self.warped_header_number);
+            } else {
+                self.verify_queue.push_back(PendingVerify {
+                    final_set_of_fragments,
+                    downloaded_source: Some(rq_source_id),
+                    fragments,
+                    next_fragment_to_verify_index: 0,
+                });
+            }
         }
 
         let _was_removed = self

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -941,17 +941,15 @@ async fn run_background<TPlat: PlatformRef>(
                 loop {
                     // There might be a new runtime download to start.
                     // Don't download more than 2 runtimes at a time.
-                    // When the finalized block runtime is unknown, don't try to download
-                    // it independently. The sync service will provide it either through
-                    // warp sync (via subscribe_all after subscription reset) or through
-                    // the initial subscription. Downloading here would fail because peers
-                    // might not be connected yet, hitting a 10-second retry delay.
-                    let wait = if num_runtime_downloads < 2 && finalized_block_known {
+                    let wait = if num_runtime_downloads < 2 {
+                        // Grab what to download. If there's nothing more to download, do nothing.
                         let async_op = match &mut background.tree {
                             Tree::FinalizedBlockRuntimeKnown { tree, .. } => {
                                 tree.next_necessary_async_op(&background.platform.now())
                             }
-                            Tree::FinalizedBlockRuntimeUnknown { .. } => unreachable!(),
+                            Tree::FinalizedBlockRuntimeUnknown { tree, .. } => {
+                                tree.next_necessary_async_op(&background.platform.now())
+                            }
                         };
 
                         match async_op {

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -406,14 +406,22 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                                 }
                             )
                         );
-                        if let Some(sender_if_still_connected) = sender_if_still_connected {
-                            task.network_service
-                                .ban_and_disconnect(
-                                    sender_if_still_connected,
-                                    network_service::BanSeverity::High,
-                                    "bad-warp-sync-fragment",
-                                )
-                                .await;
+                        // BlockNumberNotIncrementing means the chain gap is too small
+                        // for warp sync to make progress — the peer's fragments don't
+                        // advance past our current position. This is legitimate on
+                        // short/fresh chains (e.g. zombienet) and is not misbehavior.
+                        // Banning the peer in this case stalls sync entirely when
+                        // there is only one peer available.
+                        if !matches!(err, all::VerifyFragmentError::BlockNumberNotIncrementing) {
+                            if let Some(sender_if_still_connected) = sender_if_still_connected {
+                                task.network_service
+                                    .ban_and_disconnect(
+                                        sender_if_still_connected,
+                                        network_service::BanSeverity::High,
+                                        "bad-warp-sync-fragment",
+                                    )
+                                    .await;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Fixes #3156 (reported by @voliva).

After #3155, cold-start on short/fresh chains (e.g. zombienet with <10 blocks, single peer) stalls for 207+ seconds. The root cause has **three** components, all introduced by #3155:

1. **`warp_sync_minimum_gap` removal** → warp sync attempts to sync even 0-3 block gaps
2. **Peer banning on non-advancing fragments** → only peer gets banned on short chains
3. **Runtime download gated on `finalized_block_known`** → runtime never arrives because warp sync can't complete on short chains, and independent download is blocked

## Validated locally

Tested against a fresh `parity/polkadot:latest --dev` node via Docker:

| Build | Cold-start to `initialized` event |
|---|---|
| `main` (post-#3155) | **>180s timeout** (reproduces #3156) |
| fix branch (ban fix only, commits 1) | **>180s timeout** (ban fix alone insufficient) |
| fix branch (all 3 fixes) | **10.4s** (matches v102 baseline) |

## Fix (two commits)

### Commit 1 — `warp_sync.rs` + callers

**Layer 1 (state machine):** When the peer responds with zero fragments and `is_finished=true`, skip the verify-queue push and demote the source's `finalized_block_height` via `set_source_finality_state()`. This prevents `EmptyProof` from being generated and stops `desired_requests()` from re-selecting the same source.

**Layer 2 (callers):** Skip the ban for `BlockNumberNotIncrementing` (source height is already updated → naturally filtered out). `EmptyProof` is NOT exempted: the legitimate case is handled by Layer 1 and never reaches the caller. Any `EmptyProof` at the caller is `is_finished=false` (misbehavior) and correctly banned.

### Commit 2 — `runtime_service.rs`

Restore independent runtime download when the finalized block runtime is unknown (`FinalizedBlockRuntimeUnknown` state). #3155 gated this behind `finalized_block_known=true`, meaning only warp sync could provide the runtime. On short chains where warp sync can't make progress, the runtime never arrives and the chain is unusable.

This reverts the gating change from #3155 while keeping the other two improvements (`.take()` for warp sync transition, gap removal).

## Why revert part of #3155?

The gating was intended to avoid a 10-second retry cooldown when the independent runtime download fails before peers connect. That's a mild delay on normal chains. But the gate makes short chains (zombienet, dev chains, fixed-validator chains) completely unusable because warp sync can never complete on them, and no other path can provide the runtime. A 10-second delay is a much lesser evil than an infinite stall.

A more surgical fix would keep the gate for normal chains and open it only when warp sync has stalled, but that requires cross-service coordination between the sync and runtime services. This approach restores the pre-#3155 behavior as the minimal fix.

## Convergence analysis

| Error | Converges? | Why |
|---|---|---|
| `EmptyProof + is_finished=true` | Yes | Layer 1 skips queue push + demotes source. Warp sync idles. All-forks runs. Runtime downloaded independently. |
| `EmptyProof + is_finished=false` | Yes | Peer banned (misbehavior). |
| `BlockNumberNotIncrementing` | Yes | Source height updated by `warp_sync_request_response()`. Source filtered out. |

## Known edge case

When a source is demoted to `warped_header_number`, subsequent GrandPa neighbor packets restore its real height (~30s), re-enabling warp sync requests. On a permanent fixed-validator chain, this produces a slow retry cycle (~one request per 30s). Each cycle is one request-response, not a spin. On real chains, this resolves naturally via all-forks completing the sync first.

## Validation

```text
cargo fmt --check
cargo check --workspace --exclude smoldot-light-wasm
cargo test -p smoldot --lib    # 298 passed
cargo test -p smoldot-light    # all passed
```

End-to-end validation against `parity/polkadot:latest --dev` via Docker: 10.4s cold start, matching pre-#3155 behavior.