### PR TITLE
Add releasing guide

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ on:
   workflow_dispatch:
     inputs:
       npm_tag_suffix:
-        description: 'Optional suffix for the dev dist-tag. Non-empty → tag "dev-<YYYYMMDD>-<suffix>", version "<next-patch>-dev.<YYYYMMDD>.<suffix>.<N>". Empty → tag "dev-<YYYYMMDD>", version "<next-patch>-dev.<YYYYMMDD>.<N>". Version always bumps patch (never minor/major). Cannot produce "latest". Allowed suffix chars: [A-Za-z0-9-].'
+        description: 'Optional suffix for the dev dist-tag. Non-empty → tag "dev-<YYYYMMDD>-<suffix>", version "<next-patch>-dev-<YYYYMMDD>-<suffix>.<N>". Empty → tag "dev-<YYYYMMDD>", version "<next-patch>-dev-<YYYYMMDD>.<N>". Version always bumps patch (never minor/major). Cannot produce "latest". Allowed suffix chars: [A-Za-z0-9-].'
         type: string
         required: false
         default: ''
@@ -220,15 +220,15 @@ jobs:
 
           DATE=$(date -u +%Y%m%d)
 
-          # Branch prefix/tag on empty suffix to keep versions semver-valid
-          # (empty prerelease identifiers would fail semver).
+          # Build the "dev[-<suffix>]" portion once, shared by version and tag.
           if [[ -z "$SUFFIX" ]]; then
-            PREFIX="${NEXT}-dev.${DATE}"
             TAG="dev-${DATE}"
           else
-            PREFIX="${NEXT}-dev.${DATE}.${SUFFIX}"
             TAG="dev-${DATE}-${SUFFIX}"
           fi
+          # Version's first prerelease identifier is the tag; "." + numeric N
+          # is a second identifier so that N sorts numerically.
+          PREFIX="${NEXT}-${TAG}"
           MAX_N=$(
             npm view --json smoldot versions 2>/dev/null \
               | jq -r '.[]' \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,10 +25,11 @@ on:
       - main
   workflow_dispatch:
     inputs:
-      npm_tag:
-        description: 'npm distribution tag (e.g. "dev", "canary"). Required to prevent accidental @latest publish.'
+      npm_tag_suffix:
+        description: 'Optional suffix for the dev dist-tag. Non-empty → tag "dev-<YYYYMMDD>-<suffix>", version "<next-patch>-dev.<YYYYMMDD>.<suffix>.<N>". Empty → tag "dev-<YYYYMMDD>", version "<next-patch>-dev.<YYYYMMDD>.<N>". Version always bumps patch (never minor/major). Cannot produce "latest". Allowed suffix chars: [A-Za-z0-9-].'
         type: string
-        required: true
+        required: false
+        default: ''
 
 # TODO: improve the security of this module
 permissions: read-all
@@ -193,6 +194,57 @@ jobs:
           node-version: 18
       - uses: Swatinem/rust-cache@v2
 
+      # On workflow_dispatch: compute a unique dev version and a safe dist-tag,
+      # then rewrite them in-place into package.json and wasm-node/rust/Cargo.toml
+      # (never committed). On push-to-main this step is skipped; the committed
+      # versions are published to the default dist-tag (`latest`).
+      - name: Compute dev version and dist-tag
+        if: github.event_name == 'workflow_dispatch'
+        id: devver
+        run: |
+          apt-get update -qq && apt-get install -y -qq jq
+          SUFFIX='${{ inputs.npm_tag_suffix }}'
+          # Empty suffix is allowed; non-empty must match the charset.
+          if [[ -n "$SUFFIX" && ! "$SUFFIX" =~ ^[A-Za-z0-9-]+$ ]]; then
+            echo "::error::npm_tag_suffix must match [A-Za-z0-9-]+ or be empty"
+            exit 1
+          fi
+          BASE=$(jq -r .version wasm-node/javascript/package.json)
+          STABLE=${BASE%%-*}
+          IFS='.' read -r MA MI PA <<< "$STABLE"
+          # Always bump patch. Semver-safe: <next-patch>-dev.X sorts below any
+          # future stable (patch, minor, or major) regardless of what the real
+          # next release ends up being. If you ever need minor/major dev
+          # prereleases, add a `bump` workflow input.
+          NEXT="$MA.$MI.$((PA+1))"
+
+          DATE=$(date -u +%Y%m%d)
+
+          # Branch prefix/tag on empty suffix to keep versions semver-valid
+          # (empty prerelease identifiers would fail semver).
+          if [[ -z "$SUFFIX" ]]; then
+            PREFIX="${NEXT}-dev.${DATE}"
+            TAG="dev-${DATE}"
+          else
+            PREFIX="${NEXT}-dev.${DATE}.${SUFFIX}"
+            TAG="dev-${DATE}-${SUFFIX}"
+          fi
+          MAX_N=$(
+            npm view --json smoldot versions 2>/dev/null \
+              | jq -r '.[]' \
+              | grep -E "^${PREFIX}\.[0-9]+$" \
+              | sed -E "s|^${PREFIX}\.||" \
+              | sort -n | tail -1
+          )
+          N=$(( ${MAX_N:--1} + 1 ))
+          VERSION="${PREFIX}.${N}"
+          jq --arg v "$VERSION" '.version=$v' wasm-node/javascript/package.json > _pj \
+            && mv _pj wasm-node/javascript/package.json
+          sed -i -E '0,/^version = "[^"]+"/s//version = "'"$VERSION"'"/' wasm-node/rust/Cargo.toml
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG"         >> "$GITHUB_OUTPUT"
+          echo "Computed: $VERSION → dist-tag $TAG"
+
       - name: Install
         run: npm install
         working-directory: ./wasm-node/javascript
@@ -212,8 +264,9 @@ jobs:
         with:
           route: POST /repos/paritytech/npm_publish_automation/actions/workflows/publish.yml/dispatches
           ref: main
-          # Make sure to provide proper artifact_name, since this GH run produces multiple artifacts and npm_publish_automation must know, which one to use
-          inputs: '${{ format(''{{ "repo": "{0}", "run_id": "{1}", "artifact_name": "npm-package-{2}", "npm_tag": "{3}" }}'', github.repository, github.run_id, github.sha, inputs.npm_tag) }}'
+          # Empty npm_tag on push-to-main → automation omits `--tag` → npm defaults to `latest`.
+          # On workflow_dispatch → steps.devver.outputs.tag is non-empty.
+          inputs: '${{ format(''{{ "repo": "{0}", "run_id": "{1}", "artifact_name": "npm-package-{2}", "npm_tag": "{3}" }}'', github.repository, github.run_id, github.sha, steps.devver.outputs.tag) }}'
         env:
           GITHUB_TOKEN: ${{ secrets.NPM_PUBLISH_AUTOMATION_TOKEN }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -201,6 +201,7 @@ jobs:
       - name: Compute dev version and dist-tag
         if: github.event_name == 'workflow_dispatch'
         id: devver
+        shell: bash
         run: |
           apt-get update -qq && apt-get install -y -qq jq
           SUFFIX='${{ inputs.npm_tag_suffix }}'

--- a/docs/DEV-PUBLISHING.md
+++ b/docs/DEV-PUBLISHING.md
@@ -1,0 +1,43 @@
+# Publishing a dev build
+
+Manual npm publish for testing. **Never moves `latest`.** No version commit needed.
+
+## Prepare a branch
+
+- Create or check out a branch off whatever base you want to publish from.
+- Commit and push the changes you want in the dev build. The branch does not
+  need a bumped `package.json` / `Cargo.toml` — the workflow handles versions.
+
+## Trigger
+
+- Open the workflow page:
+  <https://github.com/paritytech/smoldot/actions/workflows/deploy.yml>
+- Click **Run workflow**
+- Select your branch
+- `npm_tag_suffix`: short label (e.g. `smoke`), or leave blank
+- Click **Run workflow**
+
+## What you get
+
+| Input | Published version | Dist-tag |
+|---|---|---|
+| `suffix = smoke` | `<next-patch>-dev.<YYYYMMDD>.smoke.<N>` | `dev-<YYYYMMDD>-smoke` |
+| blank | `<next-patch>-dev.<YYYYMMDD>.<N>` | `dev-<YYYYMMDD>` |
+
+Example, dispatched 2026-04-22 while stable is `3.1.1`, suffix `smoke`:
+- Version: `3.1.2-dev.20260422.smoke.0`
+- Dist-tag: `dev-20260422-smoke`
+
+Rules of thumb:
+- **`N` counter** — `0` on the first dispatch of a new `(next-patch, date, suffix)`; `+1` on every subsequent dispatch, including "Re-run jobs".
+- **Dist-tag follows the latest publish** in that tuple. Earlier versions stay installable by exact version.
+- **Version bumps patch only** (never minor/major).
+
+## Install
+
+```sh
+npm install smoldot@dev-20260422-smoke            # follow the tag (moves)
+npm install smoldot@3.1.2-dev.20260422.smoke.0    # pin to exact (immutable)
+```
+
+Full release flow: see [`RELEASING.md`](./RELEASING.md).

--- a/docs/DEV-PUBLISHING.md
+++ b/docs/DEV-PUBLISHING.md
@@ -21,11 +21,11 @@ Manual npm publish for testing. **Never moves `latest`.** No version commit need
 
 | Input | Published version | Dist-tag |
 |---|---|---|
-| `suffix = smoke` | `<next-patch>-dev.<YYYYMMDD>.smoke.<N>` | `dev-<YYYYMMDD>-smoke` |
-| blank | `<next-patch>-dev.<YYYYMMDD>.<N>` | `dev-<YYYYMMDD>` |
+| `suffix = smoke` | `<next-patch>-dev-<YYYYMMDD>-smoke.<N>` | `dev-<YYYYMMDD>-smoke` |
+| blank | `<next-patch>-dev-<YYYYMMDD>.<N>` | `dev-<YYYYMMDD>` |
 
 Example, dispatched 2026-04-22 while stable is `3.1.1`, suffix `smoke`:
-- Version: `3.1.2-dev.20260422.smoke.0`
+- Version: `3.1.2-dev-20260422-smoke.0`
 - Dist-tag: `dev-20260422-smoke`
 
 Rules of thumb:
@@ -36,8 +36,8 @@ Rules of thumb:
 ## Install
 
 ```sh
-npm install smoldot@dev-20260422-smoke            # follow the tag (moves)
-npm install smoldot@3.1.2-dev.20260422.smoke.0    # pin to exact (immutable)
+npm install smoldot@dev-20260422-smoke           # follow the tag (moves)
+npm install smoldot@3.1.2-dev-20260422-smoke.0   # pin to exact (immutable)
 ```
 
 Full release flow: see [`RELEASING.md`](./RELEASING.md).

--- a/docs/DEV-PUBLISHING.md
+++ b/docs/DEV-PUBLISHING.md
@@ -1,37 +1,20 @@
 # Publishing a dev build
 
-Manual npm publish for testing. **Never moves `latest`.** No version commit needed.
+## How
 
-## Prepare a branch
-
-- Create or check out a branch off whatever base you want to publish from.
-- Commit and push the changes you want in the dev build. The branch does not
-  need a bumped `package.json` / `Cargo.toml` — the workflow handles versions.
-
-## Trigger
-
-- Open the workflow page:
-  <https://github.com/paritytech/smoldot/actions/workflows/deploy.yml>
-- Click **Run workflow**
-- Select your branch
-- `npm_tag_suffix`: short label (e.g. `smoke`), or leave blank
-- Click **Run workflow**
+1. Push your changes to any branch — no `package.json` / `Cargo.toml` bumps
+   needed, the workflow handles versions.
+2. Open [Actions → deploy → Run workflow](https://github.com/paritytech/smoldot/actions/workflows/deploy.yml),
+   pick your branch, optionally enter `npm_tag_suffix` (e.g. `smoke`), click
+   **Run workflow**.
 
 ## What you get
 
-| Input | Published version | Dist-tag |
-|---|---|---|
-| `suffix = smoke` | `<next-patch>-dev-<YYYYMMDD>-smoke.<N>` | `dev-<YYYYMMDD>-smoke` |
-| blank | `<next-patch>-dev-<YYYYMMDD>.<N>` | `dev-<YYYYMMDD>` |
+Examples (dispatched 2026-04-22, stable `3.1.1`):
 
-Example, dispatched 2026-04-22 while stable is `3.1.1`, suffix `smoke`:
-- Version: `3.1.2-dev-20260422-smoke.0`
-- Dist-tag: `dev-20260422-smoke`
-
-Rules of thumb:
-- **`N` counter** — `0` on the first dispatch of a new `(next-patch, date, suffix)`; `+1` on every subsequent dispatch, including "Re-run jobs".
-- **Dist-tag follows the latest publish** in that tuple. Earlier versions stay installable by exact version.
-- **Version bumps patch only** (never minor/major).
+- `npm_tag_suffix=smoke` → version `3.1.2-dev-20260422-smoke.0`, dist-tag `dev-20260422-smoke`
+- `npm_tag_suffix=smoke` again, same day → version `3.1.2-dev-20260422-smoke.1`, dist-tag `dev-20260422-smoke` (moved to `.1`)
+- blank `npm_tag_suffix` → version `3.1.2-dev-20260422.0`, dist-tag `dev-20260422`
 
 ## Install
 
@@ -40,4 +23,4 @@ npm install smoldot@dev-20260422-smoke           # follow the tag (moves)
 npm install smoldot@3.1.2-dev-20260422-smoke.0   # pin to exact (immutable)
 ```
 
-Full release flow: see [`RELEASING.md`](./RELEASING.md).
+Full release flow: [`RELEASING.md`](./RELEASING.md).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -63,10 +63,14 @@ the same version is tolerated.
 ## 2. Open a release branch
 
 ```sh
-git checkout -b npm-smoldot-v<X.Y.Z>
+git checkout -b release/npm-smoldot-v<X.Y.Z>
 ```
 
-Branch naming mirrors the npm version even when the rust crate versions differ.
+The `release/` prefix is required: the post-merge tag will be
+`npm-smoldot-v<X.Y.Z>`, so the branch must not share that exact name (git
+resolves tags before branches and ambiguous refs break `git push`, `git
+checkout`, etc.). The branch follows the npm version even when the rust crate
+versions differ.
 
 ---
 
@@ -74,15 +78,18 @@ Branch naming mirrors the npm version even when the rust crate versions differ.
 
 Edit exactly these fields (do not edit anything else in the same commit):
 
-1. `lib/Cargo.toml` — `version = "<A.B.C>"` *(if bumping `smoldot`)*
-2. `light-base/Cargo.toml` — `version = "<A.B.C>"` *(if bumping `smoldot-light`)*
-3. `wasm-node/rust/Cargo.toml` — `version = "<X.Y.Z>"` *(mirror npm)*
-4. `wasm-node/javascript/package.json` — `"version": "<X.Y.Z>"`
+1. `wasm-node/javascript/package.json` — `"version": "<X.Y.Z>"`
+2. `wasm-node/rust/Cargo.toml` — `version = "<X.Y.Z>"` *(mirror npm)*
+3. `lib/Cargo.toml` — `version = "<A.B.C>"` *(if bumping `smoldot`)*
+4. `light-base/Cargo.toml` — `version = "<A.B.C>"` *(if bumping `smoldot-light`)*
 
-**Do not** touch the `version = "..."` requirement on `smoldot` /
-`smoldot-light` in `full-node/Cargo.toml`, `light-base/Cargo.toml`, or
-`wasm-node/rust/Cargo.toml` unless a dependent actually needs a newer minimum.
-Past releases have not updated these in sync.
+**Path-dep `version` strings: bump only on major crosses.** Leave the
+`version = "..."` on `smoldot` / `smoldot-light` path-deps in
+`full-node/Cargo.toml`, `light-base/Cargo.toml`, and `wasm-node/rust/Cargo.toml`
+alone on patch and minor releases. Bump them only when the dep crosses a major
+boundary (e.g. `smoldot 1.x.y` → `2.0.0`). Rationale: the `path` resolves the
+source locally regardless of the string; the string is a tripwire that only
+needs to track the current compatibility range, not the exact version.
 
 **CI-enforced invariant:** `wasm-node/javascript/package.json` `.version` and
 `wasm-node/rust/Cargo.toml` `[package].version` must match exactly. The
@@ -158,7 +165,7 @@ git add lib/Cargo.toml light-base/Cargo.toml wasm-node/rust/Cargo.toml \
         wasm-node/javascript/package.json wasm-node/javascript/package-lock.json \
         wasm-node/CHANGELOG.md Cargo.lock
 git --no-gpg-sign commit -m "npm smoldot v<X.Y.Z>"
-git push origin npm-smoldot-v<X.Y.Z>
+git push origin release/npm-smoldot-v<X.Y.Z>
 ```
 
 Open a PR. Body template:
@@ -191,22 +198,26 @@ Squash-merge. Record the resulting commit SHA on `main` — tags will point at i
 
 ---
 
-## 10. Watch the automated deploys
+## 10. Sanity check after deployment job is finished
 
-Click through to the run of `deploy.yml` triggered by the merge. Check each of:
+Once the `deploy.yml` run on the release commit completes, perform these steps:
 
-- `npm-publish` — dispatch to `paritytech/npm_publish_automation` succeeded.
-  Verify: `npm view smoldot@<X.Y.Z>`.
-- `deno-publish` — `light-js-deno-v<X.Y.Z>` tag pushed. Verify:
-  `git fetch --tags && git tag -l 'light-js-deno-v<X.Y.Z>'`.
-- `crates-io-publish` — each bumped crate published. If `smoldot` was not
-  bumped, its step fails with "version already exists" (expected — the job
-  has `continue-on-error: true`). Verify bumped crates:
-  ```sh
-  curl -s https://crates.io/api/v1/crates/smoldot       | jq .crate.max_version
-  curl -s https://crates.io/api/v1/crates/smoldot-light | jq .crate.max_version
-  ```
-- `docs-publish` — pushed to `gh-pages`.
+```sh
+# npm package
+npm view smoldot@<X.Y.Z>
+
+# crates.io — requires a User-Agent with contact info
+curl -sS -A "some-agent" https://crates.io/api/v1/crates/smoldot       | jq .crate.max_version
+curl -sS -A "some-agent" https://crates.io/api/v1/crates/smoldot-light | jq .crate.max_version
+
+# Deno tag pushed by CI
+git fetch --tags
+git tag -l 'light-js-deno-v<X.Y.Z>'
+```
+
+Expected quirk: the `crates-io-publish` job's `smoldot` step fails with
+"version already exists" when `smoldot` wasn't bumped this release — benign
+(`continue-on-error: true`).
 
 ---
 
@@ -228,19 +239,16 @@ git push origin \
     [smoldot-v<A.B.C>]
 ```
 
-Tags are lightweight (no `-a`/`-m`).
+Tags are lightweight (no `-a`/`-m`). Verify they landed on origin:
 
----
+```sh
+git fetch --tags
+git tag -l '*<X.Y.Z>*'   # should list the CI-pushed light-js-deno-v tag plus the manual ones
+```
 
-## 12. Sanity-check post-release
-
-- `npm view smoldot@<X.Y.Z>` resolves; `dist-tags.latest` updated (unless a
-  non-`latest` dist-tag was passed via `workflow_dispatch`).
-- `https://crates.io/crates/smoldot-light/<A.B.C>` loads.
-- `git tag -l '*<X.Y.Z>*'` shows the auto and manual tags.
-
-On failure, do not delete published versions — yank (`npm deprecate`,
-`cargo yank`) and cut a new release.
+On any post-publish failure, do not delete published versions — yank
+(`npm deprecate smoldot@<X.Y.Z> '...'`, `cargo yank --version <A.B.C>`) and
+cut a new release.
 
 ---
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -7,15 +7,22 @@ Runbook for cutting a release of the smoldot **npm package** and the Rust crates
 
 ## 0. What a release actually ships
 
-A single release commit on `main` drives four outputs:
+`deploy.yml` runs on **every** push to `main`, but only a version-bumping push
+produces new published artifacts. Non-bumping pushes are idempotent: npm
+rejects duplicate versions, `crates-io-publish` absorbs the "already uploaded"
+error (`continue-on-error: true`), and the Deno tag is created only if
+missing. So the release is effectively keyed on the version bump, not the
+merge itself.
 
-| Output | Trigger | Job in `.github/workflows/deploy.yml` |
-|---|---|---|
-| npm package `smoldot` | push to `main` | `npm-publish` (dispatches `paritytech/npm_publish_automation`) |
-| Deno git-tag `light-js-deno-v<npm>` | push to `main` | `deno-publish` (creates tag if missing) |
-| crates.io `smoldot` | push to `main` | `crates-io-publish` (runs `cargo publish --no-verify`; `continue-on-error: true`) |
-| crates.io `smoldot-light` | push to `main` | `crates-io-publish` (same) |
-| Docs (gh-pages) | push to `main` | `docs-publish` |
+A version-bumping release commit drives four outputs:
+
+| Output | Job in `.github/workflows/deploy.yml` |
+|---|---|
+| npm package `smoldot` | `npm-publish` (dispatches `paritytech/npm_publish_automation`) |
+| Deno git-tag `light-js-deno-v<npm>` | `deno-publish` (creates tag if missing) |
+| crates.io `smoldot` | `crates-io-publish` (runs `cargo publish --no-verify`; `continue-on-error: true`) |
+| crates.io `smoldot-light` | `crates-io-publish` (same) |
+| Docs (gh-pages) | `docs-publish` (force-pushes fresh tree every run, regardless of version) |
 
 Three git tags are created **manually** on the release commit after merge:
 `npm-smoldot-v<X.Y.Z>`, `smoldot-v<A.B.C>`, `smoldot-light-v<A.B.C>`. Create
@@ -258,7 +265,7 @@ cut a new release.
 for non-`latest` publishes (`dev`, `canary`, etc.). The commit's
 `package.json` version must not already exist on npm.
 
-## Appendix B — Files for automation
+## Appendix B — Files for future automation
 
 - Version reads: `wasm-node/javascript/package.json` (`.version`),
   `lib/Cargo.toml`, `light-base/Cargo.toml`, `wasm-node/rust/Cargo.toml`

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -259,11 +259,45 @@ cut a new release.
 
 ---
 
-## Appendix A — Manual npm republish (rare)
+## Appendix A — Manual dev publish
 
-`deploy.yml` has a `workflow_dispatch` trigger with an `npm_tag` input. Use it
-for non-`latest` publishes (`dev`, `canary`, etc.). The commit's
-`package.json` version must not already exist on npm.
+`deploy.yml` has a `workflow_dispatch` trigger with a single input,
+`npm_tag_suffix`. Use it to publish a dev build from any branch without
+editing `package.json` by hand.
+
+**Trigger.** Actions → "deploy" → "Run workflow" → pick the branch, optionally
+enter an `npm_tag_suffix`. The suffix must match `[A-Za-z0-9-]+`. Leave it
+blank for a generic dated dev publish.
+
+**What gets published.** The workflow rewrites `wasm-node/javascript/package.json`
+and `wasm-node/rust/Cargo.toml` in-memory to a computed version, packs, and
+dispatches to `npm_publish_automation`. Nothing is committed back to git.
+
+- **Version** always bumps patch — never minor or major
+- **With suffix** (e.g. `test123`):
+  - Version: `<next-patch>-dev.<YYYYMMDD>.<suffix>.<N>` → `3.1.2-dev.20260422.test123.0`
+  - Dist-tag: `dev-<YYYYMMDD>-<suffix>` → `dev-20260422-test123`
+- **Without suffix** (blank):
+  - Version: `<next-patch>-dev.<YYYYMMDD>.<N>` → `3.1.2-dev.20260422.0`
+  - Dist-tag: `dev-<YYYYMMDD>` → `dev-20260422`
+- **`N` counter** auto-increments. The workflow queries `npm view --json
+  smoldot versions` for prior publishes matching the prefix and uses
+  `max(N) + 1`. First dispatch of a new tuple starts at `0`.
+
+**Install a dev build:**
+
+```sh
+npm install smoldot@dev-20260422-test123   # by dist-tag (moves with each publish)
+npm install smoldot@3.1.2-dev.20260422.test123.0   # by exact version (immutable)
+```
+
+**Reruns are idempotent.** Re-running the same workflow run (via the UI's
+"Re-run jobs") produces the same VERSION; the automation's collision check
+skips the publish with a warning. Fresh dispatches produce fresh versions.
+
+**Why the dist-tag can't be `latest`.** The final dist-tag always starts with
+`dev-<YYYYMMDD>`. Suffix validation rejects anything outside `[A-Za-z0-9-]`.
+Even `suffix=""` produces `dev-<YYYYMMDD>`, not `latest`.
 
 ## Appendix B — Files for future automation
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -291,9 +291,12 @@ npm install smoldot@dev-20260422-test123   # by dist-tag (moves with each publis
 npm install smoldot@3.1.2-dev.20260422.test123.0   # by exact version (immutable)
 ```
 
-**Reruns are idempotent.** Re-running the same workflow run (via the UI's
-"Re-run jobs") produces the same VERSION; the automation's collision check
-skips the publish with a warning. Fresh dispatches produce fresh versions.
+**Every dispatch gets a fresh version.** `N` is derived from npm state, not
+from a workflow-run counter, so any dispatch (fresh or "Re-run jobs" after a
+successful publish) queries npm and publishes `N+1`. To publish new code,
+push your commits and dispatch again. Reruns reuse the same version *only* if
+the first attempt failed before reaching the publish step (nothing on npm
+yet) — in which case the next dispatch computes the same `N` and retries.
 
 **Why the dist-tag can't be `latest`.** The final dist-tag always starts with
 `dev-<YYYYMMDD>`. Suffix validation rejects anything outside `[A-Za-z0-9-]`.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -275,10 +275,10 @@ dispatches to `npm_publish_automation`. Nothing is committed back to git.
 
 - **Version** always bumps patch — never minor or major
 - **With suffix** (e.g. `test123`):
-  - Version: `<next-patch>-dev.<YYYYMMDD>.<suffix>.<N>` → `3.1.2-dev.20260422.test123.0`
+  - Version: `<next-patch>-dev-<YYYYMMDD>-<suffix>.<N>` → `3.1.2-dev-20260422-test123.0`
   - Dist-tag: `dev-<YYYYMMDD>-<suffix>` → `dev-20260422-test123`
 - **Without suffix** (blank):
-  - Version: `<next-patch>-dev.<YYYYMMDD>.<N>` → `3.1.2-dev.20260422.0`
+  - Version: `<next-patch>-dev-<YYYYMMDD>.<N>` → `3.1.2-dev-20260422.0`
   - Dist-tag: `dev-<YYYYMMDD>` → `dev-20260422`
 - **`N` counter** auto-increments. The workflow queries `npm view --json
   smoldot versions` for prior publishes matching the prefix and uses
@@ -288,7 +288,7 @@ dispatches to `npm_publish_automation`. Nothing is committed back to git.
 
 ```sh
 npm install smoldot@dev-20260422-test123   # by dist-tag (moves with each publish)
-npm install smoldot@3.1.2-dev.20260422.test123.0   # by exact version (immutable)
+npm install smoldot@3.1.2-dev-20260422-test123.0   # by exact version (immutable)
 ```
 
 **Every dispatch gets a fresh version.** `N` is derived from npm state, not

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,266 @@
+# Releasing smoldot
+
+Runbook for cutting a release of the smoldot **npm package** and the Rust crates
+(`smoldot`, `smoldot-light`). Written to be mechanical enough to automate.
+
+---
+
+## 0. What a release actually ships
+
+A single release commit on `main` drives four outputs:
+
+| Output | Trigger | Job in `.github/workflows/deploy.yml` |
+|---|---|---|
+| npm package `smoldot` | push to `main` | `npm-publish` (dispatches `paritytech/npm_publish_automation`) |
+| Deno git-tag `light-js-deno-v<npm>` | push to `main` | `deno-publish` (creates tag if missing) |
+| crates.io `smoldot` | push to `main` | `crates-io-publish` (runs `cargo publish --no-verify`; `continue-on-error: true`) |
+| crates.io `smoldot-light` | push to `main` | `crates-io-publish` (same) |
+| Docs (gh-pages) | push to `main` | `docs-publish` |
+
+Three git tags are created **manually** on the release commit after merge:
+`npm-smoldot-v<X.Y.Z>`, `smoldot-v<A.B.C>`, `smoldot-light-v<A.B.C>`. Create
+only the ones whose version actually changed. The `light-js-deno-v<X.Y.Z>` tag
+is created by CI, not manually.
+
+---
+
+## 1. Decide version bumps
+
+Check what changed since the last release tag (usually `npm-smoldot-v<prev>`):
+
+```sh
+git log --oneline <prev-tag>..HEAD
+git diff --stat <prev-tag>..HEAD -- lib/ light-base/ wasm-node/ full-node/
+```
+
+Apply these rules per package:
+
+| Package | Version file | Bump iff… |
+|---|---|---|
+| `smoldot` (rust lib) | `lib/Cargo.toml` | any commit touched `lib/` since last publish |
+| `smoldot-light` (rust) | `light-base/Cargo.toml` | any commit touched `light-base/` since last publish |
+| `smoldot-light-wasm` | `wasm-node/rust/Cargo.toml` | bump whenever the npm package bumps (mirrors npm version; `publish = false` so it is metadata only) |
+| `smoldot` (npm) | `wasm-node/javascript/package.json` | any commit that reaches the Wasm artifact — i.e. changes to `lib/`, `light-base/`, `wasm-node/` |
+
+Why `lib/` or `light-base/` alone forces an npm bump:
+`wasm-node/javascript/prepare.mjs` compiles `smoldot-light-wasm` at pack time.
+That crate path-depends on `smoldot-light` → `smoldot`, so any change in
+`lib/` or `light-base/` ends up in the embedded `.wasm` (base64'd into
+`src/internals/bytecode/*.ts`) even when `wasm-node/` itself is untouched.
+
+Semver level:
+
+- `fix(...)` / bug-fix only → **patch**
+- `feat(...)` or new public API → **minor**
+- Breaking API change → **major**
+
+Version streams are independent; do not force lockstep. `crates-io-publish`
+wraps each publish in `continue-on-error: true`, so a re-publish attempt at
+the same version is tolerated.
+
+---
+
+## 2. Open a release branch
+
+```sh
+git checkout -b npm-smoldot-v<X.Y.Z>
+```
+
+Branch naming mirrors the npm version even when the rust crate versions differ.
+
+---
+
+## 3. Edit the version files
+
+Edit exactly these fields (do not edit anything else in the same commit):
+
+1. `lib/Cargo.toml` — `version = "<A.B.C>"` *(if bumping `smoldot`)*
+2. `light-base/Cargo.toml` — `version = "<A.B.C>"` *(if bumping `smoldot-light`)*
+3. `wasm-node/rust/Cargo.toml` — `version = "<X.Y.Z>"` *(mirror npm)*
+4. `wasm-node/javascript/package.json` — `"version": "<X.Y.Z>"`
+
+**Do not** touch the `version = "..."` requirement on `smoldot` /
+`smoldot-light` in `full-node/Cargo.toml`, `light-base/Cargo.toml`, or
+`wasm-node/rust/Cargo.toml` unless a dependent actually needs a newer minimum.
+Past releases have not updated these in sync.
+
+**CI-enforced invariant:** `wasm-node/javascript/package.json` `.version` and
+`wasm-node/rust/Cargo.toml` `[package].version` must match exactly. The
+`wasm-node-versions-match` job fails the build on any mismatch.
+
+---
+
+## 4. Regenerate lockfiles
+
+```sh
+cargo check -p smoldot -p smoldot-light        # updates Cargo.lock
+cd wasm-node/javascript && npm install --package-lock-only && cd -
+```
+
+Both lockfiles must diff to version bumps only. If either pulls in unrelated
+updates, abort and investigate.
+
+---
+
+## 5. Update `wasm-node/CHANGELOG.md`
+
+Insert a new section **below** the `## Unreleased` heading (leave `Unreleased`
+in place). Use the current date in `YYYY-MM-DD`. Group entries under
+`### Added` / `### Changed` / `### Fixed` / `### Removed`. Each bullet must
+link to its PR.
+
+Template:
+
+```md
+## <X.Y.Z> - <YYYY-MM-DD>
+
+### Fixed
+
+- <user-facing description>. ([#<PR>](https://github.com/paritytech/smoldot/pull/<PR>))
+```
+
+Rules of thumb:
+
+- Describe the observable change, not the code path.
+- Skip internal refactors, test-only changes, CI tweaks, and doc updates.
+
+---
+
+## 6. Verify locally
+
+Required:
+
+```sh
+cargo check -p smoldot -p smoldot-light
+```
+
+Optional dry-runs:
+
+```sh
+cargo publish --dry-run --locked -p smoldot
+```
+
+Run this every release; it only validates packaging and local build.
+
+```sh
+cargo publish --dry-run --locked -p smoldot-light
+```
+
+Run this **only if `smoldot` is not being bumped**. Otherwise it fails on
+`smoldot` path-dep resolution against crates.io — harmless
+
+---
+
+## 7. Commit and push the release branch
+
+```sh
+git add lib/Cargo.toml light-base/Cargo.toml wasm-node/rust/Cargo.toml \
+        wasm-node/javascript/package.json wasm-node/javascript/package-lock.json \
+        wasm-node/CHANGELOG.md Cargo.lock
+git --no-gpg-sign commit -m "npm smoldot v<X.Y.Z>"
+git push origin npm-smoldot-v<X.Y.Z>
+```
+
+Open a PR. Body template:
+
+```md
+This is to:
+- publish `smoldot-v<X.Y.Z>` npm.
+- publish crates `smoldot-light v<A.B.C>`[, `smoldot v<A.B.C>`]
+
+## Changes
+
+[Paste the CHANGELOG entries.]
+```
+
+Past PRs for reference: #3208 (3.1.0), #3166 (3.0.0). Only list crates that
+are actually bumped.
+
+---
+
+## 8. Beg for approval
+
+Ping reviewers. Address review comments. Wait for the required approvals per
+branch protection. This is the slowest step and the least automatable.
+
+---
+
+## 9. Merge to `main`
+
+Squash-merge. Record the resulting commit SHA on `main` — tags will point at it.
+
+---
+
+## 10. Watch the automated deploys
+
+Click through to the run of `deploy.yml` triggered by the merge. Check each of:
+
+- `npm-publish` — dispatch to `paritytech/npm_publish_automation` succeeded.
+  Verify: `npm view smoldot@<X.Y.Z>`.
+- `deno-publish` — `light-js-deno-v<X.Y.Z>` tag pushed. Verify:
+  `git fetch --tags && git tag -l 'light-js-deno-v<X.Y.Z>'`.
+- `crates-io-publish` — each bumped crate published. If `smoldot` was not
+  bumped, its step fails with "version already exists" (expected — the job
+  has `continue-on-error: true`). Verify bumped crates:
+  ```sh
+  curl -s https://crates.io/api/v1/crates/smoldot       | jq .crate.max_version
+  curl -s https://crates.io/api/v1/crates/smoldot-light | jq .crate.max_version
+  ```
+- `docs-publish` — pushed to `gh-pages`.
+
+---
+
+## 11. Create and push the manual tags
+
+On the release commit SHA (the merged squash on `main`):
+
+```sh
+git fetch origin main
+git checkout <release-commit-sha>
+
+git tag npm-smoldot-v<X.Y.Z>                # always
+git tag smoldot-light-v<A.B.C>              # if smoldot-light bumped
+git tag smoldot-v<A.B.C>                    # if smoldot bumped
+
+git push origin \
+    npm-smoldot-v<X.Y.Z> \
+    [smoldot-light-v<A.B.C>] \
+    [smoldot-v<A.B.C>]
+```
+
+Tags are lightweight (no `-a`/`-m`).
+
+---
+
+## 12. Sanity-check post-release
+
+- `npm view smoldot@<X.Y.Z>` resolves; `dist-tags.latest` updated (unless a
+  non-`latest` dist-tag was passed via `workflow_dispatch`).
+- `https://crates.io/crates/smoldot-light/<A.B.C>` loads.
+- `git tag -l '*<X.Y.Z>*'` shows the auto and manual tags.
+
+On failure, do not delete published versions — yank (`npm deprecate`,
+`cargo yank`) and cut a new release.
+
+---
+
+## Appendix A — Manual npm republish (rare)
+
+`deploy.yml` has a `workflow_dispatch` trigger with an `npm_tag` input. Use it
+for non-`latest` publishes (`dev`, `canary`, etc.). The commit's
+`package.json` version must not already exist on npm.
+
+## Appendix B — Files for automation
+
+- Version reads: `wasm-node/javascript/package.json` (`.version`),
+  `lib/Cargo.toml`, `light-base/Cargo.toml`, `wasm-node/rust/Cargo.toml`
+  (each `package.version`).
+- Version writes: same four, plus `wasm-node/javascript/package-lock.json`
+  (two occurrences) and `Cargo.lock` (regenerate via `cargo check`).
+- Changelog: insert new section in `wasm-node/CHANGELOG.md` between
+  `## Unreleased` and the previous version heading.
+- Scope detection: `git diff --stat <prev-tag>..HEAD -- <path>` for
+  `lib/`, `light-base/`, `wasm-node/`.
+- Commit message: `npm smoldot v<X.Y.Z>`.
+- Tags (lightweight): `npm-smoldot-v<X.Y.Z>`, `smoldot-light-v<A.B.C>`,
+  `smoldot-v<A.B.C>`.


### PR DESCRIPTION
## Summary

1. **`docs/RELEASING.md`** — new release runbook: 12 steps + two appendices,
   covering version bumps, branch/PR/merge flow, tag creation, and post-deploy
   sanity checks. 
   **Appendix A documents the manual dev-publish flow** (how to
   trigger the workflow, what version/dist-tag get produced, how to install a
   dev build).

3. **`docs/DEV-PUBLISHING.md`** — short companion guide for the manual
   dev-publish flow (when you want a testable npm build from a feature branch
   without editing any version files by hand).

2. **`.github/workflows/deploy.yml`** — harden the `workflow_dispatch`
   dev-publish path so it can't move the `latest` dist-tag and no longer
   needs a manual `package.json` version commit.

## Dev-publish hardening

Replaces `npm_tag` input with optional `npm_tag_suffix` (charset
`[A-Za-z0-9-]`). On `workflow_dispatch` the workflow now:

- Computes `TAG = dev-<YYYYMMDD>[-<suffix>]` — cannot equal `latest`.
- Computes `VERSION = <next-patch>-<TAG>.<N>` — so the dist-tag string
  appears verbatim inside the version. `N` is `max + 1` from
  `npm view --json smoldot versions`; first dispatch of a new
  `(next-patch, date, suffix)` tuple starts at `.0`. Every subsequent
  dispatch (including "Re-run jobs") bumps `N`.
- Rewrites `wasm-node/javascript/package.json` and `wasm-node/rust/Cargo.toml`
  in-memory before `npm pack`. Never committed.

Examples (dispatched 2026-04-22, current stable = 3.1.1):

| suffix     | VERSION                         | TAG                    |
|------------|---------------------------------|------------------------|
| `smoke`    | `3.1.2-dev-20260422-smoke.0`    | `dev-20260422-smoke`   |
| *(blank)*  | `3.1.2-dev-20260422.0`          | `dev-20260422`         |

Install the first one with:
`npm install smoldot@dev-20260422-smoke` (follows the tag) or
`npm install smoldot@3.1.2-dev-20260422-smoke.0` (pinned).


