### PR TITLE
npm smoldot v3.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light-wasm"
-version = "3.1.2"
+version = "3.1.3"
 dependencies = [
  "async-lock",
  "async-task",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -7283,7 +7283,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -7360,7 +7360,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smoldot 1.1.1",
+ "smoldot 1.1.2",
  "tar",
  "tempfile",
  "tokio",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -7243,7 +7243,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -7305,7 +7305,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smoldot 1.1.1",
+ "smoldot 1.1.2",
  "tar",
  "tempfile",
  "tokio",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot"
-version = "1.1.1"
+version = "1.1.2"
 description = "Primitives to build a client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot"
 keywords = ["blockchain", "peer-to-peer"]

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light"
-version = "1.1.2"
+version = "1.1.3"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot-light"
 authors.workspace = true

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## 3.1.3 - 2026-05-13
+
+### Changed
+
+- Prefer the `wasm32v1-none` Rust target when building the embedded Wasm if it is installed, falling back to `wasm32-unknown-unknown`. ([#3250](https://github.com/paritytech/smoldot/pull/3250))
+
+### Fixed
+
+- Deliver the warp-synced parachain block to `chainHead_v1_follow` subscribers immediately after relay-chain warp sync, removing the ~6–12s wait for the next relay-chain finalization. ([#3246](https://github.com/paritytech/smoldot/pull/3246))
+
 ## 3.1.2 - 2026-05-07
 
 ### Added

--- a/wasm-node/javascript/package-lock.json
+++ b/wasm-node/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smoldot",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smoldot",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/wasm-node/javascript/package.json
+++ b/wasm-node/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoldot",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Light client that connects to Polkadot and Substrate-based blockchains",
   "contributors": [
     "Parity Technologies <admin@parity.io>",

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light-wasm"
-version = "3.1.2"
+version = "3.1.3"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
This is to:
- publish `smoldot-v3.1.3` npm.
- publish crates `smoldot-light v1.1.3`, `smoldot v1.1.2`

## Changes

### Changed

- Prefer the `wasm32v1-none` Rust target when building the embedded Wasm if it is installed, falling back to `wasm32-unknown-unknown`. ([#3250](https://github.com/paritytech/smoldot/pull/3250))

### Fixed

- Deliver the warp-synced parachain block to `chainHead_v1_follow` subscribers immediately after relay-chain warp sync, removing the ~6–12s wait for the next relay-chain finalization. ([#3246](https://github.com/paritytech/smoldot/pull/3246))