### PR TITLE
e2e-tests: Fix bulletin_fetch flake by staging the relay snapshot per-validator

### DIFF
--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -164,6 +164,59 @@ pub async fn run_browser_test(
     }
 }
 
+/// Download a snapshot to a stable local cache and return its path. If
+/// `override_var` is set, its value is used as the source instead of
+/// `default_url`; if the source is already a local path, it's returned
+/// as-is. URLs are fetched with `curl -fL --retry`. Cached under
+/// `e2e-tests/target/snapshot-cache/<basename>`.
+pub fn prefetch_snapshot(default_url: &str, override_var: &str) -> Result<String, anyhow::Error> {
+    let source = std::env::var(override_var).unwrap_or_else(|_| default_url.to_string());
+    if !source.starts_with("http://") && !source.starts_with("https://") {
+        return Ok(source);
+    }
+    let cache_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("snapshot-cache");
+    std::fs::create_dir_all(&cache_dir)?;
+    let filename = source
+        .rsplit('/')
+        .next()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("no filename in URL: {source}"))?;
+    let path = cache_dir.join(filename);
+    if !path.exists() {
+        let tmp = cache_dir.join(format!("{filename}.partial"));
+        let _ = std::fs::remove_file(&tmp);
+        let status = std::process::Command::new("curl")
+            .args([
+                "-fL", "--retry", "5", "--retry-delay", "2",
+                "--retry-max-time", "120", "--max-time", "300", "-o",
+            ])
+            .arg(&tmp)
+            .arg(&source)
+            .status()?;
+        if !status.success() {
+            let _ = std::fs::remove_file(&tmp);
+            anyhow::bail!("curl failed for {source}: {status}");
+        }
+        std::fs::rename(&tmp, &path)?;
+    }
+    Ok(path.to_string_lossy().into_owned())
+}
+
+/// Copy `src` to `<base_dir>/staged-snapshots/<name>.tgz` and return the
+/// destination path. Workaround for zombienet-provider 0.4.11's
+/// `with_db_snapshot`: it keys its extraction cache by `sha256(path)`,
+/// so sibling nodes sharing one source path race on the same
+/// intermediate file. Distinct staged paths land in distinct cache slots.
+pub fn stage_snapshot(src: &str, base_dir: &Path, name: &str) -> Result<String, anyhow::Error> {
+    let dst_dir = base_dir.join("staged-snapshots");
+    std::fs::create_dir_all(&dst_dir)?;
+    let dst = dst_dir.join(format!("{name}.tgz"));
+    std::fs::copy(src, &dst)?;
+    Ok(dst.to_string_lossy().into_owned())
+}
+
 /// Runs a JS test script with the given environment variables.
 ///
 /// Uses `tokio::process::Command` for async compatibility.

--- a/e2e-tests/tests/bulletin_fetch.rs
+++ b/e2e-tests/tests/bulletin_fetch.rs
@@ -20,7 +20,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, Result};
 use serde::Serialize;
 use smoldot_e2e_tests::{
-    bulletin, ensure_js_deps_installed, ensure_smoldot_built, resolve_base_dir, run_js_test,
+    bulletin, ensure_js_deps_installed, ensure_smoldot_built, prefetch_snapshot,
+    resolve_base_dir, run_js_test, stage_snapshot,
 };
 use zombienet_sdk::{LocalFileSystem, Network, NetworkConfigBuilder};
 
@@ -50,20 +51,21 @@ async fn bulletin_fetch() -> Result<()> {
     let chain_spec = bulletin_chain_spec();
     let base_dir = resolve_base_dir()?;
 
-    let relay = get_snapshot_url(DB_SNAPSHOT_RELAY, "DB_SNAPSHOT_RELAY_OVERRIDE");
-    let bulletin_full = get_snapshot_url(
-        DB_SNAPSHOT_BULLETIN_FULL,
-        "DB_SNAPSHOT_BULLETIN_FULL_OVERRIDE",
-    );
-    let bulletin_partial = get_snapshot_url(
+    let relay = prefetch_snapshot(DB_SNAPSHOT_RELAY, "DB_SNAPSHOT_RELAY_OVERRIDE")?;
+    let bulletin_full =
+        prefetch_snapshot(DB_SNAPSHOT_BULLETIN_FULL, "DB_SNAPSHOT_BULLETIN_FULL_OVERRIDE")?;
+    let bulletin_partial = prefetch_snapshot(
         DB_SNAPSHOT_BULLETIN_PARTIAL,
         "DB_SNAPSHOT_BULLETIN_PARTIAL_OVERRIDE",
-    );
+    )?;
+    let relay_alice = stage_snapshot(&relay, &base_dir, "relay-alice")?;
+    let relay_bob = stage_snapshot(&relay, &base_dir, "relay-bob")?;
 
     let network = spawn_with_snapshots(
         &base_dir,
         &chain_spec,
-        &relay,
+        &relay_alice,
+        &relay_bob,
         &bulletin_full,
         &bulletin_partial,
     )
@@ -107,12 +109,6 @@ async fn bulletin_fetch() -> Result<()> {
     .map_err(|e| anyhow!("JS test failed: {e}"))
 }
 
-/// Returns the GCS URL by default, or the contents of `env_var` if set
-/// (so a developer can point at a local `.tgz` for iteration).
-fn get_snapshot_url(default: &str, env_var: &str) -> String {
-    std::env::var(env_var).unwrap_or_else(|_| default.to_string())
-}
-
 fn bulletin_chain_spec() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("chain-specs/bulletin-westend-local-spec.json")
 }
@@ -120,7 +116,8 @@ fn bulletin_chain_spec() -> PathBuf {
 async fn spawn_with_snapshots(
     base_dir: &Path,
     chain_spec: &Path,
-    relay_snap: &str,
+    relay_alice_snap: &str,
+    relay_bob_snap: &str,
     bulletin_full_snap: &str,
     bulletin_partial_snap: &str,
 ) -> Result<Network<LocalFileSystem>> {
@@ -132,7 +129,8 @@ async fn spawn_with_snapshots(
         .to_str()
         .ok_or_else(|| anyhow!("non-utf8 base dir"))?
         .to_string();
-    let relay = relay_snap.to_string();
+    let relay_alice = relay_alice_snap.to_string();
+    let relay_bob = relay_bob_snap.to_string();
     let bulletin_full = bulletin_full_snap.to_string();
     let bulletin_partial = bulletin_partial_snap.to_string();
 
@@ -143,12 +141,12 @@ async fn spawn_with_snapshots(
                 .with_validator(|n| {
                     n.with_name("alice")
                         .bootnode(true)
-                        .with_db_snapshot(relay.as_str())
+                        .with_db_snapshot(relay_alice.as_str())
                 })
                 .with_validator(|n| {
                     n.with_name("bob")
                         .bootnode(true)
-                        .with_db_snapshot(relay.as_str())
+                        .with_db_snapshot(relay_bob.as_str())
                 })
         })
         .with_parachain(|p| {


### PR DESCRIPTION
## Problem

`bulletin_fetch` flakes intermittently with a panic in `zombienet-provider`'s `archive.unpack().unwrap()`:

```
called `Result::unwrap()` on an `Err` value: Custom { kind: UnexpectedEof,
  error: TarError { desc: "failed to unpack `data/chains/.../db/full/000008.log`", ... } }
```

Reproduced 3/5 in a rerun loop on a single commit. Failure path was inside zombienet's local copy/read/extract pipeline.

## Cause

`alice` and `bob` both passed the **same** relay tarball path to `with_db_snapshot(...)`. `zombienet-provider` keys its internal extraction cache by `sha256(path_string)`, so the two validators landed in the same cache slot and raced writing/reading the same intermediate `<hash>.tgz` in the namespace dir. When the read won the race against an in-progress write, tar parsing hit `UnexpectedEof` mid-entry.