### PR TITLE
Adjust timeout to 4s

### DIFF
--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -797,7 +797,7 @@ async fn run_background<TPlat: PlatformRef>(
         let tree = {
             let mut tree = async_tree::AsyncTree::new(async_tree::Config {
                 finalized_async_user_data: None,
-                retry_after_failed: Duration::from_secs(10),
+                retry_after_failed: Duration::from_secs(4),
                 blocks_capacity: 32,
             });
             let node_index = tree.input_insert_block(
@@ -1478,7 +1478,7 @@ async fn run_background<TPlat: PlatformRef>(
                             tree: {
                                 let mut tree = async_tree::AsyncTree::new(async_tree::Config {
                                     finalized_async_user_data: None,
-                                    retry_after_failed: Duration::from_secs(10), // TODO: hardcoded
+                                    retry_after_failed: Duration::from_secs(4),
                                     blocks_capacity: 32,
                                 });
                                 let node_index = tree.input_insert_block(

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -1430,7 +1430,7 @@ async fn run_background<TPlat: PlatformRef>(
                                 let mut tree =
                                     async_tree::AsyncTree::<_, Block, _>::new(async_tree::Config {
                                         finalized_async_user_data: runtime,
-                                        retry_after_failed: Duration::from_secs(10), // TODO: hardcoded
+                                        retry_after_failed: Duration::from_secs(4), // TODO: hardcoded
                                         blocks_capacity: 32,
                                     });
 
@@ -1478,7 +1478,7 @@ async fn run_background<TPlat: PlatformRef>(
                             tree: {
                                 let mut tree = async_tree::AsyncTree::new(async_tree::Config {
                                     finalized_async_user_data: None,
-                                    retry_after_failed: Duration::from_secs(4),
+                                    retry_after_failed: Duration::from_secs(4), // TODO: hardcoded
                                     blocks_capacity: 32,
                                 });
                                 let node_index = tree.input_insert_block(


### PR DESCRIPTION
When runtime download failed, we previously waited for 10s, this is now reduced to 4s.

The problem was initially when runtime download fails