### PR TITLE
perf(sync-service): parallelize Aura call proof downloads during parachain bootstrap

### DIFF
--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -1334,73 +1334,80 @@ async fn bootstrap_parachain_consensus<TPlat: PlatformRef>(
     })
     .map_err(|e| format!("Failed to compile runtime: {e}"))?;
 
-    // AuraApi_slot_duration
-    let (slot_duration, vm) = {
-        let call_proof = network_service
-            .clone()
-            .call_proof_request(
-                peer_id.clone(),
-                codec::CallProofRequestConfig {
-                    block_hash,
-                    method: Cow::Borrowed("AuraApi_slot_duration"),
-                    parameter_vectored: iter::empty::<Vec<u8>>(),
-                },
-                Duration::from_secs(16),
-            )
-            .await
-            .map_err(|e| format!("AuraApi_slot_duration call proof request failed: {e}"))?;
+    // Download both Aura call proofs in parallel. try_join cancels the
+    // remaining request eagerly if either one fails.
+    let peer_id_clone = peer_id.clone();
+    let (slot_duration_proof, authorities_proof) = future::try_join(
+        async {
+            network_service
+                .clone()
+                .call_proof_request(
+                    peer_id_clone,
+                    codec::CallProofRequestConfig {
+                        block_hash,
+                        method: Cow::Borrowed("AuraApi_slot_duration"),
+                        parameter_vectored: iter::empty::<Vec<u8>>(),
+                    },
+                    Duration::from_secs(16),
+                )
+                .await
+                .map_err(|e| format!("AuraApi_slot_duration call proof request failed: {e}"))
+        },
+        async {
+            network_service
+                .clone()
+                .call_proof_request(
+                    peer_id,
+                    codec::CallProofRequestConfig {
+                        block_hash,
+                        method: Cow::Borrowed("AuraApi_authorities"),
+                        parameter_vectored: iter::empty::<Vec<u8>>(),
+                    },
+                    Duration::from_secs(16),
+                )
+                .await
+                .map_err(|e| format!("AuraApi_authorities call proof request failed: {e}"))
+        },
+    )
+    .await?;
 
-        let decoded_call_proof =
-            trie::proof_decode::decode_and_verify_proof(trie::proof_decode::Config {
-                proof: call_proof.decode().to_vec(),
-            })
-            .map_err(|e| format!("Failed to decode slot_duration call proof: {e}"))?;
+    // Decode proofs.
+    let decoded_slot_duration_proof =
+        trie::proof_decode::decode_and_verify_proof(trie::proof_decode::Config {
+            proof: slot_duration_proof.decode().to_vec(),
+        })
+        .map_err(|e| format!("Failed to decode slot_duration call proof: {e}"))?;
 
-        let (output, vm) = run_single_runtime_call(
-            vm,
-            "AuraApi_slot_duration",
-            &decoded_call_proof,
-            &state_root,
-        )?;
+    let decoded_authorities_proof =
+        trie::proof_decode::decode_and_verify_proof(trie::proof_decode::Config {
+            proof: authorities_proof.decode().to_vec(),
+        })
+        .map_err(|e| format!("Failed to decode authorities call proof: {e}"))?;
 
-        let duration = <[u8; 8]>::try_from(output.as_slice())
-            .ok()
-            .and_then(|b| NonZero::<u64>::new(u64::from_le_bytes(b)))
-            .ok_or_else(|| String::from("Failed to decode AuraApi_slot_duration output"))?;
-        (duration, vm)
-    };
+    // Execute calls sequentially (the VM is consumed and returned by each call).
+    let (slot_duration_output, vm) = run_single_runtime_call(
+        vm,
+        "AuraApi_slot_duration",
+        &decoded_slot_duration_proof,
+        &state_root,
+    )?;
 
-    // AuraApi_authorities
-    let (authorities, vm) = {
-        let call_proof = network_service
-            .clone()
-            .call_proof_request(
-                peer_id,
-                codec::CallProofRequestConfig {
-                    block_hash,
-                    method: Cow::Borrowed("AuraApi_authorities"),
-                    parameter_vectored: iter::empty::<Vec<u8>>(),
-                },
-                Duration::from_secs(16),
-            )
-            .await
-            .map_err(|e| format!("AuraApi_authorities call proof request failed: {e}"))?;
+    let slot_duration = <[u8; 8]>::try_from(slot_duration_output.as_slice())
+        .ok()
+        .and_then(|b| NonZero::<u64>::new(u64::from_le_bytes(b)))
+        .ok_or_else(|| String::from("Failed to decode AuraApi_slot_duration output"))?;
 
-        let decoded_call_proof =
-            trie::proof_decode::decode_and_verify_proof(trie::proof_decode::Config {
-                proof: call_proof.decode().to_vec(),
-            })
-            .map_err(|e| format!("Failed to decode authorities call proof: {e}"))?;
+    let (authorities_output, vm) = run_single_runtime_call(
+        vm,
+        "AuraApi_authorities",
+        &decoded_authorities_proof,
+        &state_root,
+    )?;
 
-        let (output, vm) =
-            run_single_runtime_call(vm, "AuraApi_authorities", &decoded_call_proof, &state_root)?;
-
-        let auths = header::AuraAuthoritiesIter::decode(&output)
-            .map_err(|_| String::from("Failed to decode AuraApi_authorities output"))?
-            .map(header::AuraAuthority::from)
-            .collect::<Vec<_>>();
-        (auths, vm)
-    };
+    let authorities = header::AuraAuthoritiesIter::decode(&authorities_output)
+        .map_err(|_| String::from("Failed to decode AuraApi_authorities output"))?
+        .map(header::AuraAuthority::from)
+        .collect::<Vec<_>>();
 
     log!(
         platform,


### PR DESCRIPTION
## Summary

Download `AuraApi_slot_duration` and `AuraApi_authorities` call proofs in parallel during parachain bootstrap using `futures::try_join`, saving one P2P round-trip on every start. If either request fails, the other is cancelled eagerly.

## Changes

- Fire both call proof requests simultaneously using `future::try_join`
- Decode both proofs after both downloads complete
- Execute the calls sequentially against the compiled VM (the VM prototype is consumed and returned by each call, so execution must remain serial)

One file changed, net +7 lines. No new dependencies (`futures_util::future` already imported).

## Benchmark results

10 cold-start iterations each (baseline vs PR) on Polkadot Asset Hub via [smolbench](https://github.com/paritytech/smolbench):

**aura_phase** = full Phase 2 time (`:code` download + compile + Aura call proofs):

| Stat | Baseline (main) | PR (try_join) | Delta |
|------|----------------|---------------|-------|
| **Median** | **1361ms** | **1161ms** | **-200ms** |
| Mean | 1471ms | 1710ms | +239ms (skewed by one 6.8s outlier) |
| Min | 358ms | 325ms | -33ms |
| P25 | 401ms | 374ms | -27ms |
| P75 | 2133ms | 2126ms | -7ms |

### Baseline (sorted)
```
358, 401, 1270, 1335, 1353, 1369, 1550, 2133, 2318, 2627
```

### PR (sorted)
```
325, 373, 374, 1095, 1144, 1179, 1197, 2126, 2433, 6858
```

The median improvement of ~200ms matches the expected savings from removing one P2P round-trip. The measurement is noisy because `aura_phase` includes the `:code` download (2 MiB, high variance), which dominates timing. The call proof parallelization affects only the last ~200-500ms of this window.

## Test plan

- [x] `cargo check -p smoldot-light` clean
- [x] `cargo fmt` clean
- [x] `cargo clippy -p smoldot-light` — no new warnings
- [x] Benchmarked on Polkadot Asset Hub (10 runs each, baseline vs PR)

Closes #3219