### PR TITLE
statement-store: add bloom filter edge case tests for from_topics and truncated bits

### DIFF
--- a/lib/src/network/codec/affinity.rs
+++ b/lib/src/network/codec/affinity.rs
@@ -414,4 +414,32 @@ mod tests {
         filter.insert(&inserted);
         assert!(filter.matches_statement(&[&missing, &inserted]));
     }
+
+    #[test]
+    fn decode_rejects_truncated_bits_body() {
+        // The compact length claims 2 u64 words (16 bytes of bits) but only 8 bytes follow;
+        // `EncodedBloomFilter::decode` guards against this via the `rest.len() != bits_len * 8`
+        // check. polkadot-sdk delegates to `codec::Decode` which handles incomplete input
+        // automatically; smoldot parses peer bytes by hand and needs explicit coverage.
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&TEST_SEED.to_le_bytes());
+        bytes.extend_from_slice(&1u32.to_le_bytes());
+        bytes.extend_from_slice(crate::util::encode_scale_compact_usize(2).as_ref());
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+        assert!(AffinityFilter::decode(&bytes).is_err());
+    }
+
+    #[test]
+    fn from_topics_empty_is_not_match_all() {
+        // `from_topics` is smoldot-only (no polkadot-sdk equivalent) and the empty-iterator path
+        // must not silently behave like the explicit `match_all` broadcast filter.
+        let filter = AffinityFilter::from_topics(
+            core::iter::empty::<&[u8; 32]>(),
+            TEST_SEED,
+            BLOOM_FALSE_POS_RATE,
+        );
+        assert!(!filter.matches_statement(&[&[0x01; 32]]));
+        // Broadcast statements (no topics) always match.
+        assert!(filter.matches_statement(&[]));
+    }
 }


### PR DESCRIPTION
Part of https://github.com/paritytech/smoldot/issues/3142

Adds two targeted bloom filter tests in `lib/src/network/codec/affinity.rs` that have no polkadot-sdk equivalent but cover smoldot-specific concerns:

* **`decode_rejects_truncated_bits_body`** — the wire format encodes the bit array as `compact(len) + len * 8 bytes`. smoldot parses peer bytes by hand and guards against truncation via an explicit `rest.len() != bits_len * 8` check. polkadot-sdk uses derived `codec::Decode` which handles incomplete input automatically, so they don't test this path; smoldot does need the regression guard.
* **`from_topics_empty_is_not_match_all`** — `AffinityFilter::from_topics` is a smoldot-only helper. This documents the invariant that an empty topic iterator produces an *empty* filter, not the `match_all` broadcast filter.

Smoldot's existing `affinity.rs` tests already cover every polkadot-sdk test in `substrate/client/network/statement/src/affinity.rs` (11/11), so no further alignment is needed.

## Test plan
- [x] `cargo test -p smoldot --lib network::codec`