### PR TITLE
e2e-tests: Stage relay snapshot per-validator (fix bulletin_fetch flake)

### DIFF
--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -164,6 +164,79 @@ pub async fn run_browser_test(
     }
 }
 
+/// Pre-fetch a snapshot from `source` to a stable local path and return
+/// that path. Pass-through if `source` already points at a local file.
+///
+/// Workaround for a class of CI flakes caused by zombienet-provider
+/// 0.4.11's [`initialize_db_snapshot`]: it calls `reqwest::get(...)
+/// .bytes().await.unwrap()` without checking the HTTP status or
+/// `Content-Length`, so a 5xx-with-HTML-body or a mid-stream connection
+/// close becomes a panic on tar extraction. `curl -fL --retry` handles
+/// both cases (`-f` rejects non-2xx, retry covers transient drops),
+/// `tar -tzf` validates the archive integrity, and we hand zombienet a
+/// local file path that's already known-good.
+///
+/// Cached under `e2e-tests/target/snapshot-cache/<basename>` so repeated
+/// runs reuse the file. Only validated files reach the cache: a failed
+/// download or a corrupt archive is never renamed in.
+pub fn prefetch_snapshot(source: &str) -> Result<PathBuf, anyhow::Error> {
+    if !source.starts_with("http://") && !source.starts_with("https://") {
+        return Ok(PathBuf::from(source));
+    }
+    let cache_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("snapshot-cache");
+    std::fs::create_dir_all(&cache_dir)?;
+    let filename = source
+        .rsplit('/')
+        .next()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("no filename in URL: {source}"))?;
+    let path = cache_dir.join(filename);
+    if path.exists() {
+        return Ok(path);
+    }
+    let tmp = cache_dir.join(format!("{filename}.partial"));
+    let _ = std::fs::remove_file(&tmp);
+
+    let status = std::process::Command::new("curl")
+        .args([
+            "-fL",
+            "--retry",
+            "5",
+            "--retry-delay",
+            "2",
+            "--retry-max-time",
+            "120",
+            "--max-time",
+            "300",
+            "-o",
+        ])
+        .arg(&tmp)
+        .arg(source)
+        .status()
+        .map_err(|e| anyhow::anyhow!("failed to spawn curl: {e}"))?;
+    if !status.success() {
+        let _ = std::fs::remove_file(&tmp);
+        anyhow::bail!("curl failed for {source}: {status}");
+    }
+
+    let test_status = std::process::Command::new("tar")
+        .arg("-tzf")
+        .arg(&tmp)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map_err(|e| anyhow::anyhow!("failed to spawn tar: {e}"))?;
+    if !test_status.success() {
+        let _ = std::fs::remove_file(&tmp);
+        anyhow::bail!("tar -tzf failed for {source}: archive is not a valid gzipped tar");
+    }
+
+    std::fs::rename(&tmp, &path)?;
+    Ok(path)
+}
+
 /// Runs a JS test script with the given environment variables.
 ///
 /// Uses `tokio::process::Command` for async compatibility.

--- a/e2e-tests/tests/bulletin_fetch.rs
+++ b/e2e-tests/tests/bulletin_fetch.rs
@@ -63,9 +63,27 @@ async fn bulletin_fetch() -> Result<()> {
         DB_SNAPSHOT_BULLETIN_PARTIAL,
         "DB_SNAPSHOT_BULLETIN_PARTIAL_OVERRIDE",
     ))?;
-    let relay = relay
+
+    // Per-validator copies of the relay snapshot. zombienet-provider
+    // 0.4.11 keys its `with_db_snapshot` cache by `sha256(path)`, so two
+    // sibling nodes sharing one path race writing/reading the same
+    // intermediate `<hash>.tgz` in the namespace dir, producing
+    // `UnexpectedEof` mid-extract. Distinct paths land in distinct cache
+    // slots. (Same workaround the smoke tests use — see
+    // `stage_per_node_snapshots` in `e2e-tests/src/network.rs`.)
+    let stage_dir = base_dir.join("staged-snapshots");
+    std::fs::create_dir_all(&stage_dir)?;
+    let relay_alice = stage_dir.join("relay-alice.tgz");
+    let relay_bob = stage_dir.join("relay-bob.tgz");
+    std::fs::copy(&relay, &relay_alice)?;
+    std::fs::copy(&relay, &relay_bob)?;
+
+    let relay_alice = relay_alice
         .to_str()
-        .ok_or_else(|| anyhow!("non-utf8 prefetched relay path"))?;
+        .ok_or_else(|| anyhow!("non-utf8 staged relay-alice path"))?;
+    let relay_bob = relay_bob
+        .to_str()
+        .ok_or_else(|| anyhow!("non-utf8 staged relay-bob path"))?;
     let bulletin_full = bulletin_full
         .to_str()
         .ok_or_else(|| anyhow!("non-utf8 prefetched bulletin-full path"))?;
@@ -76,7 +94,8 @@ async fn bulletin_fetch() -> Result<()> {
     let network = spawn_with_snapshots(
         &base_dir,
         &chain_spec,
-        relay,
+        relay_alice,
+        relay_bob,
         bulletin_full,
         bulletin_partial,
     )
@@ -133,7 +152,8 @@ fn bulletin_chain_spec() -> PathBuf {
 async fn spawn_with_snapshots(
     base_dir: &Path,
     chain_spec: &Path,
-    relay_snap: &str,
+    relay_alice_snap: &str,
+    relay_bob_snap: &str,
     bulletin_full_snap: &str,
     bulletin_partial_snap: &str,
 ) -> Result<Network<LocalFileSystem>> {
@@ -145,7 +165,8 @@ async fn spawn_with_snapshots(
         .to_str()
         .ok_or_else(|| anyhow!("non-utf8 base dir"))?
         .to_string();
-    let relay = relay_snap.to_string();
+    let relay_alice = relay_alice_snap.to_string();
+    let relay_bob = relay_bob_snap.to_string();
     let bulletin_full = bulletin_full_snap.to_string();
     let bulletin_partial = bulletin_partial_snap.to_string();
 
@@ -156,12 +177,12 @@ async fn spawn_with_snapshots(
                 .with_validator(|n| {
                     n.with_name("alice")
                         .bootnode(true)
-                        .with_db_snapshot(relay.as_str())
+                        .with_db_snapshot(relay_alice.as_str())
                 })
                 .with_validator(|n| {
                     n.with_name("bob")
                         .bootnode(true)
-                        .with_db_snapshot(relay.as_str())
+                        .with_db_snapshot(relay_bob.as_str())
                 })
         })
         .with_parachain(|p| {

--- a/e2e-tests/tests/bulletin_fetch.rs
+++ b/e2e-tests/tests/bulletin_fetch.rs
@@ -20,7 +20,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, Result};
 use serde::Serialize;
 use smoldot_e2e_tests::{
-    bulletin, ensure_js_deps_installed, ensure_smoldot_built, resolve_base_dir, run_js_test,
+    bulletin, ensure_js_deps_installed, ensure_smoldot_built, prefetch_snapshot,
+    resolve_base_dir, run_js_test,
 };
 use zombienet_sdk::{LocalFileSystem, Network, NetworkConfigBuilder};
 
@@ -50,22 +51,34 @@ async fn bulletin_fetch() -> Result<()> {
     let chain_spec = bulletin_chain_spec();
     let base_dir = resolve_base_dir()?;
 
-    let relay = get_snapshot_url(DB_SNAPSHOT_RELAY, "DB_SNAPSHOT_RELAY_OVERRIDE");
-    let bulletin_full = get_snapshot_url(
+    let relay = prefetch_snapshot(&get_snapshot_url(
+        DB_SNAPSHOT_RELAY,
+        "DB_SNAPSHOT_RELAY_OVERRIDE",
+    ))?;
+    let bulletin_full = prefetch_snapshot(&get_snapshot_url(
         DB_SNAPSHOT_BULLETIN_FULL,
         "DB_SNAPSHOT_BULLETIN_FULL_OVERRIDE",
-    );
-    let bulletin_partial = get_snapshot_url(
+    ))?;
+    let bulletin_partial = prefetch_snapshot(&get_snapshot_url(
         DB_SNAPSHOT_BULLETIN_PARTIAL,
         "DB_SNAPSHOT_BULLETIN_PARTIAL_OVERRIDE",
-    );
+    ))?;
+    let relay = relay
+        .to_str()
+        .ok_or_else(|| anyhow!("non-utf8 prefetched relay path"))?;
+    let bulletin_full = bulletin_full
+        .to_str()
+        .ok_or_else(|| anyhow!("non-utf8 prefetched bulletin-full path"))?;
+    let bulletin_partial = bulletin_partial
+        .to_str()
+        .ok_or_else(|| anyhow!("non-utf8 prefetched bulletin-partial path"))?;
 
     let network = spawn_with_snapshots(
         &base_dir,
         &chain_spec,
-        &relay,
-        &bulletin_full,
-        &bulletin_partial,
+        relay,
+        bulletin_full,
+        bulletin_partial,
     )
     .await?;
 


### PR DESCRIPTION
## Summary

`bulletin_fetch` flakes with `archive.unpack().unwrap()` panicking on `UnexpectedEof` mid-extract inside zombienet-provider. Empirically reproduced 3/5 reruns on a single commit — and *not* on a fresh download path: cache hit, zombienet copying our pre-validated tarball, still failed.

The cause: alice and bob both pass the **same** relay snapshot path to `with_db_snapshot(...)`. zombienet-provider 0.4.11 keys its internal cache by `sha256(path_string)` — so the two validators race writing/reading the same intermediate `<hash>.tgz` in the namespace dir. One sees a partially-written file, panics.

The smoke tests already documented this race and worked around it the same way (`stage_per_node_snapshots` in [`e2e-tests/src/network.rs:171`](e2e-tests/src/network.rs#L171)). This PR applies the same workaround to `bulletin_fetch`: copy the relay tarball to two distinct paths (`relay-alice.tgz`, `relay-bob.tgz`) so each validator gets its own cache slot. Bulletin collators were already fine — they use *different* tarballs (`bulletin-full` vs `bulletin-partial`), so distinct paths already.

The previous commit (prefetch via curl) stays as a defensive download hardening but isn't load-bearing for this fix.

## Test plan

- [x] `cargo check` clean
- [ ] CI: 5 consecutive `bulletin_fetch` runs all pass