### PR TITLE
Release process: auto-tag + /smoldot-release command

### DIFF
--- a/.claude/commands/smoldot-release.md
+++ b/.claude/commands/smoldot-release.md
@@ -13,7 +13,7 @@ memory of past releases.
 - Read `docs/RELEASING.md` first. If it has changed since you last saw
   it, the changes win.
 - Walk the user through steps 1–11 in order. Pause for explicit
-  confirmation before any shared-state action (commit, push, tag push).
+  confirmation before any shared-state action (commit, push).
 - Step 1: use `git log --oneline <prev-tag>..HEAD` and
   `git diff --stat <prev-tag>..HEAD -- lib/ light-base/ wasm-node/ full-node/`
   to detect which packages need bumping. Propose the bump levels via
@@ -36,14 +36,13 @@ memory of past releases.
   shell. smoldot's branch protection on `main` rejects unsigned commits
   and this session cannot sign, so the commit itself must come from the
   user.
-- Pushing and tag pushing: the user runs these in their own shell (SSH
-  keys live there, not in this session). Print the exact commands and
-  wait for them to confirm.
+- Pushing the release branch: the user runs `git push` in their own shell
+  (SSH keys live there, not in this session). Print the exact command
+  and wait for them to confirm.
 - Step 10: before sanity-checking, verify the `deploy.yml` run for the
   merge SHA completed via `gh run list --workflow=deploy.yml --branch=main`.
-- Step 11: tags are lightweight (`git tag <name> <sha>`, no `-a`/`-m`).
-  Create only the tags whose version actually changed; `npm-smoldot-v…`
-  is always created, the CI-pushed `light-js-deno-v…` is not.
+- Step 11: tags are pushed automatically by the `tags-publish` and
+  `deno-publish` jobs. Verify only — don't push any tags manually.
 
 ## Announcement
 

--- a/.claude/commands/smoldot-release.md
+++ b/.claude/commands/smoldot-release.md
@@ -1,0 +1,67 @@
+---
+description: Cut a smoldot release per docs/RELEASING.md
+argument-hint: [next-npm-version]
+---
+
+Drive a release of the smoldot npm package and Rust crates by following
+@docs/RELEASING.md verbatim. That file is the source of truth — read it
+fully before doing anything, and prefer its instructions over your
+memory of past releases.
+
+## Operating rules
+
+- Read `docs/RELEASING.md` first. If it has changed since you last saw
+  it, the changes win.
+- Walk the user through steps 1–11 in order. Pause for explicit
+  confirmation before any shared-state action (commit, push, tag push).
+- Step 1: use `git log --oneline <prev-tag>..HEAD` and
+  `git diff --stat <prev-tag>..HEAD -- lib/ light-base/ wasm-node/ full-node/`
+  to detect which packages need bumping. Propose the bump levels via
+  `AskUserQuestion` and wait for confirmation.
+- Step 4: regenerate all three Cargo lockfiles (root + `e2e-tests/` +
+  `benchmarks/`) plus `wasm-node/javascript/package-lock.json`. Diff
+  each lockfile and confirm the only changes are the version bumps —
+  unrelated drift means a lockfile was already stale on `main`; stop
+  and surface it.
+- Step 5: insert the new section *below* `## Unreleased`. Skip
+  test-only / CI / docs / internal-refactor commits from the changelog.
+  Read the actual PR diffs before classifying entries; PR titles can
+  mislead (e.g. `wasm32v1-unknown` in title vs `wasm32v1-none` in code).
+- Step 6: run `cargo publish --dry-run --locked --allow-dirty -p smoldot`.
+  Skip the `smoldot-light` dry-run when `smoldot` is also being bumped
+  (it fails on path-dep resolution against crates.io).
+- Step 7 (commit): stage the nine files listed in the doc yourself, then
+  show the staged diff stat and the exact commit message
+  (`npm smoldot v<X.Y.Z>`) and let the user run `git commit` in their own
+  shell. smoldot's branch protection on `main` rejects unsigned commits
+  and this session cannot sign, so the commit itself must come from the
+  user.
+- Pushing and tag pushing: the user runs these in their own shell (SSH
+  keys live there, not in this session). Print the exact commands and
+  wait for them to confirm.
+- Step 10: before sanity-checking, verify the `deploy.yml` run for the
+  merge SHA completed via `gh run list --workflow=deploy.yml --branch=main`.
+- Step 11: tags are lightweight (`git tag <name> <sha>`, no `-a`/`-m`).
+  Create only the tags whose version actually changed; `npm-smoldot-v…`
+  is always created, the CI-pushed `light-js-deno-v…` is not.
+
+## Announcement
+
+After step 11 succeeds, draft an announcement in this exact shape:
+
+```
+smoldot-v<X.Y.Z> is out - https://www.npmjs.com/package/smoldot/v/<X.Y.Z>
+
+[Changelog](https://github.com/paritytech/smoldot/blob/<merge-sha>/wasm-node/CHANGELOG.md#<anchor>)
+```
+
+The anchor is the changelog heading lowercased, with dots stripped and
+` - ` (space-dash-space) becoming `---`. Example:
+`## 3.1.3 - 2026-05-13` → `#313---2026-05-13`.
+
+## Arguments
+
+Optional target npm version (e.g. `3.1.3`): $ARGUMENTS — if provided,
+use it as the new npm version after sanity-checking that it's a
+reasonable bump from the current `wasm-node/javascript/package.json`
+`.version`; otherwise compute the bump from scope detection.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -349,58 +349,107 @@ jobs:
         continue-on-error: true
 
   tags-publish:
-    # Creates the three release-marker tags (`npm-smoldot-v…`, `smoldot-v…`,
-    # `smoldot-light-v…`) on the merge commit. Per-tag existence check makes
-    # the job idempotent: pushes to main that don't bump a given version are
-    # a no-op for that tag because its name already points at a prior commit.
+    # Pushes `npm-smoldot-v…`, `smoldot-v…`, `smoldot-light-v…` — each only
+    # after the version is found on its registry. Guards against publish
+    # steps' `continue-on-error: true` letting a tag through on failure.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [npm-publish, deno-publish, crates-io-publish]
-    # Serialize concurrent runs so two back-to-back pushes can't race on
-    # `git push` of the same new tag.
+    # Serialize runs to avoid `git push` races on the same new tag.
     concurrency:
       group: tags-publish
       cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # Necessary in order to push tags.
+      contents: write   # to push tags
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0   # Necessary below for checking if tags exist.
       - id: tags
         name: Compute and validate tag names
         run: |
           set -euo pipefail
-          # First `version = "..."` line per Cargo.toml = [package].version.
-          # Yields empty on `version.workspace = true`; caught by the semver
-          # check below before any tag is pushed.
           NPM_VER=$(jq -r .version ./wasm-node/javascript/package.json)
-          SMOLDOT_VER=$(sed -nE '0,/^version = "(.+)"$/s//\1/p' ./lib/Cargo.toml)
-          LIGHT_VER=$(sed -nE '0,/^version = "(.+)"$/s//\1/p' ./light-base/Cargo.toml)
+          SMOLDOT_VER=$(cargo read-manifest --manifest-path=./lib/Cargo.toml        | jq -r .version)
+          LIGHT_VER=$(cargo  read-manifest --manifest-path=./light-base/Cargo.toml  | jq -r .version)
           for v in "$NPM_VER" "$SMOLDOT_VER" "$LIGHT_VER"; do
             [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]] \
               || { echo "::error::version files did not yield a semver: '$v'"; exit 1; }
           done
-          echo "npm=npm-smoldot-v$NPM_VER"       >> "$GITHUB_OUTPUT"
-          echo "smoldot=smoldot-v$SMOLDOT_VER"   >> "$GITHUB_OUTPUT"
-          echo "light=smoldot-light-v$LIGHT_VER" >> "$GITHUB_OUTPUT"
+          {
+            echo "npm_ver=$NPM_VER"
+            echo "smoldot_ver=$SMOLDOT_VER"
+            echo "light_ver=$LIGHT_VER"
+            echo "npm=npm-smoldot-v$NPM_VER"
+            echo "smoldot=smoldot-v$SMOLDOT_VER"
+            echo "light=smoldot-light-v$LIGHT_VER"
+          } >> "$GITHUB_OUTPUT"
           printf 'Computed tags:\n  npm-smoldot-v%s\n  smoldot-v%s\n  smoldot-light-v%s\n' \
             "$NPM_VER" "$SMOLDOT_VER" "$LIGHT_VER"
-      - name: Push missing release tags
+      - name: Push verified release tags
+        env:
+          NPM_VER:     ${{ steps.tags.outputs.npm_ver }}
+          SMOLDOT_VER: ${{ steps.tags.outputs.smoldot_ver }}
+          LIGHT_VER:   ${{ steps.tags.outputs.light_ver }}
+          NPM_TAG:     ${{ steps.tags.outputs.npm }}
+          SMOLDOT_TAG: ${{ steps.tags.outputs.smoldot }}
+          LIGHT_TAG:   ${{ steps.tags.outputs.light }}
         run: |
           set -euo pipefail
-          for TAG in \
-              '${{ steps.tags.outputs.npm }}' \
-              '${{ steps.tags.outputs.smoldot }}' \
-              '${{ steps.tags.outputs.light }}'; do
-            if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
-              echo "Tag $TAG already exists; skipping."
-            else
-              git tag "$TAG"
-              git push origin "$TAG"
-              echo "Pushed: $TAG -> $(git rev-parse HEAD)"
+          # crates.io requires a contact-bearing User-Agent.
+          UA="smoldot-release-ci (https://github.com/${{ github.repository }})"
+
+          # Registries are eventually-consistent; retry up to 3 min per check.
+          retry() {
+            local i; for i in 1 2 3 4 5 6; do
+              "$@" && return 0
+              sleep 30
+            done
+            return 1
+          }
+
+          npm_has() {
+            local code
+            code=$(curl -sS -o /dev/null -w '%{http_code}' \
+              "https://registry.npmjs.org/smoldot/$1")
+            [[ "$code" == "200" ]]
+          }
+          crate_has() {
+            curl -fsS -A "$UA" "https://crates.io/api/v1/crates/$1/$2" \
+              | jq -e --arg v "$2" '.version.num == $v' >/dev/null
+          }
+          remote_tag_exists() {
+            [[ -n "$(git ls-remote --tags origin "refs/tags/$1")" ]]
+          }
+          push_tag() {
+            local tag="$1"
+            if remote_tag_exists "$tag"; then
+              echo "Tag $tag already exists on remote; skipping."
+              return
             fi
-          done
+            git tag "$tag"
+            git push origin "$tag"
+            echo "Pushed: $tag -> $(git rev-parse HEAD)"
+          }
+
+          FAILED=0
+          if retry npm_has "$NPM_VER"; then
+            push_tag "$NPM_TAG"
+          else
+            echo "::error::smoldot@$NPM_VER not found on npm after retries; not tagging $NPM_TAG"
+            FAILED=1
+          fi
+          if retry crate_has smoldot "$SMOLDOT_VER"; then
+            push_tag "$SMOLDOT_TAG"
+          else
+            echo "::error::smoldot v$SMOLDOT_VER not found on crates.io after retries; not tagging $SMOLDOT_TAG"
+            FAILED=1
+          fi
+          if retry crate_has smoldot-light "$LIGHT_VER"; then
+            push_tag "$LIGHT_TAG"
+          else
+            echo "::error::smoldot-light v$LIGHT_VER not found on crates.io after retries; not tagging $LIGHT_TAG"
+            FAILED=1
+          fi
+          exit "$FAILED"
 
   all-deploy:
     # This dummy job depends on all the mandatory checks. It succeeds if and only if CI is

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -348,10 +348,64 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         continue-on-error: true
 
+  tags-publish:
+    # Creates the three release-marker tags (`npm-smoldot-v…`, `smoldot-v…`,
+    # `smoldot-light-v…`) on the merge commit. Per-tag existence check makes
+    # the job idempotent: pushes to main that don't bump a given version are
+    # a no-op for that tag because its name already points at a prior commit.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [npm-publish, deno-publish, crates-io-publish]
+    # Serialize concurrent runs so two back-to-back pushes can't race on
+    # `git push` of the same new tag.
+    concurrency:
+      group: tags-publish
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # Necessary in order to push tags.
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # Necessary below for checking if tags exist.
+      - id: tags
+        name: Compute and validate tag names
+        run: |
+          set -euo pipefail
+          # First `version = "..."` line per Cargo.toml = [package].version.
+          # Yields empty on `version.workspace = true`; caught by the semver
+          # check below before any tag is pushed.
+          NPM_VER=$(jq -r .version ./wasm-node/javascript/package.json)
+          SMOLDOT_VER=$(sed -nE '0,/^version = "(.+)"$/s//\1/p' ./lib/Cargo.toml)
+          LIGHT_VER=$(sed -nE '0,/^version = "(.+)"$/s//\1/p' ./light-base/Cargo.toml)
+          for v in "$NPM_VER" "$SMOLDOT_VER" "$LIGHT_VER"; do
+            [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]] \
+              || { echo "::error::version files did not yield a semver: '$v'"; exit 1; }
+          done
+          echo "npm=npm-smoldot-v$NPM_VER"       >> "$GITHUB_OUTPUT"
+          echo "smoldot=smoldot-v$SMOLDOT_VER"   >> "$GITHUB_OUTPUT"
+          echo "light=smoldot-light-v$LIGHT_VER" >> "$GITHUB_OUTPUT"
+          printf 'Computed tags:\n  npm-smoldot-v%s\n  smoldot-v%s\n  smoldot-light-v%s\n' \
+            "$NPM_VER" "$SMOLDOT_VER" "$LIGHT_VER"
+      - name: Push missing release tags
+        run: |
+          set -euo pipefail
+          for TAG in \
+              '${{ steps.tags.outputs.npm }}' \
+              '${{ steps.tags.outputs.smoldot }}' \
+              '${{ steps.tags.outputs.light }}'; do
+            if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
+              echo "Tag $TAG already exists; skipping."
+            else
+              git tag "$TAG"
+              git push origin "$TAG"
+              echo "Pushed: $TAG -> $(git rev-parse HEAD)"
+            fi
+          done
+
   all-deploy:
     # This dummy job depends on all the mandatory checks. It succeeds if and only if CI is
     # considered successful.
-    needs: [docs-publish, npm-publish, deno-publish, crates-io-publish]
+    needs: [docs-publish, npm-publish, deno-publish, crates-io-publish, tags-publish]
     runs-on: ubuntu-latest
     steps:
      - run: echo Success

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -22,12 +22,14 @@ A version-bumping release commit drives four outputs:
 | Deno git-tag `light-js-deno-v<npm>` | `deno-publish` (creates tag if missing) |
 | crates.io `smoldot` | `crates-io-publish` (runs `cargo publish --no-verify`; `continue-on-error: true`) |
 | crates.io `smoldot-light` | `crates-io-publish` (same) |
+| git tags `npm-smoldot-v<npm>`, `smoldot-v<lib>`, `smoldot-light-v<light-base>` | `tags-publish` (creates each tag if missing) |
 | Docs (gh-pages) | `docs-publish` (force-pushes fresh tree every run, regardless of version) |
 
-Three git tags are created **manually** on the release commit after merge:
-`npm-smoldot-v<X.Y.Z>`, `smoldot-v<A.B.C>`, `smoldot-light-v<A.B.C>`. Create
-only the ones whose version actually changed. The `light-js-deno-v<X.Y.Z>` tag
-is created by CI, not manually.
+All release tags are pushed by CI. `tags-publish` reads the version files
+and pushes `npm-smoldot-v<X.Y.Z>`, `smoldot-v<A.B.C>`, and
+`smoldot-light-v<A.B.C>` to the merge commit, but only the ones whose
+version names don't already exist on the remote — so a non-bumping push
+to `main` is a no-op for each tag.
 
 ---
 
@@ -226,10 +228,6 @@ npm view smoldot@<X.Y.Z>
 # crates.io — requires a User-Agent with contact info
 curl -sS -A "some-agent" https://crates.io/api/v1/crates/smoldot       | jq .crate.max_version
 curl -sS -A "some-agent" https://crates.io/api/v1/crates/smoldot-light | jq .crate.max_version
-
-# Deno tag pushed by CI
-git fetch --tags
-git tag -l 'light-js-deno-v<X.Y.Z>'
 ```
 
 Expected quirk: the `crates-io-publish` job's `smoldot` step fails with
@@ -238,30 +236,22 @@ Expected quirk: the `crates-io-publish` job's `smoldot` step fails with
 
 ---
 
-## 11. Create and push the manual tags
+## 11. Verify CI-pushed tags
 
-On the release commit SHA (the merged squash on `main`):
-
-```sh
-git fetch origin main
-git checkout <release-commit-sha>
-
-git tag npm-smoldot-v<X.Y.Z>                # always
-git tag smoldot-light-v<A.B.C>              # if smoldot-light bumped
-git tag smoldot-v<A.B.C>                    # if smoldot bumped
-
-git push origin \
-    npm-smoldot-v<X.Y.Z> \
-    [smoldot-light-v<A.B.C>] \
-    [smoldot-v<A.B.C>]
-```
-
-Tags are lightweight (no `-a`/`-m`). Verify they landed on origin:
+`tags-publish` and `deno-publish` push the release-marker tags
+automatically on the release commit. Confirm they landed:
 
 ```sh
 git fetch --tags
-git tag -l '*<X.Y.Z>*'   # should list the CI-pushed light-js-deno-v tag plus the manual ones
+git tag -l \
+    'npm-smoldot-v<X.Y.Z>' \
+    'smoldot-v<A.B.C>' \
+    'smoldot-light-v<A.B.C>' \
+    'light-js-deno-v<X.Y.Z>'
 ```
+
+Only the tags whose versions actually changed are pushed — `tags-publish`
+short-circuits per tag if the name already exists on the remote.
 
 On any post-publish failure, do not delete published versions — yank
 (`npm deprecate smoldot@<X.Y.Z> '...'`, `cargo yank --version <A.B.C>`) and

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -163,13 +163,14 @@ cargo check -p smoldot -p smoldot-light
 Optional dry-runs:
 
 ```sh
-cargo publish --dry-run --locked -p smoldot
+cargo publish --dry-run --locked --allow-dirty -p smoldot
 ```
 
 Run this every release; it only validates packaging and local build.
+`--allow-dirty` because the version bumps aren't committed yet (step 7).
 
 ```sh
-cargo publish --dry-run --locked -p smoldot-light
+cargo publish --dry-run --locked --allow-dirty -p smoldot-light
 ```
 
 Run this **only if `smoldot` is not being bumped**. Otherwise it fails on


### PR DESCRIPTION
## Summary

Two related changes:
1. Add a `/smoldot-release` slash command (`.claude/commands/smoldot-release.md`) that walks through the runbook in `docs/RELEASING.md` — useful when cutting a release with Claude Code.

2. Add `tags-publish` job to `deploy.yml` that pushes `npm-smoldot-v…`, `smoldot-v…`, and`smoldot-light-v…` on the merge commit, mirroring `deno-publish`. 
Updates `docs/RELEASING.md` accordingly

## Behavior (tags-publish)

- Runs on push to `main` after `npm-publish`, `deno-publish`, `crates-io-publish`.
- Per-tag existence check: non-bumping pushes are a no-op; works for any combination of
npm/lib/light-base bumps.
- Semver-regex validates parsed versions; `concurrency:` serializes back-to-back pushes.

