### PR TITLE
deploy: make manual npm publish workflow work

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -234,10 +234,12 @@ jobs:
           # Version's first prerelease identifier is the tag; "." + numeric N
           # is a second identifier so that N sorts numerically.
           PREFIX="${NEXT}-${TAG}"
+          # `grep || true`: on the first dev release of the day no version matches
+          # the prefix; grep exits 1 which under `set -e -o pipefail` would kill the step.
           MAX_N=$(
             npm view --json smoldot versions 2>/dev/null \
               | jq -r '.[]' \
-              | grep -E "^${PREFIX}\.[0-9]+$" \
+              | { grep -E "^${PREFIX}\.[0-9]+$" || true; } \
               | sed -E "s|^${PREFIX}\.||" \
               | sort -n | tail -1
           )

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,7 @@ jobs:
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
   build-js-doc:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     container:
       image: rust:1.92
@@ -91,6 +92,7 @@ jobs:
           path: ./doc/
 
   build-rust-doc:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     container:
       image: rust:1.92
@@ -112,6 +114,7 @@ jobs:
           path: ./doc/
 
   build-tests-coverage:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     container:
       image: rust:1.92
@@ -139,6 +142,7 @@ jobs:
           path: ./html-out/
 
   docs-publish:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: [build-js-doc, build-rust-doc, build-tests-coverage]
     permissions:
@@ -272,6 +276,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.NPM_PUBLISH_AUTOMATION_TOKEN }}
 
   deno-publish:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write   # Necessary in order to push tags.
@@ -318,6 +323,7 @@ jobs:
         if: ${{ steps.check-tag-exists.outputs.num-existing == 0 && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
   crates-io-publish:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     container:
       image: rust:1.92

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ on:
   workflow_dispatch:
     inputs:
       npm_tag_suffix:
-        description: 'Optional suffix for the dev dist-tag. Non-empty → tag "dev-<YYYYMMDD>-<suffix>", version "<next-patch>-dev-<YYYYMMDD>-<suffix>.<N>". Empty → tag "dev-<YYYYMMDD>", version "<next-patch>-dev-<YYYYMMDD>.<N>". Version always bumps patch (never minor/major). Cannot produce "latest". Allowed suffix chars: [A-Za-z0-9-].'
+        description: 'Optional dev dist-tag suffix. Empty → "dev-<YYYYMMDD>"; else "dev-<YYYYMMDD>-<suffix>". Charset: [A-Za-z0-9-].'
         type: string
         required: false
         default: ''


### PR DESCRIPTION
- Fix silent failure of `Compute dev version and dist-tag` on the first dev release of the day
- Skip non-npm jobs on `workflow_dispatch` to give CI a breath
- Shorten `npm_tag_suffix` description