### PR TITLE
Fix `forbidNonLocalWs` flag detection

### DIFF
--- a/wasm-node/javascript/src/no-auto-bytecode-browser.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-browser.ts
@@ -52,9 +52,9 @@ export function startWithBytecode(options: ClientOptionsWithBytecode): Client {
     // avoid storing in memory addresses that it knows it can't connect to.
     // The condition below is a hint, and false-positives or false-negatives are not fundamentally
     // an issue.
-    if ((typeof isSecureContext === 'boolean' && isSecureContext) && typeof location !== undefined) {
-        const loc = location.toString();
-        if (loc.indexOf('localhost') !== -1 && loc.indexOf('127.0.0.1') !== -1 && loc.indexOf('::1') !== -1) {
+    if ((typeof isSecureContext === 'boolean' && isSecureContext) && typeof location !== 'undefined') {
+        const hostname = location.hostname;
+        if (hostname !== 'localhost' && hostname !== '127.0.0.1' && hostname !== '[::1]' && hostname !== '::1') {
             options.forbidNonLocalWs = true;
         }
     }

--- a/wasm-node/javascript/test/browser-options.mjs
+++ b/wasm-node/javascript/test/browser-options.mjs
@@ -1,0 +1,108 @@
+// Smoldot
+// Copyright (C) 2019-2022  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import test from "ava";
+import { startWithBytecode } from "../dist/mjs/no-auto-bytecode-browser.js";
+
+const bytecode = new Promise(() => {});
+
+function withBrowserLocation(href, isSecureContext, callback) {
+  const previousIsSecureContext = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "isSecureContext",
+  );
+  const previousLocation = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "location",
+  );
+
+  Object.defineProperty(globalThis, "isSecureContext", {
+    configurable: true,
+    value: isSecureContext,
+  });
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: new URL(href),
+  });
+
+  try {
+    callback();
+  } finally {
+    restoreGlobal("isSecureContext", previousIsSecureContext);
+    restoreGlobal("location", previousLocation);
+  }
+}
+
+function restoreGlobal(name, descriptor) {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+  } else {
+    delete globalThis[name];
+  }
+}
+
+for (const { title, href, isSecureContext, expectedForbidNonLocalWs } of [
+  {
+    title: "secure browser context on remote host forbids non-local WebSockets",
+    href: "https://example.com/app",
+    isSecureContext: true,
+    expectedForbidNonLocalWs: true,
+  },
+  {
+    title: "secure browser context on another remote host forbids non-local WebSockets",
+    href: "https://rpc.example.org:443/ws",
+    isSecureContext: true,
+    expectedForbidNonLocalWs: true,
+  },
+  {
+    title: "secure browser context on localhost keeps non-local WebSockets allowed",
+    href: "http://localhost:9090",
+    isSecureContext: true,
+    expectedForbidNonLocalWs: undefined,
+  },
+  {
+    title: "secure browser context on IPv4 loopback keeps non-local WebSockets allowed",
+    href: "http://127.0.0.1:9090",
+    isSecureContext: true,
+    expectedForbidNonLocalWs: undefined,
+  },
+  {
+    title: "secure browser context on IPv6 loopback keeps non-local WebSockets allowed",
+    href: "http://[::1]:9090",
+    isSecureContext: true,
+    expectedForbidNonLocalWs: undefined,
+  },
+  {
+    title: "insecure browser context on remote host keeps non-local WebSockets allowed",
+    href: "http://example.com/app",
+    isSecureContext: false,
+    expectedForbidNonLocalWs: undefined,
+  },
+]) {
+  test(title, (t) => {
+    withBrowserLocation(href, isSecureContext, () => {
+      const options = {
+        bytecode,
+        logCallback: () => {},
+      };
+
+      startWithBytecode(options);
+
+      t.is(options.forbidNonLocalWs, expectedForbidNonLocalWs);
+    });
+  });
+}


### PR DESCRIPTION
Adds regression test and should now properly set the flag based on actual URL.

closes #3261 