### PR TITLE
runtime_service: reject genesis as pre_warp_finalized

### DIFF
--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -3217,9 +3217,11 @@ fn build_warp_sync_tree<TPlat: PlatformRef>(
             })
         }
     }
-    // Disable when missing, degenerately equal to the new finalized, or
-    // not strictly older.
-    .filter(|b| b.hash != new_finalized_block.hash && b.height < new_finalized_block.height);
+    // Disable when missing, degenerately equal to the new finalized, not strictly older,
+    // or pointing at genesis
+    .filter(|b| {
+        b.hash != new_finalized_block.hash && b.height < new_finalized_block.height && b.height > 0
+    });
 
     let pre_warp_finalized_hash = pre_warp_finalized.as_ref().map(|b| b.hash);
 

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -3217,12 +3217,12 @@ fn build_warp_sync_tree<TPlat: PlatformRef>(
             })
         }
     }
-    // Disable when missing, degenerately equal to the new finalized, not strictly older,
-    // or pointing at genesis. Genesis state isn't reliably served by peers, so clients
+    // Disable when missing, pointing at genesis, degenerately equal to the new finalized,
+    // or not strictly older. Genesis state isn't reliably served by peers, so clients
     // would fail storage/runtime calls against the Initialized hash. Relay falls back
     // here when no checkpoint is set; parachain always falls back at first bootstrap.
     .filter(|b| {
-        b.hash != new_finalized_block.hash && b.height < new_finalized_block.height && b.height > 0
+        b.height > 0 && b.hash != new_finalized_block.hash && b.height < new_finalized_block.height
     });
 
     let pre_warp_finalized_hash = pre_warp_finalized.as_ref().map(|b| b.hash);

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -3218,7 +3218,9 @@ fn build_warp_sync_tree<TPlat: PlatformRef>(
         }
     }
     // Disable when missing, degenerately equal to the new finalized, not strictly older,
-    // or pointing at genesis
+    // or pointing at genesis. Genesis state isn't reliably served by peers, so clients
+    // would fail storage/runtime calls against the Initialized hash. Relay falls back
+    // here when no checkpoint is set; parachain always falls back at first bootstrap.
     .filter(|b| {
         b.hash != new_finalized_block.hash && b.height < new_finalized_block.height && b.height > 0
     });

--- a/light-base/src/runtime_service/tests.rs
+++ b/light-base/src/runtime_service/tests.rs
@@ -47,6 +47,17 @@ fn known_tree(finalized: Block) -> Tree<TestPlat> {
     }
 }
 
+fn unknown_tree_with_finalized(initial: Block) -> Tree<TestPlat> {
+    let mut tree = async_tree::AsyncTree::new(async_tree::Config {
+        finalized_async_user_data: None,
+        retry_after_failed: Duration::from_secs(4),
+        blocks_capacity: 0,
+    });
+    let idx = tree.input_insert_block(initial, None, false, true);
+    tree.input_finalize(idx);
+    Tree::FinalizedBlockRuntimeUnknown { tree }
+}
+
 #[test]
 fn attaches_warp_synced_block_under_prior_finalized() {
     let pre_warp_finalized = block(0x01, 100);
@@ -175,6 +186,42 @@ fn notifies_subscribers_of_warp_synced_block() {
     assert_eq!(result.tree.input_output_iter_unordered().count(), 0);
 
     assert!(result.tree.try_advance_output().is_none());
+}
+
+#[test]
+fn rejects_genesis_as_pre_warp_finalized() {
+    // Skip genesis as pre_warp_finalized: clients use the Initialized hash for
+    // storage and runtime calls, and genesis state isn't reliably served by peers.
+    let genesis = block(0x00, 0);
+    let new_finalized = block(0x02, 101);
+
+    let result = build_warp_sync_tree::<TestPlat>(
+        &unknown_tree_with_finalized(genesis),
+        new_finalized.clone(),
+        dummy_runtime(),
+        vec![],
+    );
+
+    assert_eq!(result.finalized_block.hash, new_finalized.hash);
+    assert_eq!(result.pre_warp_finalized_hash, None);
+    assert_eq!(result.tree.input_output_iter_unordered().count(), 0);
+}
+
+#[test]
+fn rejects_genesis_in_known_prev_tree() {
+    let genesis = block(0x00, 0);
+    let new_finalized = block(0x02, 101);
+
+    let result = build_warp_sync_tree::<TestPlat>(
+        &known_tree(genesis),
+        new_finalized.clone(),
+        dummy_runtime(),
+        vec![],
+    );
+
+    assert_eq!(result.finalized_block.hash, new_finalized.hash);
+    assert_eq!(result.pre_warp_finalized_hash, None);
+    assert_eq!(result.tree.input_output_iter_unordered().count(), 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary


`build_warp_sync_tree` could pick genesis as the tree's `pre_warp_finalized`, which surfaces to `chainHead_v1` subscribers as the `Initialized` event hash. Genesis state isn't reliably served by peers, so clients (e.g. PAPI) that use the Initialized hash for storage or runtime calls fail.

Above was introduced in #3246.

Observed PAPI failure on `next-asset-hub-paseo'
```
[FRAMELOG][host.localhost:5173/][debug] [smoldot +18.46s] [json-rpc-next-asset-hub-paseo] json-rpc-response-yielded; response={"jsonrpc":"2.0","method":"chainHead_v1_followEvent","params":{"subscription":"GhoxNtfsPRJMVuMrfkZCbN6Ufmg7bvjy8SPnFGc7ckc5","result":{"event":"initialized","finalizedBlockHashes":["0x173cea9df45656cf612c8b8ece56e04e9a693c69cfaac47d3628dae735067af8"]…
[FRAMELOG][host.localhost:5173/][debug] [smoldot +18.46s] [json-rpc-next-asset-hub-paseo] json-rpc-request-queued; request={"jsonrpc":"2.0","id":"1-2","method":"chainHead_v1_header","params":["GhoxNtfsPRJMVuMrfkZCbN6Ufmg7bvjy8SPnFGc7ckc5","0x173cea9df45656cf612c8b8ece56e04e9a693c69cfaac47d3628dae735067af8"]}
[FRAMELOG][host.localhost:5173/][debug] [smoldot +18.46s] [json-rpc-next-asset-hub-paseo] json-rpc-request-queued; request={"jsonrpc":"2.0","id":"1-3","method":"chainHead_v1_storage","params":["GhoxNtfsPRJMVuMrfkZCbN6Ufmg7bvjy8SPnFGc7ckc5","0x173cea9df45656cf612c8b8ece56e04e9a693c69cfaac47d3628dae735067af8",[{"key":"0x3a636f6465","type":"hash"}],null]}
[FRAMELOG][host.localhost:5173/][debug] [smoldot +18.47s] [json-rpc-next-asset-hub-paseo] json-rpc-response-yielded; response={"jsonrpc":"2.0","id":"1-3","result":{"result":"started","operationId":"DRUdj8pvY3EztntB1dfqKB5kiLYp6WcFJgkF2aa9EU4k","discardedItems":0}}
[FRAMELOG][host.localhost:5173/][debug] [smoldot +18.90s] [json-rpc-next-asset-hub-paseo] json-rpc-response-yielded; response={"jsonrpc":"2.0","method":"chainHead_v1_followEvent","params":{"subscription":"GhoxNtfsPRJMVuMrfkZCbN6Ufmg7bvjy8SPnFGc7ckc5","result":{"event":"operationInaccessible","operationId":"DRUdj8pvY3EztntB1dfqKB5kiLYp6WcFJgkF2aa9EU4k"}}}
```

## Fix

Add `b.height > 0` to the `build_warp_sync_tree` filter. When `pre_warp_finalized` would be genesis, fall back `finalized_block = new_finalized_block`.

## Test plan
- New unit tests cover both `prev_tree` variants:
  - `rejects_genesis_as_pre_warp_finalized` (FinalizedBlockRuntimeUnknown with genesis input-finalized)
  - `rejects_genesis_in_known_prev_tree` (FinalizedBlockRuntimeKnown with finalized=genesis)

