### PR TITLE
fix(sync): avoid node ban after justification error UnknownTargetBlock

### DIFF
--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -578,9 +578,18 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                         // Errors of type `JustificationEngineMismatch` indicate that the chain
                         // uses a finality engine that smoldot doesn't recognize. This is a benign
                         // error that shouldn't lead to a ban.
+                        // 
+                        // Errors of type `UnknownTargetBlock` are expected during the catch-up
+                        // window that follows a warp sync: the non-finalized tree only contains
+                        // the warp-sync target block, so peers may send justifications for
+                        // higher blocks that the local node hasn't downloaded yet.
+                        // Banning these peers would slow down the catch-up.
                         if !matches!(
                             error,
-                            all::JustificationVerifyError::JustificationEngineMismatch
+                            all::JustificationVerifyError::JustificationEngineMismatch |
+                            all::JustificationVerifyError::FinalityVerify(
+                                smoldot::chain::blocks_tree::FinalityVerifyError::UnknownTargetBlock { .. }
+                            )
                         ) {
                             log!(
                                 &task.platform,

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -578,7 +578,7 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                         // Errors of type `JustificationEngineMismatch` indicate that the chain
                         // uses a finality engine that smoldot doesn't recognize. This is a benign
                         // error that shouldn't lead to a ban.
-                        // 
+                        //
                         // Errors of type `UnknownTargetBlock` are expected during the catch-up
                         // window that follows a warp sync: the non-finalized tree only contains
                         // the warp-sync target block, so peers may send justifications for


### PR DESCRIPTION
After warp sync finishes, the non finalized tree contains just the warp-sync target block. The node now needs to catch up from that target to the chain tip. During that window, peers will send justifications targeting blocks the local node hasn't yet downloaded.

Not banning the node avoids delays in receiving important data needed to continue the sync.

This has been extracted from [paritytech/smoldot-archive#2222](https://github.com/paritytech/smoldot-archive/pull/2222), but not being relevant only to WebRTC, it has been moved into its own pr.