### PR TITLE
Warp-sync-aware runtime service for parachain bootstrap speedup

### DIFF
--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -831,6 +831,7 @@ async fn run_background<TPlat: PlatformRef>(
             blocks_stream: None,
             runtime_downloads: stream::FuturesUnordered::new(),
             progress_runtime_call_requests: stream::FuturesUnordered::new(),
+            warp_sync_state: sync_service::WarpSyncState::NotStarted,
         }
     };
 
@@ -946,6 +947,17 @@ async fn run_background<TPlat: PlatformRef>(
                         let async_op = match &mut background.tree {
                             Tree::FinalizedBlockRuntimeKnown { tree, .. } => {
                                 tree.next_necessary_async_op(&background.platform.now())
+                            }
+                            // Suppress pre-warp runtime downloads while warp sync is running.
+                            // If such a download completes, `TreeAdvanceFinalizedUnknown::Finalized`
+                            // fires → tree transitions to `Known(pre-warp)` → `subscribe_all`
+                            // returns the checkpoint hash, which is now stale since warp sync has
+                            // started.
+                            Tree::FinalizedBlockRuntimeUnknown { .. }
+                                if background.warp_sync_state
+                                    == sync_service::WarpSyncState::InProgress =>
+                            {
+                                async_tree::NextNecessaryAsyncOp::NotReady { when: None }
                             }
                             Tree::FinalizedBlockRuntimeUnknown { tree, .. } => {
                                 tree.next_necessary_async_op(&background.platform.now())
@@ -1326,6 +1338,7 @@ async fn run_background<TPlat: PlatformRef>(
                 // Note that this `await` freezes the entire runtime service background task,
                 // but the sync service guarantees that `subscribe_all` returns very quickly.
                 let subscription = background.sync_service.subscribe_all(32, true).await;
+                background.warp_sync_state = subscription.warp_sync_state;
 
                 log!(
                     &background.platform,
@@ -2923,6 +2936,10 @@ struct Background<TPlat: PlatformRef> {
     /// List of actions to perform to progress runtime calls requested by the frontend.
     progress_runtime_call_requests:
         stream::FuturesUnordered<future::BoxFuture<'static, ProgressRuntimeCallRequest>>,
+
+    /// Latest [`sync_service::SubscribeAll::warp_sync_state`]. Suppresses runtime downloads
+    /// while it equals `InProgress`.
+    warp_sync_state: sync_service::WarpSyncState,
 }
 
 enum Tree<TPlat: PlatformRef> {

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -2937,8 +2937,7 @@ struct Background<TPlat: PlatformRef> {
     progress_runtime_call_requests:
         stream::FuturesUnordered<future::BoxFuture<'static, ProgressRuntimeCallRequest>>,
 
-    /// Latest [`sync_service::SubscribeAll::warp_sync_state`]. Suppresses runtime downloads
-    /// while it equals `InProgress`.
+    /// Latest [`sync_service::SubscribeAll::warp_sync_state`] received from `MustSubscribe`.
     warp_sync_state: sync_service::WarpSyncState,
 }
 

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -1117,6 +1117,26 @@ pub struct SubscribeAll {
     /// Channel onto which new blocks are sent. The channel gets closed if it is full when a new
     /// block needs to be reported.
     pub new_blocks: async_channel::Receiver<Notification>,
+
+    /// State of GrandPa warp sync at the time of subscription.
+    pub warp_sync_state: WarpSyncState,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum WarpSyncState {
+    /// Chain doesn't run warp sync at this layer (parachain / paraheads).
+    NotApplicable,
+    NotStarted,
+    InProgress,
+    Finished(FinishedReason),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum FinishedReason {
+    /// `WarpSyncFinished` fired.
+    Success,
+    /// Determined unnecessary at runtime (AllForks-only progress tiebreaker).
+    Terminated,
 }
 
 /// See [`SubscribeAll::finalized_block_runtime`].

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -1352,7 +1352,7 @@ enum ToBackground {
 #[cfg(test)]
 mod tests {
     use super::{
-        FinishedReason, WarpSyncEffect, WARP_SYNC_NOT_NEEDED_AFTER_ALLFORKS_VERIFIES,
+        FinishedReason, WARP_SYNC_NOT_NEEDED_AFTER_ALLFORKS_VERIFIES, WarpSyncEffect,
         WarpSyncEvent, WarpSyncState, WarpSyncTracker,
     };
 

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -1135,8 +1135,100 @@ pub enum WarpSyncState {
 pub enum FinishedReason {
     /// `WarpSyncFinished` fired.
     Success,
-    /// Determined unnecessary at runtime (AllForks-only progress tiebreaker).
+    /// Terminated at runtime because AllForks alone made enough progress that warp sync
+    /// was deemed unnecessary.
     Terminated,
+}
+
+/// Number of AllForks block verifications observed while [`WarpSyncState::NotStarted`]
+/// after which warp sync is considered unnecessary and the tracker terminates it.
+pub(crate) const WARP_SYNC_NOT_NEEDED_AFTER_ALLFORKS_VERIFIES: u32 = 10;
+
+/// Events observed by the sync task that drive [`WarpSyncTracker`] transitions.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum WarpSyncEvent {
+    /// `VerifyWarpSyncFragment` returned `Ok`.
+    WarpSyncFragmentVerified,
+    /// An AllForks `VerifyBlock` was processed.
+    AllForksBlockVerified,
+    /// `WarpSyncFinished` fired.
+    WarpSyncFinished,
+}
+
+/// Side effects the caller must apply after [`WarpSyncTracker::on_event`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[must_use]
+pub(crate) struct WarpSyncEffect {
+    /// True when the warp-sync state machine requires
+    /// `task.all_notifications.clear()` so consumers re-subscribe and drop any
+    /// in-flight pre-warp runtime download.
+    pub force_resubscribe: bool,
+}
+
+impl WarpSyncEffect {
+    /// Returned by [`WarpSyncTracker::on_event`] when an event does not require
+    /// any action by the caller.
+    pub(crate) const fn none() -> Self {
+        Self {
+            force_resubscribe: false,
+        }
+    }
+}
+
+/// Pure state-machine tracking [`WarpSyncState`] independent of the surrounding task plumbing.
+///
+/// Split out so the transitions can be unit-tested without a `PlatformRef` /
+/// network stack.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) struct WarpSyncTracker {
+    state: WarpSyncState,
+    all_forks_verifies_while_not_started: u32,
+}
+
+impl WarpSyncTracker {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: WarpSyncState::NotStarted,
+            all_forks_verifies_while_not_started: 0,
+        }
+    }
+
+    pub(crate) fn state(&self) -> WarpSyncState {
+        self.state
+    }
+
+    pub(crate) fn on_event(&mut self, event: WarpSyncEvent) -> WarpSyncEffect {
+        match (self.state, event) {
+            (WarpSyncState::NotStarted, WarpSyncEvent::WarpSyncFragmentVerified) => {
+                self.state = WarpSyncState::InProgress;
+                WarpSyncEffect {
+                    force_resubscribe: true,
+                }
+            }
+            (WarpSyncState::NotStarted, WarpSyncEvent::AllForksBlockVerified) => {
+                self.all_forks_verifies_while_not_started =
+                    self.all_forks_verifies_while_not_started.saturating_add(1);
+                if self.all_forks_verifies_while_not_started
+                    >= WARP_SYNC_NOT_NEEDED_AFTER_ALLFORKS_VERIFIES
+                {
+                    self.state = WarpSyncState::Finished(FinishedReason::Terminated);
+                    WarpSyncEffect {
+                        force_resubscribe: true,
+                    }
+                } else {
+                    WarpSyncEffect::none()
+                }
+            }
+            (
+                WarpSyncState::NotStarted | WarpSyncState::InProgress,
+                WarpSyncEvent::WarpSyncFinished,
+            ) => {
+                self.state = WarpSyncState::Finished(FinishedReason::Success);
+                WarpSyncEffect::none()
+            }
+            _ => WarpSyncEffect::none(),
+        }
+    }
 }
 
 /// See [`SubscribeAll::finalized_block_runtime`].
@@ -1261,4 +1353,140 @@ enum ToBackground {
     SerializeChainInformation {
         send_back: oneshot::Sender<Option<chain::chain_information::ValidChainInformation>>,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        FinishedReason, WarpSyncEffect, WARP_SYNC_NOT_NEEDED_AFTER_ALLFORKS_VERIFIES,
+        WarpSyncEvent, WarpSyncState, WarpSyncTracker,
+    };
+
+    #[test]
+    fn fresh_tracker_starts_in_not_started() {
+        let tracker = WarpSyncTracker::new();
+        assert_eq!(tracker.state(), WarpSyncState::NotStarted);
+    }
+
+    #[test]
+    fn first_fragment_moves_not_started_to_in_progress_and_forces_resubscribe() {
+        let mut tracker = WarpSyncTracker::new();
+        let effects = tracker.on_event(WarpSyncEvent::WarpSyncFragmentVerified);
+        assert_eq!(tracker.state(), WarpSyncState::InProgress);
+        assert_eq!(
+            effects,
+            WarpSyncEffect {
+                force_resubscribe: true
+            }
+        );
+    }
+
+    #[test]
+    fn subsequent_fragments_in_progress_are_noop() {
+        let mut tracker = WarpSyncTracker::new();
+        let _ = tracker.on_event(WarpSyncEvent::WarpSyncFragmentVerified);
+        for _ in 0..5 {
+            let effects = tracker.on_event(WarpSyncEvent::WarpSyncFragmentVerified);
+            assert_eq!(tracker.state(), WarpSyncState::InProgress);
+            assert_eq!(effects, WarpSyncEffect::none());
+        }
+    }
+
+    #[test]
+    fn warp_sync_finished_from_in_progress_transitions_to_finished_success() {
+        let mut tracker = WarpSyncTracker::new();
+        let _ = tracker.on_event(WarpSyncEvent::WarpSyncFragmentVerified);
+        let effects = tracker.on_event(WarpSyncEvent::WarpSyncFinished);
+        assert_eq!(
+            tracker.state(),
+            WarpSyncState::Finished(FinishedReason::Success)
+        );
+        // The gap-driven `all_notifications.clear()` is unrelated to the state
+        // machine; the tracker itself should not request a resubscribe here.
+        assert_eq!(effects, WarpSyncEffect::none());
+    }
+
+    #[test]
+    fn warp_sync_finished_directly_from_not_started_also_transitions_to_finished_success() {
+        let mut tracker = WarpSyncTracker::new();
+        let effects = tracker.on_event(WarpSyncEvent::WarpSyncFinished);
+        assert_eq!(
+            tracker.state(),
+            WarpSyncState::Finished(FinishedReason::Success)
+        );
+        assert_eq!(effects, WarpSyncEffect::none());
+    }
+
+    #[test]
+    fn all_forks_verifies_trip_terminated_at_threshold() {
+        let mut tracker = WarpSyncTracker::new();
+        for n in 1..WARP_SYNC_NOT_NEEDED_AFTER_ALLFORKS_VERIFIES {
+            let effects = tracker.on_event(WarpSyncEvent::AllForksBlockVerified);
+            assert_eq!(
+                tracker.state(),
+                WarpSyncState::NotStarted,
+                "should still be NotStarted after {n} verifications",
+            );
+            assert_eq!(effects, WarpSyncEffect::none());
+        }
+        let effects = tracker.on_event(WarpSyncEvent::AllForksBlockVerified);
+        assert_eq!(
+            tracker.state(),
+            WarpSyncState::Finished(FinishedReason::Terminated)
+        );
+        assert_eq!(
+            effects,
+            WarpSyncEffect {
+                force_resubscribe: true
+            }
+        );
+    }
+
+    #[test]
+    fn all_forks_counter_frozen_once_warp_sync_is_in_progress() {
+        let mut tracker = WarpSyncTracker::new();
+        let _ = tracker.on_event(WarpSyncEvent::WarpSyncFragmentVerified);
+        // Far more AllForks ticks than the termination threshold should not flip the state.
+        for _ in 0..(WARP_SYNC_NOT_NEEDED_AFTER_ALLFORKS_VERIFIES * 3) {
+            let effects = tracker.on_event(WarpSyncEvent::AllForksBlockVerified);
+            assert_eq!(tracker.state(), WarpSyncState::InProgress);
+            assert_eq!(effects, WarpSyncEffect::none());
+        }
+    }
+
+    #[test]
+    fn finished_states_are_terminal() {
+        for finished in [
+            WarpSyncState::Finished(FinishedReason::Success),
+            WarpSyncState::Finished(FinishedReason::Terminated),
+        ] {
+            let mut tracker = WarpSyncTracker::new();
+            // Drive the tracker into the target finished state.
+            match finished {
+                WarpSyncState::Finished(FinishedReason::Success) => {
+                    let _ = tracker.on_event(WarpSyncEvent::WarpSyncFinished);
+                }
+                WarpSyncState::Finished(FinishedReason::Terminated) => {
+                    for _ in 0..WARP_SYNC_NOT_NEEDED_AFTER_ALLFORKS_VERIFIES {
+                        let _ = tracker.on_event(WarpSyncEvent::AllForksBlockVerified);
+                    }
+                }
+                _ => unreachable!(),
+            }
+            assert_eq!(tracker.state(), finished);
+            for ev in [
+                WarpSyncEvent::WarpSyncFragmentVerified,
+                WarpSyncEvent::AllForksBlockVerified,
+                WarpSyncEvent::WarpSyncFinished,
+            ] {
+                let effects = tracker.on_event(ev);
+                assert_eq!(
+                    tracker.state(),
+                    finished,
+                    "event {ev:?} should not change a finished state",
+                );
+                assert_eq!(effects, WarpSyncEffect::none());
+            }
+        }
+    }
 }

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -1140,34 +1140,31 @@ pub enum FinishedReason {
     Terminated,
 }
 
-/// Number of AllForks block verifications observed while [`WarpSyncState::NotStarted`]
-/// after which warp sync is considered unnecessary and the tracker terminates it.
+/// AllForks verifications observed while [`WarpSyncState::NotStarted`] after which
+/// warp sync is considered unnecessary.
 pub(crate) const WARP_SYNC_NOT_NEEDED_AFTER_ALLFORKS_VERIFIES: u32 = 10;
 
-/// Events observed by the sync task that drive [`WarpSyncTracker`] transitions.
+/// Events driving [`WarpSyncTracker`] transitions.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum WarpSyncEvent {
     /// `VerifyWarpSyncFragment` returned `Ok`.
     WarpSyncFragmentVerified,
-    /// An AllForks `VerifyBlock` was processed.
+    /// AllForks `VerifyBlock` was processed.
     AllForksBlockVerified,
     /// `WarpSyncFinished` fired.
     WarpSyncFinished,
 }
 
-/// Side effects the caller must apply after [`WarpSyncTracker::on_event`].
+/// Side effects to apply after [`WarpSyncTracker::on_event`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[must_use]
 pub(crate) struct WarpSyncEffect {
-    /// True when the warp-sync state machine requires
-    /// `task.all_notifications.clear()` so consumers re-subscribe and drop any
-    /// in-flight pre-warp runtime download.
+    /// Caller must `all_notifications.clear()` to force a re-subscribe.
     pub force_resubscribe: bool,
 }
 
 impl WarpSyncEffect {
-    /// Returned by [`WarpSyncTracker::on_event`] when an event does not require
-    /// any action by the caller.
+    /// No action required.
     pub(crate) const fn none() -> Self {
         Self {
             force_resubscribe: false,
@@ -1175,10 +1172,7 @@ impl WarpSyncEffect {
     }
 }
 
-/// Pure state-machine tracking [`WarpSyncState`] independent of the surrounding task plumbing.
-///
-/// Split out so the transitions can be unit-tested without a `PlatformRef` /
-/// network stack.
+/// Pure state-machine for [`WarpSyncState`], testable without `PlatformRef`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) struct WarpSyncTracker {
     state: WarpSyncState,
@@ -1401,8 +1395,7 @@ mod tests {
             tracker.state(),
             WarpSyncState::Finished(FinishedReason::Success)
         );
-        // The gap-driven `all_notifications.clear()` is unrelated to the state
-        // machine; the tracker itself should not request a resubscribe here.
+        // Gap-driven clear() is the caller's, not the tracker's.
         assert_eq!(effects, WarpSyncEffect::none());
     }
 
@@ -1446,7 +1439,7 @@ mod tests {
     fn all_forks_counter_frozen_once_warp_sync_is_in_progress() {
         let mut tracker = WarpSyncTracker::new();
         let _ = tracker.on_event(WarpSyncEvent::WarpSyncFragmentVerified);
-        // Far more AllForks ticks than the termination threshold should not flip the state.
+        // Counter must not advance once past NotStarted.
         for _ in 0..(WARP_SYNC_NOT_NEEDED_AFTER_ALLFORKS_VERIFIES * 3) {
             let effects = tracker.on_event(WarpSyncEvent::AllForksBlockVerified);
             assert_eq!(tracker.state(), WarpSyncState::InProgress);
@@ -1461,7 +1454,7 @@ mod tests {
             WarpSyncState::Finished(FinishedReason::Terminated),
         ] {
             let mut tracker = WarpSyncTracker::new();
-            // Drive the tracker into the target finished state.
+            // Drive to the target finished state.
             match finished {
                 WarpSyncState::Finished(FinishedReason::Success) => {
                     let _ = tracker.on_event(WarpSyncEvent::WarpSyncFinished);

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -1123,7 +1123,6 @@ async fn fetch_parachain_head_from_relay<TPlat: PlatformRef>(
     let mut next_hash = Some(header::hash_from_scale_encoded_header(
         &subscription.finalized_block_scale_encoded_header,
     ));
-    let mut waiting_logged = false;
 
     loop {
         let finalized_hash = if let Some(h) = next_hash.take() {
@@ -1138,15 +1137,12 @@ async fn fetch_parachain_head_from_relay<TPlat: PlatformRef>(
             );
             h
         } else {
-            if !waiting_logged {
-                log!(
-                    platform,
-                    Info,
-                    log_target,
-                    "Waiting for relay chain to finalize a block..."
-                );
-                waiting_logged = true;
-            }
+            log!(
+                platform,
+                Info,
+                log_target,
+                "Waiting for relay chain to finalize a block..."
+            );
             loop {
                 match subscription.new_blocks.next().await {
                     Some(runtime_service::Notification::Finalized { hash, .. }) => {

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -589,6 +589,7 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
                     },
                     non_finalized_blocks_ancestry_order,
                     new_blocks,
+                    warp_sync_state: super::WarpSyncState::NotApplicable,
                 });
             }
 
@@ -1117,28 +1118,55 @@ async fn fetch_parachain_head_from_relay<TPlat: PlatformRef>(
         .subscribe_all(32, NonZero::<usize>::new(usize::MAX).unwrap())
         .await;
 
-    log!(
-        platform,
-        Info,
-        log_target,
-        "Waiting for relay chain to finalize a block..."
-    );
+    // runtime_service withholds the response until warp sync is not `InProgress`, so the
+    // initial header is post-warp and safe to use directly.
+    let mut next_hash = Some(header::hash_from_scale_encoded_header(
+        &subscription.finalized_block_scale_encoded_header,
+    ));
+    let mut waiting_logged = false;
 
     loop {
-        let finalized_hash = loop {
-            match subscription.new_blocks.next().await {
-                Some(runtime_service::Notification::Finalized { hash, .. }) => {
-                    break hash;
-                }
-                Some(_) => continue,
-                None => {
-                    // Subscription died. Re-subscribe.
-                    subscription = relay_chain_sync
-                        .subscribe_all(32, NonZero::<usize>::new(usize::MAX).unwrap())
-                        .await;
-                    break header::hash_from_scale_encoded_header(
-                        &subscription.finalized_block_scale_encoded_header,
-                    );
+        let finalized_hash = if let Some(h) = next_hash.take() {
+            log!(
+                platform,
+                Debug,
+                log_target,
+                format!(
+                    "Using subscription's initial finalized header {}",
+                    HashDisplay(&h)
+                )
+            );
+            h
+        } else {
+            if !waiting_logged {
+                log!(
+                    platform,
+                    Info,
+                    log_target,
+                    "Waiting for relay chain to finalize a block..."
+                );
+                waiting_logged = true;
+            }
+            loop {
+                match subscription.new_blocks.next().await {
+                    Some(runtime_service::Notification::Finalized { hash, .. }) => {
+                        break hash;
+                    }
+                    Some(_) => continue,
+                    None => {
+                        log!(
+                            platform,
+                            Debug,
+                            log_target,
+                            "Re-subscribing to the relay channel"
+                        );
+                        subscription = relay_chain_sync
+                            .subscribe_all(32, NonZero::<usize>::new(usize::MAX).unwrap())
+                            .await;
+                        break header::hash_from_scale_encoded_header(
+                            &subscription.finalized_block_scale_encoded_header,
+                        );
+                    }
                 }
             }
         };

--- a/light-base/src/sync_service/paraheads.rs
+++ b/light-base/src/sync_service/paraheads.rs
@@ -980,6 +980,7 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                         finalized_block_runtime: None,
                         non_finalized_blocks_ancestry_order: Vec::new(),
                         new_blocks,
+                        warp_sync_state: super::WarpSyncState::NotApplicable,
                     });
 
                     all_subscriptions.push(tx);
@@ -1098,6 +1099,7 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                                 list.into_iter().map(|(_, v)| v).collect()
                             },
                             new_blocks,
+                            warp_sync_state: super::WarpSyncState::NotApplicable,
                         });
                     } else {
                         // No known finalized parahead.
@@ -1108,6 +1110,7 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                             finalized_block_runtime: None,
                             non_finalized_blocks_ancestry_order: Vec::new(),
                             new_blocks,
+                            warp_sync_state: super::WarpSyncState::NotApplicable,
                         });
                     }
 

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -17,7 +17,7 @@
 
 use super::{
     BlockNotification, ConfigSubstrateCompatibleRuntimeCodeHint, FinalizedBlockRuntime,
-    Notification, SubscribeAll, ToBackground,
+    FinishedReason, Notification, SubscribeAll, ToBackground, WarpSyncState,
 };
 use crate::{log, network_service, platform::PlatformRef, util};
 
@@ -103,6 +103,8 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
             platform.sleep(Duration::from_secs(10)),
         ))
         .fuse(),
+        warp_sync_state: WarpSyncState::NotStarted,
+        all_forks_verifies_while_not_started: 0,
         all_notifications: Vec::<async_channel::Sender<Notification>>::new(),
         log_target,
         from_network_service: None,
@@ -354,6 +356,14 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                 // Since there is a gap in the blocks, all active notifications to all blocks
                 // must be cleared.
                 task.all_notifications.clear();
+
+                log!(
+                    &task.platform,
+                    Debug,
+                    &task.log_target,
+                    "warp-sync-state-transition; to=Finished(Success)"
+                );
+                task.warp_sync_state = WarpSyncState::Finished(FinishedReason::Success);
             }
 
             WakeUpReason::SyncProcess(all::ProcessOne::VerifyWarpSyncFragment(verify)) => {
@@ -384,6 +394,20 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                             verified_hash = HashDisplay(&fragment_hash),
                             verified_height = fragment_number
                         );
+                        if task.warp_sync_state == WarpSyncState::NotStarted {
+                            log!(
+                                &task.platform,
+                                Debug,
+                                &task.log_target,
+                                "warp-sync-state-transition; to=InProgress (first fragment)"
+                            );
+                            task.warp_sync_state = WarpSyncState::InProgress;
+                            // Force re-subscribe to drop any in-flight pre-warp runtime download.
+                            // If such a download completes, `TreeAdvanceFinalizedUnknown::Finalized` fires
+                            // → tree transitions to `Known(pre-warp)` → `subscribe_all` returns the
+                            // checkpoint hash, which is now stale since warp sync has started.
+                            task.all_notifications.clear();
+                        }
                     }
                     Err(err) => {
                         log!(
@@ -422,6 +446,24 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
             WakeUpReason::SyncProcess(all::ProcessOne::VerifyBlock(verify)) => {
                 // Header to verify.
                 let verified_hash = verify.hash();
+
+                // If only AllForks only works and warp sync not even started then we are
+                // very close to the chain tip, so warp sync not needed.
+                if matches!(task.warp_sync_state, WarpSyncState::NotStarted) {
+                    task.all_forks_verifies_while_not_started =
+                        task.all_forks_verifies_while_not_started.saturating_add(1);
+                    if task.all_forks_verifies_while_not_started >= 10 {
+                        log!(
+                            &task.platform,
+                            Debug,
+                            &task.log_target,
+                            "warp-sync-state-transition; to=Finished(Terminated)"
+                        );
+                        task.warp_sync_state = WarpSyncState::Finished(FinishedReason::Terminated);
+                        task.all_notifications.clear();
+                    }
+                }
+
                 match verify.verify_header(task.platform.now_from_unix_epoch()) {
                     all::HeaderVerifyOutcome::Success {
                         success,
@@ -578,9 +620,18 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                         // Errors of type `JustificationEngineMismatch` indicate that the chain
                         // uses a finality engine that smoldot doesn't recognize. This is a benign
                         // error that shouldn't lead to a ban.
+                        //
+                        // Errors of type `UnknownTargetBlock` are expected during the catch-up
+                        // window that follows a warp sync: the non-finalized tree only contains
+                        // the warp-sync target block, so peers may send justifications for
+                        // higher blocks that the local node hasn't downloaded yet.
+                        // Banning these peers would slow down the catch-up.
                         if !matches!(
                             error,
-                            all::JustificationVerifyError::JustificationEngineMismatch
+                            all::JustificationVerifyError::JustificationEngineMismatch |
+                            all::JustificationVerifyError::FinalityVerify(
+                                smoldot::chain::blocks_tree::FinalityVerifyError::UnknownTargetBlock { .. }
+                            )
                         ) {
                             log!(
                                 &task.platform,
@@ -935,6 +986,7 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                     },
                     non_finalized_blocks_ancestry_order,
                     new_blocks,
+                    warp_sync_state: task.warp_sync_state,
                 });
             }
 
@@ -1451,6 +1503,13 @@ struct Task<TPlat: PlatformRef> {
     pending_requests: stream::FuturesUnordered<
         future::BoxFuture<'static, (all::RequestId, Result<RequestOutcome, future::Aborted>)>,
     >,
+
+    /// Current state of GrandPa warp sync.
+    warp_sync_state: WarpSyncState,
+
+    /// Number of AllForks block verifications observed while [`Task::warp_sync_state`] is
+    /// [`WarpSyncState::NotStarted`]. Used as the "warp sync is not needed" tiebreaker.
+    all_forks_verifies_while_not_started: u32,
 }
 
 enum RequestOutcome {

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -17,7 +17,7 @@
 
 use super::{
     BlockNotification, ConfigSubstrateCompatibleRuntimeCodeHint, FinalizedBlockRuntime,
-    FinishedReason, Notification, SubscribeAll, ToBackground, WarpSyncState,
+    Notification, SubscribeAll, ToBackground, WarpSyncEvent, WarpSyncTracker,
 };
 use crate::{log, network_service, platform::PlatformRef, util};
 
@@ -103,8 +103,7 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
             platform.sleep(Duration::from_secs(10)),
         ))
         .fuse(),
-        warp_sync_state: WarpSyncState::NotStarted,
-        all_forks_verifies_while_not_started: 0,
+        warp_sync: WarpSyncTracker::new(),
         all_notifications: Vec::<async_channel::Sender<Notification>>::new(),
         log_target,
         from_network_service: None,
@@ -357,13 +356,13 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                 // must be cleared.
                 task.all_notifications.clear();
 
+                let _ = task.warp_sync.on_event(WarpSyncEvent::WarpSyncFinished);
                 log!(
                     &task.platform,
                     Debug,
                     &task.log_target,
                     "warp-sync-state-transition; to=Finished(Success)"
                 );
-                task.warp_sync_state = WarpSyncState::Finished(FinishedReason::Success);
             }
 
             WakeUpReason::SyncProcess(all::ProcessOne::VerifyWarpSyncFragment(verify)) => {
@@ -394,14 +393,16 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                             verified_hash = HashDisplay(&fragment_hash),
                             verified_height = fragment_number
                         );
-                        if task.warp_sync_state == WarpSyncState::NotStarted {
+                        let effects = task
+                            .warp_sync
+                            .on_event(WarpSyncEvent::WarpSyncFragmentVerified);
+                        if effects.force_resubscribe {
                             log!(
                                 &task.platform,
                                 Debug,
                                 &task.log_target,
                                 "warp-sync-state-transition; to=InProgress (first fragment)"
                             );
-                            task.warp_sync_state = WarpSyncState::InProgress;
                             // Force re-subscribe to drop any in-flight pre-warp runtime download.
                             // If such a download completes, `TreeAdvanceFinalizedUnknown::Finalized` fires
                             // → tree transitions to `Known(pre-warp)` → `subscribe_all` returns the
@@ -447,22 +448,19 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                 // Header to verify.
                 let verified_hash = verify.hash();
 
-                // If only AllForks only works and warp sync not even started then we are
+                // If only AllForks works and warp sync hasn't even started then we are
                 // very close to the chain tip, so warp sync not needed.
-                if matches!(task.warp_sync_state, WarpSyncState::NotStarted) {
-                    task.all_forks_verifies_while_not_started =
-                        task.all_forks_verifies_while_not_started.saturating_add(1);
-                    // TODO: after how many forks set assume warp-sync terminated?
-                    if task.all_forks_verifies_while_not_started >= 10 {
-                        log!(
-                            &task.platform,
-                            Debug,
-                            &task.log_target,
-                            "warp-sync-state-transition; to=Finished(Terminated)"
-                        );
-                        task.warp_sync_state = WarpSyncState::Finished(FinishedReason::Terminated);
-                        task.all_notifications.clear();
-                    }
+                let effects = task
+                    .warp_sync
+                    .on_event(WarpSyncEvent::AllForksBlockVerified);
+                if effects.force_resubscribe {
+                    log!(
+                        &task.platform,
+                        Debug,
+                        &task.log_target,
+                        "warp-sync-state-transition; to=Finished(Terminated)"
+                    );
+                    task.all_notifications.clear();
                 }
 
                 match verify.verify_header(task.platform.now_from_unix_epoch()) {
@@ -978,7 +976,7 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                     },
                     non_finalized_blocks_ancestry_order,
                     new_blocks,
-                    warp_sync_state: task.warp_sync_state,
+                    warp_sync_state: task.warp_sync.state(),
                 });
             }
 
@@ -1496,12 +1494,8 @@ struct Task<TPlat: PlatformRef> {
         future::BoxFuture<'static, (all::RequestId, Result<RequestOutcome, future::Aborted>)>,
     >,
 
-    /// Current state of GrandPa warp sync.
-    warp_sync_state: WarpSyncState,
-
-    /// Number of AllForks block verifications observed while [`Task::warp_sync_state`] is
-    /// [`WarpSyncState::NotStarted`]. Used as the "warp sync is not needed" tiebreaker.
-    all_forks_verifies_while_not_started: u32,
+    /// Tracker for GrandPa warp sync state and the AllForks early-termination counter.
+    warp_sync: WarpSyncTracker,
 }
 
 enum RequestOutcome {

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -452,6 +452,7 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                 if matches!(task.warp_sync_state, WarpSyncState::NotStarted) {
                     task.all_forks_verifies_while_not_started =
                         task.all_forks_verifies_while_not_started.saturating_add(1);
+                    // TODO: after how many forks set assume warp-sync terminated?
                     if task.all_forks_verifies_while_not_started >= 10 {
                         log!(
                             &task.platform,

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -620,18 +620,9 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                         // Errors of type `JustificationEngineMismatch` indicate that the chain
                         // uses a finality engine that smoldot doesn't recognize. This is a benign
                         // error that shouldn't lead to a ban.
-                        //
-                        // Errors of type `UnknownTargetBlock` are expected during the catch-up
-                        // window that follows a warp sync: the non-finalized tree only contains
-                        // the warp-sync target block, so peers may send justifications for
-                        // higher blocks that the local node hasn't downloaded yet.
-                        // Banning these peers would slow down the catch-up.
                         if !matches!(
                             error,
-                            all::JustificationVerifyError::JustificationEngineMismatch |
-                            all::JustificationVerifyError::FinalityVerify(
-                                smoldot::chain::blocks_tree::FinalityVerifyError::UnknownTargetBlock { .. }
-                            )
+                            all::JustificationVerifyError::JustificationEngineMismatch
                         ) {
                             log!(
                                 &task.platform,

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -403,10 +403,8 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                                 &task.log_target,
                                 "warp-sync-state-transition; to=InProgress (first fragment)"
                             );
-                            // Force re-subscribe to drop any in-flight pre-warp runtime download.
-                            // If such a download completes, `TreeAdvanceFinalizedUnknown::Finalized` fires
-                            // → tree transitions to `Known(pre-warp)` → `subscribe_all` returns the
-                            // checkpoint hash, which is now stale since warp sync has started.
+                            // Drop any in-flight pre-warp runtime download so it can't
+                            // complete and stale the subscribe_all hash.
                             task.all_notifications.clear();
                         }
                     }
@@ -448,8 +446,7 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                 // Header to verify.
                 let verified_hash = verify.hash();
 
-                // If only AllForks works and warp sync hasn't even started then we are
-                // very close to the chain tip, so warp sync not needed.
+                // AllForks-only progress near chain tip: warp sync is unnecessary.
                 let effects = task
                     .warp_sync
                     .on_event(WarpSyncEvent::AllForksBlockVerified);
@@ -1494,7 +1491,7 @@ struct Task<TPlat: PlatformRef> {
         future::BoxFuture<'static, (all::RequestId, Result<RequestOutcome, future::Aborted>)>,
     >,
 
-    /// Tracker for GrandPa warp sync state and the AllForks early-termination counter.
+    /// Warp sync state + AllForks early-termination counter.
     warp_sync: WarpSyncTracker,
 }
 


### PR DESCRIPTION
## Summary

Reintroduces the goal of #3246 (skip the post-warp-sync wait in parachain bootstrap)

**Why:** the previous attempt let a pre-warp runtime download finish after warp sync had started, pinning a stale checkpoint hash in `subscribe_all` and breaking the parachain head lookup.

**How:** the sync service now tracks where warp sync is (not started, in progress, finished). Subscribers see that state at subscription time, and the runtime service uses it to hold off on runtime downloads while warp sync is mid-flight. Once warp sync settles (or AllForks makes enough progress on its own that warp sync is unnecessary), downloads resume and subscribers get a post-warp header.

With that guarantee in place, parachain bootstrap can use the subscription's initial finalized header directly instead of waiting for the next finalized block.

## Test plan
- Unit tests for the warp sync state machine transitions.
- [WIP] JSON-RPC compliance tests
