### PR TITLE
npm smoldot v3.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light-wasm"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "async-lock",
  "async-task",

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light"
-version = "1.1.0"
+version = "1.1.1"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot-light"
 authors.workspace = true

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 3.1.1 - 2026-04-22
+
+### Fixed
+
+- Fix parachain cold-start where `chainHead_v1_follow` never emitted `initialized` because the bootstrapped runtime was discarded before being passed to the parachain runtime service. ([#3203](https://github.com/paritytech/smoldot/pull/3203))
+- Tolerate races between `chainHead_v1_follow` background events and client-initiated `unfollow` / `stopOperation`, which could previously panic the JSON-RPC background task. ([#3194](https://github.com/paritytech/smoldot/pull/3194))
+
 ## 3.1.0 - 2026-04-17
 
 ### Added

--- a/wasm-node/javascript/package-lock.json
+++ b/wasm-node/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smoldot",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smoldot",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/wasm-node/javascript/package.json
+++ b/wasm-node/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoldot",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Light client that connects to Polkadot and Substrate-based blockchains",
   "contributors": [
     "Parity Technologies <admin@parity.io>",

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light-wasm"
-version = "3.1.0"
+version = "3.1.1"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
This is to:
- publish `smoldot-v3.1.1` npm
- publish crate `smoldot-light v1.1.1`

## Changes

### Fixed

- Fix parachain cold-start where `chainHead_v1_follow` never emitted `initialized` because the bootstrapped runtime was discarded before being passed to the parachain runtime service. (#3203)
- Tolerate races between `chainHead_v1_follow` background events and client-initiated `unfollow` / `stopOperation`, which could previously panic the JSON-RPC background task. (#3194)
