### PR TITLE
npm smoldot v3.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light-wasm"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "async-lock",
  "async-task",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -7283,7 +7283,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -7354,10 +7354,14 @@ dependencies = [
  "anyhow",
  "ed25519-dalek",
  "env_logger",
+ "flate2",
  "hex",
  "log",
+ "serde",
  "serde_json",
- "smoldot 1.1.0",
+ "sha2 0.10.9",
+ "smoldot 1.1.1",
+ "tar",
  "tempfile",
  "tokio",
  "zombienet-sdk",

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -106,13 +106,23 @@ needs to track the current compatibility range, not the exact version.
 
 ## 4. Regenerate lockfiles
 
+The repo has **three** Cargo workspaces, each with its own `Cargo.lock`. CI
+runs `cargo test --locked` against `e2e-tests/` and `benchmarks/`, so any
+crate version bump in `lib/` or `light-base/` invalidates their lockfiles via
+the `path` deps. Bumping only the root `Cargo.lock` will fail CI on the
+zombienet jobs with `error: cannot update the lock file ... because --locked
+was passed`.
+
 ```sh
-cargo check -p smoldot -p smoldot-light        # updates Cargo.lock
-cd wasm-node/javascript && npm install --package-lock-only && cd -
+cargo check -p smoldot -p smoldot-light        # updates root Cargo.lock
+(cd e2e-tests && cargo check)                  # updates e2e-tests/Cargo.lock
+(cd benchmarks && cargo check)                 # updates benchmarks/Cargo.lock
+(cd wasm-node/javascript && npm install --package-lock-only)
 ```
 
-Both lockfiles must diff to version bumps only. If either pulls in unrelated
-updates, abort and investigate.
+Each lockfile must diff to version bumps only. If any pulls in unrelated
+updates, that lockfile was already stale on `main`; investigate before
+committing — the drift may belong in a separate PR.
 
 ---
 
@@ -170,7 +180,7 @@ Run this **only if `smoldot` is not being bumped**. Otherwise it fails on
 ```sh
 git add lib/Cargo.toml light-base/Cargo.toml wasm-node/rust/Cargo.toml \
         wasm-node/javascript/package.json wasm-node/javascript/package-lock.json \
-        wasm-node/CHANGELOG.md Cargo.lock
+        wasm-node/CHANGELOG.md Cargo.lock e2e-tests/Cargo.lock benchmarks/Cargo.lock
 git --no-gpg-sign commit -m "npm smoldot v<X.Y.Z>"
 git push origin release/npm-smoldot-v<X.Y.Z>
 ```
@@ -308,7 +318,8 @@ Even `suffix=""` produces `dev-<YYYYMMDD>`, not `latest`.
   `lib/Cargo.toml`, `light-base/Cargo.toml`, `wasm-node/rust/Cargo.toml`
   (each `package.version`).
 - Version writes: same four, plus `wasm-node/javascript/package-lock.json`
-  (two occurrences) and `Cargo.lock` (regenerate via `cargo check`).
+  (two occurrences) and three Cargo lockfiles (regenerate via `cargo check`):
+  root `Cargo.lock`, `e2e-tests/Cargo.lock`, `benchmarks/Cargo.lock`.
 - Changelog: insert new section in `wasm-node/CHANGELOG.md` between
   `## Unreleased` and the previous version heading.
 - Scope detection: `git diff --stat <prev-tag>..HEAD -- <path>` for

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -7243,7 +7243,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -7305,7 +7305,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smoldot 1.1.0",
+ "smoldot 1.1.1",
  "tar",
  "tempfile",
  "tokio",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot"
-version = "1.1.0"
+version = "1.1.1"
 description = "Primitives to build a client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot"
 keywords = ["blockchain", "peer-to-peer"]

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light"
-version = "1.1.1"
+version = "1.1.2"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot-light"
 authors.workspace = true

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## 3.1.2 - 2026-05-07
+
+### Added
+
+- Log when the statement protocol substream opens, to make peer connectivity easier to diagnose. ([#3154](https://github.com/paritytech/smoldot/pull/3154))
+
+### Fixed
+
+- Strip the trailing `/p2p/<peer_id>` from discovered addresses so peers advertised in this form are no longer rejected as unsupported, restoring peer discovery beyond the configured bootnodes. ([#3245](https://github.com/paritytech/smoldot/pull/3245))
+- Stop continuously re-trying statement-store submissions after a peer rejects them. ([#3230](https://github.com/paritytech/smoldot/pull/3230))
+- Avoid panicking on shutdown when background tasks observe the client being torn down. ([#3243](https://github.com/paritytech/smoldot/pull/3243))
+
 ## 3.1.1 - 2026-04-22
 
 ### Fixed

--- a/wasm-node/javascript/package-lock.json
+++ b/wasm-node/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smoldot",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smoldot",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/wasm-node/javascript/package.json
+++ b/wasm-node/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoldot",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Light client that connects to Polkadot and Substrate-based blockchains",
   "contributors": [
     "Parity Technologies <admin@parity.io>",

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light-wasm"
-version = "3.1.1"
+version = "3.1.2"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
This is to:
- publish `smoldot-v3.1.2` npm.
- publish crates `smoldot-light v1.1.2`, `smoldot v1.1.1`

## Changes

### Added

- Log when the statement protocol substream opens, to make peer connectivity easier to diagnose. ([#3154](https://github.com/paritytech/smoldot/pull/3154))

### Fixed

- Strip the trailing `/p2p/<peer_id>` from discovered addresses so peers advertised in this form are no longer rejected as unsupported, restoring peer discovery beyond the configured bootnodes. ([#3245](https://github.com/paritytech/smoldot/pull/3245))
- Stop continuously re-trying statement-store submissions after a peer rejects them. ([#3230](https://github.com/paritytech/smoldot/pull/3230))
- Avoid panicking on shutdown when background tasks observe the client being torn down. ([#3243](https://github.com/paritytech/smoldot/pull/3243))