### PR TITLE
sync_service: upfront bootstrap mode decision

### DIFF
--- a/.github/workflows/zombienet.yml
+++ b/.github/workflows/zombienet.yml
@@ -80,6 +80,15 @@ jobs:
           - job-name: "zombienet-smoldot-0007-bulletin_fetch"
             test: "bulletin_fetch"
             runner-type: "default"
+          - job-name: "zombienet-smoldot-0008-chainhead_v1_follow_fresh"
+            test: "chainhead_v1_follow_fresh"
+            runner-type: "default"
+          - job-name: "zombienet-smoldot-0009-chainhead_v1_follow_cold"
+            test: "chainhead_v1_follow_cold"
+            runner-type: "default"
+          - job-name: "zombienet-smoldot-0010-chainhead_v1_follow_warm"
+            test: "chainhead_v1_follow_warm"
+            runner-type: "default"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/demo-chain-specs/paseo_asset_hub_next.json
+++ b/demo-chain-specs/paseo_asset_hub_next.json
@@ -1,0 +1,21 @@
+{
+  "name": "Paseo Asset Hub Next",
+  "id": "next-asset-hub-paseo",
+  "chainType": "Live",
+  "bootNodes": [
+    "/dns/paseo-asset-hub-next-collator-node-0.parity-testnet.parity.io/tcp/443/wss/p2p/12D3KooWKT5DcVLoBbVDAM6N5ujDVknPfQWHk8SGJqJPyAM8Z4Y4",
+    "/dns/paseo-asset-hub-next-collator-node-1.parity-testnet.parity.io/tcp/443/wss/p2p/12D3KooWFjpVdBnfJFntogWhinn15WW2n8Fd2DiAcqU6i9rg47Yg"
+  ],
+  "telemetryEndpoints": null,
+  "protocolId": null,
+  "properties": {
+    "tokenDecimals": 10,
+    "tokenSymbol": "PAS"
+  },
+  "relay_chain": "paseo",
+  "para_id": 1500,
+  "codeSubstitutes": {},
+  "genesis": {
+    "stateRootHash": "0xf60bedeca8d9c1cd928473b6fb4bc4e42896636dd783acf55d3800938dcdb24a"
+  }
+}

--- a/demo-chain-specs/paseo_asset_hub_next.json
+++ b/demo-chain-specs/paseo_asset_hub_next.json
@@ -16,6 +16,6 @@
   "para_id": 1500,
   "codeSubstitutes": {},
   "genesis": {
-    "stateRootHash": "0xf60bedeca8d9c1cd928473b6fb4bc4e42896636dd783acf55d3800938dcdb24a"
+    "stateRootHash": "0x9202fc20d789aecfb88faf17dca27d42f8b90cf0a0b02c96d7024585864b7271"
   }
 }

--- a/e2e-tests/js/chainhead_v1_follow_test.js
+++ b/e2e-tests/js/chainhead_v1_follow_test.js
@@ -1,0 +1,637 @@
+// Smoldot
+// Copyright (C) 2019-2026  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// chainHead_v1_follow conformance + regression driver.
+//
+// Subscribes the para chain (withRuntime=true), validates the spec invariants
+// of every event, and on resubscribe (after `stop` or explicit unfollow)
+// reports a regression if the new initial finalized number is below the
+// previous subscription's last finalized number.
+
+import * as fs from "node:fs";
+import {
+  createSmoldotClient,
+  addChainFromSpec,
+  readDbContentIfSet,
+  sendRpc,
+  sendRpcAndWait,
+  report,
+} from "./helpers.js";
+
+// TODO: refactor env hell
+const relaySpecPath = process.env.RELAY_CHAIN_SPEC;
+const paraSpecPath = process.env.PARA_CHAIN_SPEC;
+const withRuntime = (process.env.WITH_RUNTIME ?? "true") === "true";
+const minNewBlocks = Number.parseInt(process.env.MIN_NEW_BLOCKS ?? "5", 10);
+const minFinalized = Number.parseInt(process.env.MIN_FINALIZED_EVENTS ?? "2", 10);
+const testResubscribe = (process.env.TEST_RESUBSCRIBE ?? "true") === "true";
+const overallTimeoutMs = Number.parseInt(process.env.OVERALL_TIMEOUT_MS ?? "300000", 10);
+const perSubTimeoutMs = Number.parseInt(process.env.PER_SUB_TIMEOUT_MS ?? "180000", 10);
+const relayBestAtLaunch = Number.parseInt(process.env.RELAY_BEST_AT_LAUNCH ?? "0", 10);
+const relayFinalizedAtLaunch = Number.parseInt(process.env.RELAY_FINALIZED_AT_LAUNCH ?? "0", 10);
+const paraBestAtLaunch = Number.parseInt(process.env.PARA_BEST_AT_LAUNCH ?? "0", 10);
+const paraFinalizedAtLaunch = Number.parseInt(process.env.PARA_FINALIZED_AT_LAUNCH ?? "0", 10);
+const initialLagTolerance = Number.parseInt(process.env.INITIAL_LAG_TOLERANCE ?? "50", 10);
+const dbDumpDir = process.env.SMOLDOT_DB_DUMP_DIR || null;
+
+if (!relaySpecPath || !paraSpecPath) {
+  console.error("Required env vars: RELAY_CHAIN_SPEC, PARA_CHAIN_SPEC");
+  process.exit(1);
+}
+
+// Decodes a hex SCALE-encoded substrate header and returns its parent hash
+// and block number. Header layout: parent_hash (32 B) | compact-encoded
+// number | state_root (32 B) | extrinsics_root (32 B) | digest.
+function decodeHeader(hexStr) {
+  const stripped = hexStr.startsWith("0x") ? hexStr.slice(2) : hexStr;
+  const bytes = Buffer.from(stripped, "hex");
+  if (bytes.length < 33) throw new Error(`header hex too short: ${bytes.length} bytes`);
+  const parentHash = "0x" + bytes.subarray(0, 32).toString("hex");
+  const off = 32;
+  const b0 = bytes[off];
+  const mode = b0 & 0b11;
+  let number;
+  if (mode === 0) number = b0 >>> 2;
+  else if (mode === 1) number = (b0 | (bytes[off + 1] << 8)) >>> 2;
+  else if (mode === 2) {
+    number = (b0 | (bytes[off + 1] << 8) | (bytes[off + 2] << 16) | (bytes[off + 3] << 24)) >>> 2;
+  } else {
+    throw new Error("compact mode 3 not supported");
+  }
+  return { number, parentHash };
+}
+
+// Multiplexes a smoldot chain's JSON-RPC stream. One pump loop classifies each
+// message into either a `chainHead_v1_followEvent` (queued by subId, awaited
+// via nextEvent) or an id-bearing response (resolved against pending requests
+// via request). Without this, calling chainHead_v1_header from inside the
+// event loop would drop events arriving between request and response.
+class JsonRpcMux {
+  constructor(chain) {
+    this.chain = chain;
+    this.eventQueues = new Map();
+    this.eventWaiters = new Map();
+    this.pendingById = new Map();
+    this.errors = [];
+    this._loop();
+  }
+
+  async _loop() {
+    while (true) {
+      let raw;
+      try {
+        raw = await this.chain.nextJsonRpcResponse();
+      } catch (e) {
+        this.errors.push(e);
+        return;
+      }
+      let msg;
+      try {
+        msg = JSON.parse(raw);
+      } catch (e) {
+        this.errors.push(new Error(`malformed JSON: ${raw}`));
+        continue;
+      }
+      if (msg.method === "chainHead_v1_followEvent") {
+        const sub = msg.params?.subscription;
+        if (!sub) continue;
+        const waiters = this.eventWaiters.get(sub);
+        if (waiters && waiters.length > 0) {
+          waiters.shift()(msg.params.result);
+        } else {
+          if (!this.eventQueues.has(sub)) this.eventQueues.set(sub, []);
+          this.eventQueues.get(sub).push(msg.params.result);
+        }
+      } else if (msg.id != null) {
+        const resolver = this.pendingById.get(msg.id);
+        if (resolver) {
+          this.pendingById.delete(msg.id);
+          resolver(msg);
+        }
+      }
+    }
+  }
+
+  nextEvent(subId, timeoutMs) {
+    const q = this.eventQueues.get(subId);
+    if (q && q.length > 0) return Promise.resolve(q.shift());
+    return new Promise((resolve, reject) => {
+      const wrapped = (val) => {
+        clearTimeout(timer);
+        resolve(val);
+      };
+      const timer = setTimeout(() => {
+        const waiters = this.eventWaiters.get(subId);
+        if (waiters) {
+          const idx = waiters.indexOf(wrapped);
+          if (idx >= 0) waiters.splice(idx, 1);
+        }
+        reject(new Error(`timeout waiting for event on ${subId} after ${timeoutMs}ms`));
+      }, timeoutMs);
+      if (!this.eventWaiters.has(subId)) this.eventWaiters.set(subId, []);
+      this.eventWaiters.get(subId).push(wrapped);
+    });
+  }
+
+  request(method, params, timeoutMs) {
+    const id = sendRpc(this.chain, method, params).toString();
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingById.delete(id);
+        reject(new Error(`timeout waiting for ${method} response`));
+      }, timeoutMs);
+      this.pendingById.set(id, (msg) => {
+        clearTimeout(timer);
+        if (msg.error) {
+          reject(new Error(`${method}: ${JSON.stringify(msg.error)}`));
+        } else {
+          resolve(msg.result);
+        }
+      });
+    });
+  }
+}
+
+// Spec-conformance + regression validator for one chainHead_v1_follow stream.
+// State is per-subscription; counters accumulate across subscriptions via
+// `beginNewSubscription`. Violations push into `violations` and are surfaced
+// at the end so a single test can collect several before exiting.
+class ChainHeadValidator {
+  constructor(opts) {
+    this.withRuntime = opts.withRuntime;
+    this.subscriptionCount = 0;
+    this.counters = {
+      initialized: 0,
+      newBlock: 0,
+      bestBlockChanged: 0,
+      finalized: 0,
+      stop: 0,
+    };
+    this.violations = [];
+    this.regressions = [];
+    this.previousSub = null;
+    this._resetSubState();
+  }
+
+  _resetSubState() {
+    for (const k of Object.keys(this.counters)) this.counters[k] = 0;
+    this.subLabel = `sub#${this.subscriptionCount}`;
+    this.knownHashes = new Set();
+    this.parents = new Map();
+    this.heights = new Map();
+    this.currentBest = null;
+    this.initialFinalizedHash = null;
+    this.lastFinalizedHash = null;
+    this.lastFinalizedNumber = null;
+    this.initialFinalizedNumber = null;
+    this.initialized = false;
+    this.stopped = false;
+  }
+
+  beginNewSubscription() {
+    if (this.initialized) {
+      this.previousSub = {
+        lastFinalizedHash: this.lastFinalizedHash,
+        lastFinalizedNumber: this.lastFinalizedNumber,
+        initialFinalizedNumber: this.initialFinalizedNumber,
+      };
+    }
+    this.subscriptionCount += 1;
+    this._resetSubState();
+  }
+
+  violation(msg) {
+    const full = `[${this.subLabel}] ${msg}`;
+    this.violations.push(full);
+    console.error(`VIOLATION ${full}`);
+  }
+
+  regression(msg) {
+    const full = `[${this.subLabel}] ${msg}`;
+    this.regressions.push(full);
+    console.error(`REGRESSION ${full}`);
+  }
+
+  onEvent(event) {
+    if (this.stopped) {
+      this.violation(`event ${event.event} arrived after stop`);
+      return;
+    }
+    switch (event.event) {
+      case "initialized":
+        this._onInitialized(event);
+        break;
+      case "newBlock":
+        this._onNewBlock(event);
+        break;
+      case "bestBlockChanged":
+        this._onBestBlockChanged(event);
+        break;
+      case "finalized":
+        this._onFinalized(event);
+        break;
+      case "stop":
+        this.stopped = true;
+        this.counters.stop += 1;
+        break;
+      default:
+        if (typeof event.event === "string" && event.event.startsWith("operation")) {
+          this.violation(`unexpected operation event: ${event.event}`);
+        } else {
+          this.violation(`unknown event kind: ${JSON.stringify(event.event)}`);
+        }
+    }
+  }
+
+  _onInitialized(event) {
+    if (this.initialized) {
+      this.violation("duplicate initialized event");
+      return;
+    }
+    const hashes = event.finalizedBlockHashes;
+    if (!Array.isArray(hashes) || hashes.length === 0) {
+      this.violation("initialized.finalizedBlockHashes empty");
+      return;
+    }
+    if (this.withRuntime && !event.finalizedBlockRuntime) {
+      this.violation("initialized.finalizedBlockRuntime missing with withRuntime=true");
+    }
+    for (const h of hashes) this.knownHashes.add(h);
+    this.initialFinalizedHash = hashes[hashes.length - 1];
+    this.lastFinalizedHash = this.initialFinalizedHash;
+    this.initialized = true;
+    this.counters.initialized += 1;
+  }
+
+  _onNewBlock(event) {
+    if (!this.initialized) {
+      this.violation(`newBlock before initialized: ${event.blockHash}`);
+      return;
+    }
+    if (this.knownHashes.has(event.blockHash)) {
+      this.violation(`duplicate newBlock: ${event.blockHash}`);
+      return;
+    }
+    if (!this.knownHashes.has(event.parentBlockHash)) {
+      this.violation(
+        `newBlock parent unknown: parent=${event.parentBlockHash} block=${event.blockHash}`,
+      );
+      return;
+    }
+    this.knownHashes.add(event.blockHash);
+    this.parents.set(event.blockHash, event.parentBlockHash);
+    this.counters.newBlock += 1;
+  }
+
+  _onBestBlockChanged(event) {
+    if (!this.initialized) {
+      this.violation(`bestBlockChanged before initialized: ${event.bestBlockHash}`);
+      return;
+    }
+    if (!this.knownHashes.has(event.bestBlockHash)) {
+      this.violation(`bestBlockChanged hash unknown: ${event.bestBlockHash}`);
+      return;
+    }
+    this.currentBest = event.bestBlockHash;
+    this.counters.bestBlockChanged += 1;
+  }
+
+  _onFinalized(event) {
+    if (!this.initialized) {
+      this.violation("finalized before initialized");
+      return;
+    }
+    const finalizedHashes = event.finalizedBlockHashes ?? [];
+    const prunedHashes = event.prunedBlockHashes ?? [];
+    if (finalizedHashes.length === 0) {
+      this.violation("finalized.finalizedBlockHashes empty");
+      return;
+    }
+    for (const h of finalizedHashes) {
+      if (!this.knownHashes.has(h)) {
+        this.violation(`finalized hash unknown: ${h}`);
+        return;
+      }
+    }
+    for (const h of prunedHashes) {
+      if (!this.knownHashes.has(h)) {
+        this.violation(`pruned hash unknown: ${h}`);
+        return;
+      }
+    }
+    // Chain check: the first finalized's parent must be the previous last finalized;
+    // every subsequent block must chain to its predecessor in the list.
+    let prev = this.lastFinalizedHash;
+    for (const h of finalizedHashes) {
+      const parent = this.parents.get(h);
+      if (parent && parent !== prev) {
+        this.violation(
+          `finalized chain break: ${h} parent=${parent} expected=${prev}`,
+        );
+        return;
+      }
+      prev = h;
+    }
+    for (const h of prunedHashes) {
+      this.knownHashes.delete(h);
+      this.parents.delete(h);
+      this.heights.delete(h);
+    }
+    this.lastFinalizedHash = finalizedHashes[finalizedHashes.length - 1];
+    this.counters.finalized += 1;
+  }
+
+  recordInitialFinalizedNumber(n) {
+    this.initialFinalizedNumber = n;
+    this.lastFinalizedNumber = n;
+    this.heights.set(this.initialFinalizedHash, n);
+    if (
+      this.previousSub &&
+      this.previousSub.lastFinalizedNumber != null &&
+      n < this.previousSub.lastFinalizedNumber
+    ) {
+      this.regression(
+        `new initial finalized #${n} < previous last finalized #${this.previousSub.lastFinalizedNumber}`,
+      );
+    }
+    if (
+      paraFinalizedAtLaunch > 0 &&
+      n + initialLagTolerance < paraFinalizedAtLaunch
+    ) {
+      this.regression(
+        `initial finalized #${n} lags more than ${initialLagTolerance} behind para finalized at launch #${paraFinalizedAtLaunch}`,
+      );
+    }
+  }
+
+  setHeight(hash, n) {
+    this.heights.set(hash, n);
+    if (hash === this.lastFinalizedHash) {
+      this.lastFinalizedNumber = n;
+    }
+  }
+
+  thresholdsMet() {
+    return (
+      this.counters.newBlock >= minNewBlocks && this.counters.finalized >= minFinalized
+    );
+  }
+}
+
+// Returns `null` when smoldot reports the block as not available (spec-legal:
+// the block is part of the announced chain but smoldot has no header for it
+// at this moment — transient pin/unpin state). Caller skips height tracking
+// and the parent-hash cross-check for that block.
+async function fetchBlockHeader(mux, subId, hash) {
+  const headerHex = await mux.request("chainHead_v1_header", [subId, hash], 30_000);
+  if (headerHex == null) return null;
+  return decodeHeader(headerHex);
+}
+
+async function populateHeader(mux, subId, validator, hash, announcedParent) {
+  if (!hash || validator.heights.has(hash)) return;
+  const header = await fetchBlockHeader(mux, subId, hash);
+  if (header == null) return;
+  validator.setHeight(hash, header.number);
+  if (announcedParent != null && announcedParent !== header.parentHash) {
+    validator.violation(
+      `announced parent ${shortHash(announcedParent)} for block ${shortHash(hash)} #${header.number} mismatches header parent ${shortHash(header.parentHash)}`,
+    );
+  }
+}
+
+function shortHash(h) {
+  if (!h) return "<none>";
+  if (!h.startsWith("0x") || h.length < 12) return h;
+  return `${h.slice(0, 6)}…${h.slice(-4)}`;
+}
+
+function heightStr(validator, hash) {
+  const h = validator.heights.get(hash);
+  return h != null ? `#${h}` : "#?";
+}
+
+function logEvent(label, event, validator) {
+  const name = event.event.padEnd(16);
+  switch (event.event) {
+    case "initialized": {
+      const last = validator.initialFinalizedHash;
+      console.log(`[${label}] ${name} ${heightStr(validator, last)} ${shortHash(last)}`);
+      break;
+    }
+    case "newBlock":
+      console.log(
+        `[${label}] ${name} ${heightStr(validator, event.blockHash)} ${shortHash(event.blockHash)} parent=${shortHash(event.parentBlockHash)}`,
+      );
+      break;
+    case "bestBlockChanged":
+      console.log(
+        `[${label}] ${name} ${heightStr(validator, event.bestBlockHash)} ${shortHash(event.bestBlockHash)}`,
+      );
+      break;
+    case "finalized": {
+      const f = event.finalizedBlockHashes ?? [];
+      const p = event.prunedBlockHashes ?? [];
+      const last = f[f.length - 1];
+      console.log(
+        `[${label}] ${name} ${heightStr(validator, last)} ${shortHash(last)} finalized_cnt=${f.length} pruned_cnt=${p.length}`,
+      );
+      break;
+    }
+    case "stop":
+      console.log(`[${label}] ${name}`);
+      break;
+    default:
+      break;
+  }
+}
+
+async function followSubscription(mux) {
+  const subId = await mux.request("chainHead_v1_follow", [withRuntime], 30_000);
+  if (typeof subId !== "string" || !subId) {
+    throw new Error(`Unexpected follow subscription id: ${JSON.stringify(subId)}`);
+  }
+  return subId;
+}
+
+async function runSubscription(mux, validator, subId, perSubDeadline, isDone) {
+  // First event must be `initialized`.
+  const first = await mux.nextEvent(subId, perSubDeadline - Date.now());
+  validator.onEvent(first);
+  if (first.event !== "initialized") {
+    throw new Error(`first event was ${first.event}, expected initialized`);
+  }
+  const initialHeader = await fetchBlockHeader(mux, subId, validator.initialFinalizedHash);
+  if (initialHeader != null) {
+    validator.recordInitialFinalizedNumber(initialHeader.number);
+  } else {
+    console.error(
+      `[${validator.subLabel}] chainHead_v1_header returned null for initial finalized; number-based checks for this sub skipped`,
+    );
+  }
+  logEvent(validator.subLabel, first, validator);
+
+  while (!validator.stopped && Date.now() < perSubDeadline) {
+    if (isDone()) return { reason: "done" };
+    let ev;
+    try {
+      ev = await mux.nextEvent(subId, Math.max(1, perSubDeadline - Date.now()));
+    } catch (e) {
+      return { reason: "per_sub_timeout" };
+    }
+    validator.onEvent(ev);
+    switch (ev.event) {
+      case "newBlock":
+        await populateHeader(mux, subId, validator, ev.blockHash, ev.parentBlockHash);
+        break;
+      case "bestBlockChanged":
+        await populateHeader(mux, subId, validator, ev.bestBlockHash, null);
+        break;
+      case "finalized": {
+        const f = ev.finalizedBlockHashes ?? [];
+        await populateHeader(mux, subId, validator, f[f.length - 1], null);
+        break;
+      }
+      default:
+        break;
+    }
+    logEvent(validator.subLabel, ev, validator);
+  }
+
+  if (validator.stopped) return { reason: "stop" };
+  if (isDone()) return { reason: "done" };
+  return { reason: "per_sub_timeout" };
+}
+
+const client = createSmoldotClient();
+let relay;
+let para;
+let exitOk = false;
+
+try {
+  const relayDbContent = readDbContentIfSet("SMOLDOT_DB_RELAY");
+  const paraDbContent = readDbContentIfSet("SMOLDOT_DB_PARA");
+
+  console.log(
+    `network at launch: relay best=#${relayBestAtLaunch} finalized=#${relayFinalizedAtLaunch} | para best=#${paraBestAtLaunch} finalized=#${paraFinalizedAtLaunch} (lag tolerance=${initialLagTolerance})`,
+  );
+
+  relay = await addChainFromSpec(client, relaySpecPath, { databaseContent: relayDbContent });
+  report("addChain relay", true);
+
+  para = await addChainFromSpec(client, paraSpecPath, {
+    databaseContent: paraDbContent,
+    potentialRelayChains: [relay],
+  });
+  report("addChain parachain", true);
+
+  const mux = new JsonRpcMux(para);
+  const validator = new ChainHeadValidator({ withRuntime });
+  const overallDeadline = Date.now() + overallTimeoutMs;
+
+  // Phase 1: primary subscription. Auto-resubscribe on `stop` until thresholds met or budget gone.
+  validator.beginNewSubscription();
+  let subId = await followSubscription(mux);
+  report("chainHead_v1_follow accepted", true, `subId=${subId}`);
+  let result;
+  do {
+    if (result?.reason === "stop") {
+      console.log(`[${validator.subLabel}] received stop, resubscribing`);
+      validator.beginNewSubscription();
+      subId = await followSubscription(mux);
+    }
+    result = await runSubscription(
+      mux,
+      validator,
+      subId,
+      Math.min(Date.now() + perSubTimeoutMs, overallDeadline),
+      () => validator.thresholdsMet(),
+    );
+  } while (result.reason === "stop" && Date.now() < overallDeadline);
+
+  const primaryOk = validator.thresholdsMet();
+  report(
+    "primary subscription thresholds met",
+    primaryOk,
+    `newBlock=${validator.counters.newBlock}/${minNewBlocks} finalized=${validator.counters.finalized}/${minFinalized}`,
+  );
+
+  // Phase 2: explicit resubscribe. Same thresholds; counters reset per sub.
+  if (testResubscribe && primaryOk && Date.now() < overallDeadline) {
+    try {
+      await mux.request("chainHead_v1_unfollow", [subId], 30_000);
+      report("chainHead_v1_unfollow accepted", true, `subId=${subId}`);
+    } catch (e) {
+      report("chainHead_v1_unfollow accepted", false, e.message);
+    }
+    validator.beginNewSubscription();
+    let phase2SubId = await followSubscription(mux);
+    report("chainHead_v1_follow after unfollow accepted", true, `subId=${phase2SubId}`);
+    let phase2Result;
+    do {
+      if (phase2Result?.reason === "stop") {
+        console.log(`[${validator.subLabel}] received stop, resubscribing`);
+        validator.beginNewSubscription();
+        phase2SubId = await followSubscription(mux);
+      }
+      phase2Result = await runSubscription(
+        mux,
+        validator,
+        phase2SubId,
+        Math.min(Date.now() + perSubTimeoutMs, overallDeadline),
+        () => validator.thresholdsMet(),
+      );
+    } while (phase2Result.reason === "stop" && Date.now() < overallDeadline);
+    const phase2Ok = validator.thresholdsMet();
+    report(
+      "resubscribe phase thresholds met",
+      phase2Ok,
+      `newBlock=${validator.counters.newBlock}/${minNewBlocks} finalized=${validator.counters.finalized}/${minFinalized}`,
+    );
+  }
+
+  const reportList = (name, items) => {
+    const suffix = `${items.length} issue${items.length === 1 ? "" : "s"}`;
+    report(name, items.length === 0, suffix);
+    for (const item of items) console.log(`  ${item}`);
+  };
+  reportList("no spec violations", validator.violations);
+  reportList("no regressions", validator.regressions);
+
+  if (dbDumpDir && validator.violations.length === 0) {
+    try {
+      fs.mkdirSync(dbDumpDir, { recursive: true });
+      // Relay has no mux, so use sendRpcAndWait directly. Para is muxed.
+      const relayDb = await sendRpcAndWait(relay, "chainHead_unstable_finalizedDatabase", [], 30_000);
+      const paraDb = await mux.request("chainHead_unstable_finalizedDatabase", [], 30_000);
+      fs.writeFileSync(`${dbDumpDir}/relay.json`, relayDb);
+      fs.writeFileSync(`${dbDumpDir}/para.json`, paraDb);
+      report("dumped smoldot databaseContent", true, dbDumpDir);
+    } catch (e) {
+      report("dumped smoldot databaseContent", false, e.message);
+    }
+  }
+
+  exitOk =
+    validator.violations.length === 0 &&
+    validator.regressions.length === 0 &&
+    primaryOk;
+} catch (e) {
+  report("chainhead_v1_follow_test", false, e.message);
+}
+
+process.exit(exitOk && !process.exitCode ? 0 : 1);

--- a/e2e-tests/run_chainhead_test.sh
+++ b/e2e-tests/run_chainhead_test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Launches chainhead_v1_follow_test.js against a live public network. Picks
+# bundled chain specs from demo-chain-specs/ by network name and (when an RPC
+# URL is configured) queries the parachain's current finalized height so the
+# validator's lag-regression check is meaningful.
+#
+# Usage:
+#   ./run_chainhead_test.sh <network>
+#
+# Supported networks (asset-hub para by default):
+#   paseo, polkadot, kusama, westend
+
+set -euo pipefail
+
+network="${1:-paseo}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SPECS_DIR="${REPO_ROOT}/demo-chain-specs"
+
+case "${network}" in
+  paseo)
+    relay_spec="${SPECS_DIR}/paseo.json"
+    para_spec="${SPECS_DIR}/paseo_asset_hub.json"
+    relay_rpc="https://paseo-rpc.n.dwellir.com"
+    para_rpc="https://asset-hub-paseo-rpc.n.dwellir.com"
+    ;;
+  paseo-next)
+    relay_spec="${SPECS_DIR}/paseo.json"
+    para_spec="${SPECS_DIR}/paseo_asset_hub_next.json"
+    relay_rpc="https://paseo-rpc.n.dwellir.com"
+    para_rpc="" # TODO
+    ;;
+  polkadot)
+    relay_spec="${SPECS_DIR}/polkadot.json"
+    para_spec="${SPECS_DIR}/polkadot_asset_hub.json"
+    relay_rpc=""  # TODO: set Polkadot relay RPC URL
+    para_rpc=""  # TODO: set Polkadot Asset Hub RPC URL
+    ;;
+  kusama)
+    relay_spec="${SPECS_DIR}/ksmcc3.json"
+    para_spec="${SPECS_DIR}/ksmcc3_asset_hub.json"
+    relay_rpc=""  # TODO: set Kusama relay RPC URL
+    para_rpc=""  # TODO: set Kusama Asset Hub RPC URL
+    ;;
+  westend)
+    relay_spec="${SPECS_DIR}/westend2.json"
+    para_spec="${SPECS_DIR}/westend2_asset_hub.json"
+    relay_rpc=""  # TODO: set Westend relay RPC URL
+    para_rpc=""  # TODO: set Westend Asset Hub RPC URL
+    ;;
+  *)
+    echo "Unknown network: ${network}" >&2
+    echo "Supported: paseo, polkadot, kusama, westend" >&2
+    exit 1
+    ;;
+esac
+
+RELAY_CHAIN_SPEC="${RELAY_CHAIN_SPEC:-${relay_spec}}"
+PARA_CHAIN_SPEC="${PARA_CHAIN_SPEC:-${para_spec}}"
+RELAY_RPC_URL="${RELAY_RPC_URL:-${relay_rpc}}"
+PARA_RPC_URL="${PARA_RPC_URL:-${para_rpc}}"
+
+if [[ ! -f "${RELAY_CHAIN_SPEC}" ]]; then
+  echo "Relay chain spec not found: ${RELAY_CHAIN_SPEC}" >&2
+  exit 1
+fi
+if [[ ! -f "${PARA_CHAIN_SPEC}" ]]; then
+  echo "Para chain spec not found: ${PARA_CHAIN_SPEC}" >&2
+  exit 1
+fi
+
+# Echoes the decimal block number for the head returned by `${head_method}` on
+# `${url}`, or empty string on failure.
+fetch_head_number() {
+  local url="$1" head_method="$2"
+  local hash number_hex
+  hash=$(curl -fsS -H 'Content-Type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"${head_method}\"}" \
+    "${url}" | jq -r '.result' 2>/dev/null || true)
+  [[ -z "${hash}" || "${hash}" == "null" ]] && return 0
+  number_hex=$(curl -fsS -H 'Content-Type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"chain_getHeader\",\"params\":[\"${hash}\"]}" \
+    "${url}" | jq -r '.result.number' 2>/dev/null || true)
+  [[ -z "${number_hex}" || "${number_hex}" == "null" ]] && return 0
+  printf '%d' "${number_hex}"
+}
+
+RELAY_FINALIZED_AT_LAUNCH="${RELAY_FINALIZED_AT_LAUNCH:-0}"
+RELAY_BEST_AT_LAUNCH="${RELAY_BEST_AT_LAUNCH:-0}"
+if [[ -n "${RELAY_RPC_URL}" ]]; then
+  echo "Fetching relay best + finalized from ${RELAY_RPC_URL}..." >&2
+  if [[ "${RELAY_FINALIZED_AT_LAUNCH}" == "0" ]]; then
+    RELAY_FINALIZED_AT_LAUNCH=$(fetch_head_number "${RELAY_RPC_URL}" "chain_getFinalizedHead")
+    RELAY_FINALIZED_AT_LAUNCH="${RELAY_FINALIZED_AT_LAUNCH:-0}"
+  fi
+  if [[ "${RELAY_BEST_AT_LAUNCH}" == "0" ]]; then
+    RELAY_BEST_AT_LAUNCH=$(fetch_head_number "${RELAY_RPC_URL}" "chain_getHead")
+    RELAY_BEST_AT_LAUNCH="${RELAY_BEST_AT_LAUNCH:-0}"
+  fi
+  echo "Relay at launch: best=#${RELAY_BEST_AT_LAUNCH} finalized=#${RELAY_FINALIZED_AT_LAUNCH}" >&2
+fi
+if [[ "${RELAY_FINALIZED_AT_LAUNCH}" == "0" ]]; then
+  echo "Relay lag-regression check disabled (no RELAY_FINALIZED_AT_LAUNCH)." >&2
+fi
+
+PARA_FINALIZED_AT_LAUNCH="${PARA_FINALIZED_AT_LAUNCH:-0}"
+PARA_BEST_AT_LAUNCH="${PARA_BEST_AT_LAUNCH:-0}"
+if [[ -n "${PARA_RPC_URL}" ]]; then
+  echo "Fetching para best + finalized from ${PARA_RPC_URL}..." >&2
+  if [[ "${PARA_FINALIZED_AT_LAUNCH}" == "0" ]]; then
+    PARA_FINALIZED_AT_LAUNCH=$(fetch_head_number "${PARA_RPC_URL}" "chain_getFinalizedHead")
+    PARA_FINALIZED_AT_LAUNCH="${PARA_FINALIZED_AT_LAUNCH:-0}"
+  fi
+  if [[ "${PARA_BEST_AT_LAUNCH}" == "0" ]]; then
+    PARA_BEST_AT_LAUNCH=$(fetch_head_number "${PARA_RPC_URL}" "chain_getHead")
+    PARA_BEST_AT_LAUNCH="${PARA_BEST_AT_LAUNCH:-0}"
+  fi
+  echo "Para at launch: best=#${PARA_BEST_AT_LAUNCH} finalized=#${PARA_FINALIZED_AT_LAUNCH}" >&2
+fi
+if [[ "${PARA_FINALIZED_AT_LAUNCH}" == "0" ]]; then
+  echo "Para lag-regression check disabled (no PARA_FINALIZED_AT_LAUNCH)." >&2
+fi
+
+# Opt-in DB caching: set SMOLDOT_DB_DUMP_DIR to dump on success and to auto-load
+# any previously-dumped DBs from the same directory on subsequent runs.
+if [[ -n "${SMOLDOT_DB_DUMP_DIR:-}" ]]; then
+  if [[ -z "${SMOLDOT_DB_RELAY:-}" && -f "${SMOLDOT_DB_DUMP_DIR}/relay.json" ]]; then
+    SMOLDOT_DB_RELAY="${SMOLDOT_DB_DUMP_DIR}/relay.json"
+  fi
+  if [[ -z "${SMOLDOT_DB_PARA:-}" && -f "${SMOLDOT_DB_DUMP_DIR}/para.json" ]]; then
+    SMOLDOT_DB_PARA="${SMOLDOT_DB_DUMP_DIR}/para.json"
+  fi
+  if [[ -n "${SMOLDOT_DB_RELAY:-}" || -n "${SMOLDOT_DB_PARA:-}" ]]; then
+    echo "Warm-loading smoldot DBs from ${SMOLDOT_DB_DUMP_DIR}" >&2
+  else
+    echo "Cold start. DBs will be dumped to ${SMOLDOT_DB_DUMP_DIR} on success." >&2
+  fi
+fi
+
+cd "${SCRIPT_DIR}"
+exec env \
+  RELAY_CHAIN_SPEC="${RELAY_CHAIN_SPEC}" \
+  PARA_CHAIN_SPEC="${PARA_CHAIN_SPEC}" \
+  RELAY_FINALIZED_AT_LAUNCH="${RELAY_FINALIZED_AT_LAUNCH}" \
+  RELAY_BEST_AT_LAUNCH="${RELAY_BEST_AT_LAUNCH}" \
+  PARA_FINALIZED_AT_LAUNCH="${PARA_FINALIZED_AT_LAUNCH}" \
+  PARA_BEST_AT_LAUNCH="${PARA_BEST_AT_LAUNCH}" \
+  SMOLDOT_DB_RELAY="${SMOLDOT_DB_RELAY:-}" \
+  SMOLDOT_DB_PARA="${SMOLDOT_DB_PARA:-}" \
+  SMOLDOT_DB_DUMP_DIR="${SMOLDOT_DB_DUMP_DIR:-}" \
+  MIN_NEW_BLOCKS="${MIN_NEW_BLOCKS:-5}" \
+  MIN_FINALIZED_EVENTS="${MIN_FINALIZED_EVENTS:-2}" \
+  PER_SUB_TIMEOUT_MS="${PER_SUB_TIMEOUT_MS:-600000}" \
+  OVERALL_TIMEOUT_MS="${OVERALL_TIMEOUT_MS:-900000}" \
+  SMOLDOT_LOG_LEVEL="${SMOLDOT_LOG_LEVEL:-2}" \
+  node js/chainhead_v1_follow_test.js

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -23,8 +23,8 @@ pub mod snapshot;
 pub mod statement;
 
 pub use network::{
-    run_smoke_js, spawn_scenario, spawned_chain_spec_paths, LiveNetwork, Scenario, SmoldotDbPaths,
-    SnapshotPaths, BEST_METRIC, FINALIZED_METRIC, PARA_ID,
+    run_chainhead_v1_follow_js, run_smoke_js, spawn_scenario, spawned_chain_spec_paths,
+    LiveNetwork, Scenario, SmoldotDbPaths, SnapshotPaths, BEST_METRIC, FINALIZED_METRIC, PARA_ID,
 };
 
 /// A file-backed Rust → JS message channel. Rust appends newline-terminated
@@ -145,8 +145,8 @@ pub async fn run_browser_test(script: &str, env_vars: &[(&str, &str)]) -> Result
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
-    eprintln!("--- browser stdout ---\n{stdout}");
     eprintln!("--- browser stderr ---\n{stderr}");
+    eprintln!("--- browser stdout ---\n{stdout}");
 
     if output.status.success() {
         Ok(())
@@ -177,8 +177,8 @@ pub async fn run_js_test(script: &str, env_vars: &[(&str, &str)]) -> Result<(), 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
-    eprintln!("--- JS stdout ---\n{stdout}");
     eprintln!("--- JS stderr ---\n{stderr}");
+    eprintln!("--- JS stdout ---\n{stdout}");
 
     if output.status.success() {
         Ok(())

--- a/e2e-tests/src/network.rs
+++ b/e2e-tests/src/network.rs
@@ -377,6 +377,56 @@ fn decode_header_number(hex_str: &str) -> Result<u64, anyhow::Error> {
     Ok(header.number)
 }
 
+/// Runs `js/chainhead_v1_follow_test.js` against a live network. Snapshots the
+/// relay and para best/finalized heights from the validator/collator metrics
+/// immediately before launching JS, so the validator can flag an initialized
+/// finalized that lags too far behind the live network.
+pub async fn run_chainhead_v1_follow_js(
+    live: &LiveNetwork,
+    cfg: &Scenario,
+) -> Result<(), anyhow::Error> {
+    let relay_spec_str = live.relay_spec.to_str().expect("UTF-8 path");
+    let para_spec_str = live.para_spec.to_str().expect("UTF-8 path");
+
+    let smoldot_db_paths = cfg.smoldot_db().map(|db| {
+        (
+            db.relay_db_json.to_str().expect("UTF-8 path").to_owned(),
+            db.para_db_json.to_str().expect("UTF-8 path").to_owned(),
+        )
+    });
+
+    let relay_node = live.network.get_node("validator-0")?;
+    let relay_best = relay_node.reports(BEST_METRIC).await? as u64;
+    let relay_finalized = relay_node.reports(FINALIZED_METRIC).await? as u64;
+    let para_node = live.network.get_node("alice")?;
+    let para_best = para_node.reports(BEST_METRIC).await? as u64;
+    let para_finalized = para_node.reports(FINALIZED_METRIC).await? as u64;
+    let relay_best_str = relay_best.to_string();
+    let relay_finalized_str = relay_finalized.to_string();
+    let para_best_str = para_best.to_string();
+    let para_finalized_str = para_finalized.to_string();
+
+    let mut env_vars: Vec<(&str, &str)> = vec![
+        ("RELAY_CHAIN_SPEC", relay_spec_str),
+        ("PARA_CHAIN_SPEC", para_spec_str),
+        ("RELAY_BEST_AT_LAUNCH", relay_best_str.as_str()),
+        ("RELAY_FINALIZED_AT_LAUNCH", relay_finalized_str.as_str()),
+        ("PARA_BEST_AT_LAUNCH", para_best_str.as_str()),
+        ("PARA_FINALIZED_AT_LAUNCH", para_finalized_str.as_str()),
+    ];
+    if let Some((relay_db, para_db)) = smoldot_db_paths.as_ref() {
+        env_vars.push(("SMOLDOT_DB_RELAY", relay_db.as_str()));
+        env_vars.push(("SMOLDOT_DB_PARA", para_db.as_str()));
+    }
+
+    log::info!(
+        "running chainHead_v1_follow JS driver (relay_spec={relay_spec_str}, para_spec={para_spec_str}, relay best/finalized=#{relay_best}/#{relay_finalized}, para best/finalized=#{para_best}/#{para_finalized})"
+    );
+    crate::run_js_test("js/chainhead_v1_follow_test.js", &env_vars)
+        .await
+        .map_err(|e| anyhow!("JS test failed: {e}"))
+}
+
 /// Runs `js/smoke.js` against a live network. Env-injects spec paths, the
 /// expected-initial-finalized floor, and (warm only) smoldot DB content
 /// paths.

--- a/e2e-tests/tests/chainhead_v1_follow_cold.rs
+++ b/e2e-tests/tests/chainhead_v1_follow_cold.rs
@@ -1,0 +1,63 @@
+// Smoldot
+// Copyright (C) 2019-2026  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use anyhow::anyhow;
+use smoldot_e2e_tests::*;
+
+const REQUIRED_BLOCKS: u32 = 5;
+
+/// Cold chainHead_v1_follow conformance + warp-sync-regression test. Spawns
+/// westend-local + people-westend-local from snapshots, hands smoldot a chain
+/// spec carrying `lightSyncState` (no persisted DB), and drives the JS
+/// validator. The cold-only regression check fails if smoldot's initial
+/// finalized hash equals the chain-spec checkpoint hash (the warp-sync bug).
+#[tokio::test(flavor = "multi_thread")]
+async fn chainhead_v1_follow_cold() -> Result<(), anyhow::Error> {
+    let _ = env_logger::try_init_from_env(
+        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
+    );
+
+    let base_dir = resolve_base_dir()?;
+    let base_dir_str = base_dir.to_str().expect("UTF-8 path").to_owned();
+
+    let cfg = Scenario::Cold(SnapshotPaths {
+        relay_db_tgz: snapshot::relay_db()?,
+        para_db_tgz: snapshot::para_db()?,
+        relay_full_spec: snapshot::relay_spec()?,
+        para_full_spec: snapshot::para_spec()?,
+        smoldot_relay_spec: snapshot::relay_spec_light_sync_state()?,
+        smoldot_para_spec: snapshot::para_spec_light_sync_state()?,
+    });
+    let live = spawn_scenario(&cfg, &base_dir_str).await?;
+
+    log::info!("checking that alice has produced post-snapshot parachain blocks (best)");
+    let alice = live.network.get_node("alice")?;
+    let baseline = alice.reports(BEST_METRIC).await? as u32;
+    let target = baseline + REQUIRED_BLOCKS;
+    alice
+        .wait_metric_with_timeout(BEST_METRIC, |h| h >= target as f64, 180u64)
+        .await
+        .map_err(|e| {
+            anyhow!(
+                "alice did not produce {REQUIRED_BLOCKS} parachain blocks past #{baseline}: {e}"
+            )
+        })?;
+    log::info!("alice reached #{target} (>= baseline+{REQUIRED_BLOCKS})");
+
+    run_chainhead_v1_follow_js(&live, &cfg).await?;
+    Ok(())
+}

--- a/e2e-tests/tests/chainhead_v1_follow_fresh.rs
+++ b/e2e-tests/tests/chainhead_v1_follow_fresh.rs
@@ -1,0 +1,48 @@
+// Smoldot
+// Copyright (C) 2019-2026  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use anyhow::anyhow;
+use smoldot_e2e_tests::*;
+
+const REQUIRED_BLOCKS: u32 = 5;
+
+/// Fresh chainHead_v1_follow conformance test. No checkpoint regression
+/// (chain spec has no `lightSyncState`); only spec invariants + cross-sub
+/// monotonicity are asserted.
+#[tokio::test(flavor = "multi_thread")]
+async fn chainhead_v1_follow_fresh() -> Result<(), anyhow::Error> {
+    let _ = env_logger::try_init_from_env(
+        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
+    );
+
+    let base_dir = resolve_base_dir()?;
+    let base_dir_str = base_dir.to_str().expect("UTF-8 path").to_owned();
+
+    let cfg = Scenario::Fresh;
+    let live = spawn_scenario(&cfg, &base_dir_str).await?;
+
+    log::info!("checking that alice has \u{2265}{REQUIRED_BLOCKS} parachain blocks (best)");
+    live.network
+        .get_node("alice")?
+        .wait_metric_with_timeout(BEST_METRIC, |h| h >= REQUIRED_BLOCKS as f64, 180u64)
+        .await
+        .map_err(|e| anyhow!("alice did not produce parachain blocks: {e}"))?;
+    log::info!("alice has \u{2265}{REQUIRED_BLOCKS} parachain blocks");
+
+    run_chainhead_v1_follow_js(&live, &cfg).await?;
+    Ok(())
+}

--- a/e2e-tests/tests/chainhead_v1_follow_warm.rs
+++ b/e2e-tests/tests/chainhead_v1_follow_warm.rs
@@ -1,0 +1,68 @@
+// Smoldot
+// Copyright (C) 2019-2026  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use anyhow::anyhow;
+use smoldot_e2e_tests::*;
+
+const REQUIRED_BLOCKS: u32 = 5;
+
+/// Warm chainHead_v1_follow conformance test. With a persisted DB and small
+/// block gap, the warp-sync code path is rarely engaged, so no checkpoint
+/// regression check; only spec invariants + cross-sub monotonicity are
+/// asserted.
+#[tokio::test(flavor = "multi_thread")]
+async fn chainhead_v1_follow_warm() -> Result<(), anyhow::Error> {
+    let _ = env_logger::try_init_from_env(
+        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
+    );
+
+    let base_dir = resolve_base_dir()?;
+    let base_dir_str = base_dir.to_str().expect("UTF-8 path").to_owned();
+
+    let cfg = Scenario::Warm {
+        snapshot: SnapshotPaths {
+            relay_db_tgz: snapshot::relay_db()?,
+            para_db_tgz: snapshot::para_db()?,
+            relay_full_spec: snapshot::relay_spec()?,
+            para_full_spec: snapshot::para_spec()?,
+            smoldot_relay_spec: snapshot::relay_spec_light_sync_state()?,
+            smoldot_para_spec: snapshot::para_spec_light_sync_state()?,
+        },
+        smoldot_db: SmoldotDbPaths {
+            relay_db_json: snapshot::smoldot_db_relay()?,
+            para_db_json: snapshot::smoldot_db_para()?,
+        },
+    };
+    let live = spawn_scenario(&cfg, &base_dir_str).await?;
+
+    log::info!("checking that alice has produced post-snapshot parachain blocks (best)");
+    let alice = live.network.get_node("alice")?;
+    let baseline = alice.reports(BEST_METRIC).await? as u32;
+    let target = baseline + REQUIRED_BLOCKS;
+    alice
+        .wait_metric_with_timeout(BEST_METRIC, |h| h >= target as f64, 180u64)
+        .await
+        .map_err(|e| {
+            anyhow!(
+                "alice did not produce {REQUIRED_BLOCKS} parachain blocks past #{baseline}: {e}"
+            )
+        })?;
+    log::info!("alice reached #{target} (>= baseline+{REQUIRED_BLOCKS})");
+
+    run_chainhead_v1_follow_js(&live, &cfg).await?;
+    Ok(())
+}

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -224,8 +224,22 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                 max_requests_per_block: config.max_requests_per_block,
                 block_number_bytes: config.block_number_bytes,
                 allow_unknown_consensus_engines: config.allow_unknown_consensus_engines,
+                warp_completion_suppressed: false,
             },
         }
+    }
+
+    /// Gates the final `all_forks` rebuild in [`AllSync::process_one`]. Warp's verification,
+    /// build, and [`AllSync::desired_requests`] keep running so callers can probe warp
+    /// readiness; a result completed while suppressed sits in [`Self::ready_to_transition`]
+    /// until lifted or dropped via [`AllSync::discard_pending_warp_completion`].
+    pub fn set_warp_completion_suppressed(&mut self, v: bool) {
+        self.shared.warp_completion_suppressed = v;
+    }
+
+    /// Drops any pending warp-sync completion before un-suppressing avoids a stale rebuild.
+    pub fn discard_pending_warp_completion(&mut self) {
+        self.ready_to_transition = None;
     }
 
     /// Returns the value that was initially passed in [`Config::block_number_bytes`].
@@ -401,14 +415,10 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         all_forks.non_finalized_blocks_ancestry_order()
     }
 
-    /// Drops the warp-sync state machine. After this call:
-    ///
-    /// - No new warp-sync requests are produced by [`AllSync::desired_requests`].
-    /// - In-flight warp-sync requests are removed; their user data is returned to the
-    ///   caller (typically abort handles for the outer futures).
-    ///
-    /// No-op if called twice; returns an empty vector.
-    pub fn cancel_warp_sync(&mut self) -> Vec<TRq> {
+    /// Aborts all in-flight warp-sync requests, returning their user data (typically
+    /// `AbortHandle`s for the outer futures). `warp_sync` remains alive and may re-engage
+    /// later. No-op if warp-sync is not in use.
+    pub fn abort_in_flight_warp_requests(&mut self) -> Vec<TRq> {
         if self.warp_sync.is_none() {
             return Vec::new();
         }
@@ -421,19 +431,10 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
             .map(|(id, _)| RequestId(id))
             .collect();
 
-        let aborted_handles: Vec<TRq> = warp_request_ids
+        warp_request_ids
             .into_iter()
             .map(|id| self.remove_request(id))
-            .collect();
-
-        for (_, source_mapping) in self.shared.sources.iter_mut() {
-            source_mapping.warp_sync = None;
-        }
-
-        self.warp_sync = None;
-        self.ready_to_transition = None;
-
-        aborted_handles
+            .collect()
     }
 
     /// Returns true if it is believed that we are near the head of the chain.
@@ -1016,14 +1017,15 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
             }
         }
 
-        if let Some(RuntimeInformation {
-            finalized_runtime: finalized_block_runtime,
-            finalized_body,
-            finalized_storage_code,
-            finalized_storage_heap_pages,
-            finalized_storage_code_merkle_value,
-            finalized_storage_code_closest_ancestor_excluding,
-        }) = self.ready_to_transition.take()
+        if !self.shared.warp_completion_suppressed
+            && let Some(RuntimeInformation {
+                finalized_runtime: finalized_block_runtime,
+                finalized_body,
+                finalized_storage_code,
+                finalized_storage_heap_pages,
+                finalized_storage_code_merkle_value,
+                finalized_storage_code_closest_ancestor_excluding,
+            }) = self.ready_to_transition.take()
         {
             let (Some(all_forks), Some(warp_sync)) =
                 (self.all_forks.as_mut(), self.warp_sync.as_mut())
@@ -2527,6 +2529,8 @@ struct Shared<TRq, TSrc> {
     block_number_bytes: usize,
     /// Value passed through [`Config::allow_unknown_consensus_engines`].
     allow_unknown_consensus_engines: bool,
+    /// See [`AllSync::set_warp_completion_suppressed`].
+    warp_completion_suppressed: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2613,10 +2617,41 @@ mod tests {
     }
 
     #[test]
-    fn status_reports_sync_after_cancel_warp() {
+    fn abort_in_flight_warp_requests_keeps_warp_alive() {
         let mut sync = fresh_sync();
-        let _ = sync.cancel_warp_sync();
-        assert!(matches!(sync.status(), Status::Sync));
+        let aborted = sync.abort_in_flight_warp_requests();
+        assert!(aborted.is_empty());
+        // warp_sync remains alive; status still reflects it.
+        assert!(matches!(
+            sync.status(),
+            Status::WarpSyncFragments { source: None, .. }
+        ));
+    }
+
+    #[test]
+    fn desired_requests_emits_warp_regardless_of_suppression() {
+        let mut sync = fresh_sync();
+        let source_id = match sync.prepare_add_source(100, [1; 32]) {
+            AddSource::UnknownBestBlock(s) => s.add_source_and_insert_block((), ()),
+            _ => unreachable!(),
+        };
+        sync.update_source_finality_state(source_id, 100);
+
+        // Suppression only gates the final rebuild; warp's desired_requests must still
+        // emit so callers can probe whether warp would make progress.
+        sync.set_warp_completion_suppressed(true);
+        assert!(
+            sync.desired_requests()
+                .any(|(_, _, rq)| matches!(rq, DesiredRequest::WarpSync { .. }))
+        );
+    }
+
+    #[test]
+    fn discard_pending_warp_completion_is_noop_when_empty() {
+        let mut sync = fresh_sync();
+        assert!(sync.ready_to_transition.is_none());
+        sync.discard_pending_warp_completion();
+        assert!(sync.ready_to_transition.is_none());
     }
 
     #[test]

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -2562,3 +2562,65 @@ fn all_forks_request_convert(
         request_justification: true,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chain::chain_information;
+
+    fn aura_grandpa_genesis() -> chain_information::ValidChainInformation {
+        chain_information::ValidChainInformation::try_from(chain_information::ChainInformation {
+            finalized_block_header: Box::new(header::Header {
+                parent_hash: [0; 32],
+                number: 0,
+                state_root: [0; 32],
+                extrinsics_root: [0; 32],
+                digest: header::Digest::from(header::DigestRef::empty()),
+            }),
+            consensus: chain_information::ChainInformationConsensus::Aura {
+                finalized_authorities_list: Vec::new(),
+                slot_duration: NonZero::new(6000).unwrap(),
+            },
+            finality: chain_information::ChainInformationFinality::Grandpa {
+                after_finalized_block_authorities_set_id: 0,
+                finalized_triggered_authorities: Vec::new(),
+                finalized_scheduled_change: None,
+            },
+        })
+        .unwrap()
+    }
+
+    fn fresh_sync() -> AllSync<(), (), ()> {
+        AllSync::new(Config {
+            chain_information: aura_grandpa_genesis(),
+            block_number_bytes: 4,
+            allow_unknown_consensus_engines: false,
+            sources_capacity: 4,
+            blocks_capacity: 4,
+            max_disjoint_headers: 4,
+            max_requests_per_block: NonZero::new(1).unwrap(),
+            download_ahead_blocks: NonZero::new(1).unwrap(),
+            download_bodies: false,
+            download_all_chain_information_storage_proofs: false,
+            code_trie_node_hint: None,
+        })
+    }
+
+    // Regression: AllSync::status() used to be a stub returning Status::Sync, hiding the active
+    // warp phase from callers (notably sync_service's warp_sync_can_proceed).
+    #[test]
+    fn status_reports_warp_for_fresh_grandpa_chain() {
+        let sync = fresh_sync();
+        assert!(matches!(
+            sync.status(),
+            Status::WarpSyncFragments { source: None, .. }
+        ));
+    }
+
+    #[test]
+    fn status_reports_sync_after_cancel_warp() {
+        let mut sync = fresh_sync();
+        let _ = sync.cancel_warp_sync();
+        assert!(matches!(sync.status(), Status::Sync));
+    }
+}

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -2606,8 +2606,6 @@ mod tests {
         })
     }
 
-    // Regression: AllSync::status() used to be a stub returning Status::Sync, hiding the active
-    // warp phase from callers (notably sync_service's warp_sync_can_proceed).
     #[test]
     fn status_reports_warp_for_fresh_grandpa_chain() {
         let sync = fresh_sync();
@@ -2622,5 +2620,48 @@ mod tests {
         let mut sync = fresh_sync();
         let _ = sync.cancel_warp_sync();
         assert!(matches!(sync.status(), Status::Sync));
+    }
+
+    #[test]
+    fn status_reports_warp_fragments_during_inflight_download() {
+        let mut sync = fresh_sync();
+
+        let source_id = match sync.prepare_add_source(100, [1; 32]) {
+            AddSource::UnknownBestBlock(s) => s.add_source_and_insert_block((), ()),
+            _ => unreachable!(),
+        };
+        sync.update_source_finality_state(source_id, 100);
+
+        let sync_start_block_hash = sync
+            .desired_requests()
+            .find_map(|(_, _, rq)| match rq {
+                DesiredRequest::WarpSync {
+                    sync_start_block_hash,
+                } => Some(sync_start_block_hash),
+                _ => None,
+            })
+            .expect("warp request should be desired");
+
+        let _ = sync.add_request(
+            source_id,
+            RequestDetail::WarpSync {
+                sync_start_block_hash,
+            },
+            (),
+        );
+
+        // No further WarpSync desired while one is in flight
+        assert!(
+            !sync
+                .desired_requests()
+                .any(|(_, _, rq)| matches!(rq, DesiredRequest::WarpSync { .. }))
+        );
+        assert!(matches!(
+            sync.status(),
+            Status::WarpSyncFragments {
+                source: Some(_),
+                ..
+            }
+        ));
     }
 }

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -231,8 +231,8 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
 
     /// Gates the final `all_forks` rebuild in [`AllSync::process_one`]. Warp's verification,
     /// build, and [`AllSync::desired_requests`] keep running so callers can probe warp
-    /// readiness; a result completed while suppressed sits in [`Self::ready_to_transition`]
-    /// until lifted or dropped via [`AllSync::discard_pending_warp_completion`].
+    /// readiness; a result completed while suppressed is held until lifted or dropped via
+    /// [`AllSync::discard_pending_warp_completion`].
     pub fn set_warp_completion_suppressed(&mut self, v: bool) {
         self.shared.warp_completion_suppressed = v;
     }

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -407,6 +407,45 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         all_forks.non_finalized_blocks_ancestry_order()
     }
 
+    /// Drops the warp-sync state machine. After this call:
+    ///
+    /// - No new warp-sync requests are produced by [`AllSync::desired_requests`].
+    /// - In-flight warp-sync requests are removed; their user data is returned to the
+    ///   caller (typically abort handles for the outer futures).
+    /// - [`SourceMapping::warp_sync`] is cleared on all sources.
+    ///
+    /// No-op if called twice; returns an empty vector.
+    pub fn cancel_warp_sync(&mut self) -> Vec<TRq> {
+        if self.warp_sync.is_none() {
+            return Vec::new();
+        }
+
+        let warp_request_ids: Vec<usize> = self
+            .shared
+            .requests
+            .iter()
+            .filter(|(_, rq)| rq.warp_sync.is_some())
+            .map(|(id, _)| id)
+            .collect();
+
+        let mut aborted_handles = Vec::with_capacity(warp_request_ids.len());
+        for id in warp_request_ids {
+            let request = self.shared.requests.remove(id);
+            debug_assert!(request.all_forks.is_none());
+            self.shared.sources[request.source_id.0].num_requests -= 1;
+            aborted_handles.push(request.user_data);
+        }
+
+        for (_, source_mapping) in self.shared.sources.iter_mut() {
+            source_mapping.warp_sync = None;
+        }
+
+        self.warp_sync = None;
+        self.ready_to_transition = None;
+
+        aborted_handles
+    }
+
     /// Returns true if it is believed that we are near the head of the chain.
     ///
     /// The way this method is implemented is opaque and cannot be relied on. The return value
@@ -496,8 +535,8 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         };
 
         let _ = all_forks.remove_source(source_info.all_forks);
-        if let Some(warp_sync) = &mut self.warp_sync {
-            let _ = warp_sync.remove_source(source_info.warp_sync.unwrap());
+        if let (Some(warp_sync), Some(inner_id)) = (&mut self.warp_sync, source_info.warp_sync) {
+            let _ = warp_sync.remove_source(inner_id);
         }
 
         // TODO: optimize

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -412,7 +412,6 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     /// - No new warp-sync requests are produced by [`AllSync::desired_requests`].
     /// - In-flight warp-sync requests are removed; their user data is returned to the
     ///   caller (typically abort handles for the outer futures).
-    /// - [`SourceMapping::warp_sync`] is cleared on all sources.
     ///
     /// No-op if called twice; returns an empty vector.
     pub fn cancel_warp_sync(&mut self) -> Vec<TRq> {

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -413,21 +413,18 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
             return Vec::new();
         }
 
-        let warp_request_ids: Vec<usize> = self
+        let warp_request_ids: Vec<RequestId> = self
             .shared
             .requests
             .iter()
             .filter(|(_, rq)| rq.warp_sync.is_some())
-            .map(|(id, _)| id)
+            .map(|(id, _)| RequestId(id))
             .collect();
 
-        let mut aborted_handles = Vec::with_capacity(warp_request_ids.len());
-        for id in warp_request_ids {
-            let request = self.shared.requests.remove(id);
-            debug_assert!(request.all_forks.is_none());
-            self.shared.sources[request.source_id.0].num_requests -= 1;
-            aborted_handles.push(request.user_data);
-        }
+        let aborted_handles: Vec<TRq> = warp_request_ids
+            .into_iter()
+            .map(|id| self.remove_request(id))
+            .collect();
 
         for (_, source_mapping) in self.shared.sources.iter_mut() {
             source_mapping.warp_sync = None;

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -2655,6 +2655,48 @@ mod tests {
     }
 
     #[test]
+    fn warp_sync_alive_after_all_forks_only_commit() {
+        let mut sync = fresh_sync();
+
+        let source_id = match sync.prepare_add_source(100, [1; 32]) {
+            AddSource::UnknownBestBlock(s) => s.add_source_and_insert_block((), ()),
+            _ => unreachable!(),
+        };
+        sync.update_source_finality_state(source_id, 100);
+
+        let sync_start_block_hash = sync
+            .desired_requests()
+            .find_map(|(_, _, rq)| match rq {
+                DesiredRequest::WarpSync {
+                    sync_start_block_hash,
+                } => Some(sync_start_block_hash),
+                _ => None,
+            })
+            .expect("warp request should be desired");
+        let _ = sync.add_request(
+            source_id,
+            RequestDetail::WarpSync {
+                sync_start_block_hash,
+            },
+            (),
+        );
+
+        // Simulate commit_all_forks_only: abort in-flight, drop any pending completion,
+        // then lift suppression.
+        sync.set_warp_completion_suppressed(true);
+        let aborted = sync.abort_in_flight_warp_requests();
+        assert_eq!(aborted.len(), 1);
+        sync.discard_pending_warp_completion();
+        sync.set_warp_completion_suppressed(false);
+
+        // Source still far enough ahead -> warp must be desired again.
+        assert!(
+            sync.desired_requests()
+                .any(|(_, _, rq)| matches!(rq, DesiredRequest::WarpSync { .. }))
+        );
+    }
+
+    #[test]
     fn status_reports_warp_fragments_during_inflight_download() {
         let mut sync = fresh_sync();
 

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -245,39 +245,33 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
 
     /// Returns the current status of the syncing.
     pub fn status(&'_ self) -> Status<'_, TSrc> {
-        // TODO:
-        Status::Sync
-        /*match &self.inner {
-            AllSyncInner::AllForks(_) => Status::Sync,
-            AllSyncInner::WarpSync { inner, .. } => match inner.status() {
-                warp_sync::Status::Fragments {
-                    source: None,
-                    finalized_block_hash,
-                    finalized_block_number,
-                } => Status::WarpSyncFragments {
-                    source: None,
-                    finalized_block_hash,
-                    finalized_block_number,
-                },
-                warp_sync::Status::Fragments {
-                    source: Some((_, user_data)),
-                    finalized_block_hash,
-                    finalized_block_number,
-                } => Status::WarpSyncFragments {
-                    source: Some((user_data.outer_source_id, &user_data.user_data)),
-                    finalized_block_hash,
-                    finalized_block_number,
-                },
-                warp_sync::Status::ChainInformation {
-                    finalized_block_hash,
-                    finalized_block_number,
-                } => Status::WarpSyncChainInformation {
-                    finalized_block_hash,
-                    finalized_block_number,
-                },
+        let Some(warp_sync) = &self.warp_sync else {
+            return Status::Sync;
+        };
+        match warp_sync.status() {
+            warp_sync::Status::Fragments {
+                source,
+                finalized_block_hash,
+                finalized_block_number,
+            } => Status::WarpSyncFragments {
+                source: source.map(|(_, src)| {
+                    let outer_source_id = src.outer_source_id;
+                    (
+                        outer_source_id,
+                        &self.shared.sources[outer_source_id.0].user_data,
+                    )
+                }),
+                finalized_block_hash,
+                finalized_block_number,
             },
-            AllSyncInner::Poisoned => unreachable!(),
-        }*/
+            warp_sync::Status::ChainInformation {
+                finalized_block_hash,
+                finalized_block_number,
+            } => Status::WarpSyncChainInformation {
+                finalized_block_hash,
+                finalized_block_number,
+            },
+        }
     }
 
     /// Returns the header of the finalized block.

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -1442,7 +1442,10 @@ async fn run_background<TPlat: PlatformRef>(
                                         Some(
                                             tree.input_output_iter_unordered()
                                                 .find(|b| b.user_data.hash == block.parent_hash)
-                                                .unwrap()
+                                                .expect(
+                                                    "blocks come in ancestry order, parent \
+                                                     was already inserted; qed",
+                                                )
                                                 .id,
                                         )
                                     };
@@ -1460,7 +1463,10 @@ async fn run_background<TPlat: PlatformRef>(
                                                 &block.scale_encoded_header,
                                                 background.sync_service.block_number_bytes(),
                                             )
-                                            .unwrap()
+                                            .expect(
+                                                "header provided by sync_service was already \
+                                                 validated; qed",
+                                            )
                                             .number, // TODO: consider feeding the information from the sync service?
                                             scale_encoded_header: block.scale_encoded_header,
                                         },

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -1323,8 +1323,10 @@ async fn run_background<TPlat: PlatformRef>(
 
                 // The buffer size should be large enough so that, if the CPU is busy, it
                 // doesn't become full before the execution of the runtime service resumes.
-                // Note that this `await` freezes the entire runtime service background task,
-                // but the sync service guarantees that `subscribe_all` returns very quickly.
+                // Note that this `await` freezes the entire runtime service background task.
+                // The sync service returns promptly except for the first call after startup,
+                // which may block until the bootstrap mode commits (see
+                // `SyncService::subscribe_all`).
                 let subscription = background.sync_service.subscribe_all(32, true).await;
 
                 log!(

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -222,8 +222,10 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
     /// always be `None`. Since the runtime can only be provided to one call to this function,
     /// only one subscriber should use `runtime_interest` equal to `true`.
     ///
-    /// While this function is asynchronous, it is guaranteed to finish relatively quickly. Only
-    /// CPU operations are performed.
+    /// While this function is asynchronous, it normally finishes quickly. The first call after
+    /// startup may block until the sync service commits its bootstrap mode (warp-sync vs
+    /// all-forks-only), so that the returned finalized block isn't a chain-spec checkpoint
+    /// that warp-sync would later overwrite.
     pub async fn subscribe_all(&self, buffer_size: usize, runtime_interest: bool) -> SubscribeAll {
         let (send_back, rx) = oneshot::channel();
 

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -1117,28 +1117,31 @@ async fn fetch_parachain_head_from_relay<TPlat: PlatformRef>(
         .subscribe_all(32, NonZero::<usize>::new(usize::MAX).unwrap())
         .await;
 
-    log!(
-        platform,
-        Info,
-        log_target,
-        "Waiting for relay chain to finalize a block..."
-    );
+    // sync_service withholds the response until the bootstrap mode is committed, so the
+    // initial finalized header is authoritative and safe to use directly.
+    let mut next_finalized_hash = Some(header::hash_from_scale_encoded_header(
+        &subscription.finalized_block_scale_encoded_header,
+    ));
 
     loop {
-        let finalized_hash = loop {
-            match subscription.new_blocks.next().await {
-                Some(runtime_service::Notification::Finalized { hash, .. }) => {
-                    break hash;
-                }
-                Some(_) => continue,
-                None => {
-                    // Subscription died. Re-subscribe.
-                    subscription = relay_chain_sync
-                        .subscribe_all(32, NonZero::<usize>::new(usize::MAX).unwrap())
-                        .await;
-                    break header::hash_from_scale_encoded_header(
-                        &subscription.finalized_block_scale_encoded_header,
-                    );
+        let finalized_hash = if let Some(h) = next_finalized_hash.take() {
+            h
+        } else {
+            loop {
+                match subscription.new_blocks.next().await {
+                    Some(runtime_service::Notification::Finalized { hash, .. }) => {
+                        break hash;
+                    }
+                    Some(_) => continue,
+                    None => {
+                        // Subscription died. Re-subscribe.
+                        subscription = relay_chain_sync
+                            .subscribe_all(32, NonZero::<usize>::new(usize::MAX).unwrap())
+                            .await;
+                        break header::hash_from_scale_encoded_header(
+                            &subscription.finalized_block_scale_encoded_header,
+                        );
+                    }
                 }
             }
         };

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -20,7 +20,9 @@ use super::{
 };
 use crate::{log, network_service, platform::PlatformRef, runtime_service, util};
 
-use alloc::{borrow::Cow, boxed::Box, format, string::String, sync::Arc, vec::Vec};
+use alloc::{
+    borrow::Cow, boxed::Box, collections::VecDeque, format, string::String, sync::Arc, vec::Vec,
+};
 use core::{cmp, iter, num::NonZero, pin::Pin, time::Duration};
 use futures_channel::oneshot;
 use futures_lite::FutureExt as _;
@@ -171,6 +173,8 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
         known_finalized_runtime: Some(finalized_runtime),
         pending_requests: stream::FuturesUnordered::new(),
         all_notifications: Vec::<async_channel::Sender<Notification>>::new(),
+        pending_subscriptions: VecDeque::new(),
+        bootstrap_complete: false,
         log_target,
         from_network_service: None,
         network_service,
@@ -558,38 +562,15 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
                 buffer_size,
                 runtime_interest,
             }) => {
-                let Some(sync) = &task.sync else {
-                    unreachable!()
-                };
-
-                let (tx, new_blocks) = async_channel::bounded(buffer_size.saturating_sub(1));
-                task.all_notifications.push(tx);
-
-                let non_finalized_blocks_ancestry_order = {
-                    sync.non_finalized_blocks_ancestry_order()
-                        .map(|h| {
-                            let scale_encoding = h.scale_encoding_vec(sync.block_number_bytes());
-                            BlockNotification {
-                                is_new_best: header::hash_from_scale_encoded_header(
-                                    &scale_encoding,
-                                ) == *sync.best_block_hash(),
-                                scale_encoded_header: scale_encoding,
-                                parent_hash: *h.parent_hash,
-                            }
-                        })
-                        .collect()
-                };
-
-                let _ = send_back.send(SubscribeAll {
-                    finalized_block_scale_encoded_header: sync.finalized_block_header().to_vec(),
-                    finalized_block_runtime: if runtime_interest {
-                        task.known_finalized_runtime.take()
-                    } else {
-                        None
-                    },
-                    non_finalized_blocks_ancestry_order,
-                    new_blocks,
-                });
+                if task.bootstrap_complete {
+                    respond_subscribe_all(&mut task, send_back, buffer_size, runtime_interest);
+                } else {
+                    task.pending_subscriptions.push_back(PendingSubscribeAll {
+                        send_back,
+                        buffer_size,
+                        runtime_interest,
+                    });
+                }
             }
 
             WakeUpReason::ForegroundMessage(ToBackground::PeersAssumedKnowBlock {
@@ -948,6 +929,11 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
                 }
 
                 task.paraheads_notifications = Some(subscribe_all.new_blocks);
+
+                if !task.bootstrap_complete {
+                    drain_pending_subscriptions(&mut task);
+                    task.bootstrap_complete = true;
+                }
             }
 
             WakeUpReason::ParaheadNotification(Notification::Finalized {
@@ -1075,6 +1061,16 @@ struct Task<TPlat: PlatformRef> {
 
     all_notifications: Vec<async_channel::Sender<Notification>>,
 
+    /// `SubscribeAll` requests received before the initial paraheads subscription resolved.
+    /// Drained in the `ParaheadSubscribed` arm so the very first response a client sees
+    /// carries the authoritative relay-derived finalized parahead, never a transient
+    /// pre-bootstrap one.
+    pending_subscriptions: VecDeque<PendingSubscribeAll>,
+
+    /// `false` until the first drain runs. Once `true`, subsequent `SubscribeAll` requests
+    /// get the current finalized synchronously.
+    bootstrap_complete: bool,
+
     network_service: Arc<network_service::NetworkServiceChain<TPlat>>,
     from_network_service: Option<Pin<Box<async_channel::Receiver<network_service::Event>>>>,
 
@@ -1087,6 +1083,61 @@ enum RequestOutcome {
     Block(Result<Vec<codec::BlockData>, network_service::BlocksRequestError>),
     Storage(Result<Vec<u8>, ()>),
     CallProof(Result<network::service::EncodedMerkleProof, ()>),
+}
+
+struct PendingSubscribeAll {
+    send_back: oneshot::Sender<SubscribeAll>,
+    buffer_size: usize,
+    runtime_interest: bool,
+}
+
+fn respond_subscribe_all<TPlat: PlatformRef>(
+    task: &mut Task<TPlat>,
+    send_back: oneshot::Sender<SubscribeAll>,
+    buffer_size: usize,
+    runtime_interest: bool,
+) {
+    let Some(sync) = &task.sync else {
+        unreachable!()
+    };
+
+    let (tx, new_blocks) = async_channel::bounded(buffer_size.saturating_sub(1));
+    task.all_notifications.push(tx);
+
+    let non_finalized_blocks_ancestry_order = sync
+        .non_finalized_blocks_ancestry_order()
+        .map(|h| {
+            let scale_encoding = h.scale_encoding_vec(sync.block_number_bytes());
+            BlockNotification {
+                is_new_best: header::hash_from_scale_encoded_header(&scale_encoding)
+                    == *sync.best_block_hash(),
+                scale_encoded_header: scale_encoding,
+                parent_hash: *h.parent_hash,
+            }
+        })
+        .collect();
+
+    let _ = send_back.send(SubscribeAll {
+        finalized_block_scale_encoded_header: sync.finalized_block_header().to_vec(),
+        finalized_block_runtime: if runtime_interest {
+            task.known_finalized_runtime.take()
+        } else {
+            None
+        },
+        non_finalized_blocks_ancestry_order,
+        new_blocks,
+    });
+}
+
+fn drain_pending_subscriptions<TPlat: PlatformRef>(task: &mut Task<TPlat>) {
+    while let Some(pending) = task.pending_subscriptions.pop_front() {
+        respond_subscribe_all(
+            task,
+            pending.send_back,
+            pending.buffer_size,
+            pending.runtime_interest,
+        );
+    }
 }
 
 impl<TPlat: PlatformRef> Task<TPlat> {

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -117,6 +117,7 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
         ))
         .fuse(),
         mode: ModeState::Deciding,
+        bootstrap_complete: false,
         deciding_packets_seen: 0,
         mode_decision_deadline: future::Either::Left(Box::pin(
             platform.sleep(MODE_DECISION_TIMEOUT),
@@ -137,6 +138,12 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
         ),
         platform,
     };
+
+    // Suppress warp completion during Deciding; lifted once the chosen mode drains.
+    task.sync
+        .as_mut()
+        .unwrap_or_else(|| unreachable!())
+        .set_warp_completion_suppressed(true);
 
     // Main loop of the syncing logic.
     //
@@ -393,6 +400,13 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                         "mode-decision; transition=Ready (WarpSyncFinished)",
                     );
                     drain_pending_subscriptions(&mut task);
+                    task.bootstrap_complete = true;
+                    // Post-bootstrap re-warp is allowed; the `Stop` flows through
+                    // `all_notifications.clear()` above.
+                    task.sync
+                        .as_mut()
+                        .unwrap_or_else(|| unreachable!())
+                        .set_warp_completion_suppressed(false);
                 }
             }
 
@@ -871,6 +885,11 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                                 task.platform.sleep(MODE_DECISION_TIMEOUT),
                             ))
                             .fuse();
+                            // Allow warp completion to rebuild all_forks.
+                            task.sync
+                                .as_mut()
+                                .unwrap_or_else(|| unreachable!())
+                                .set_warp_completion_suppressed(false);
                             log!(
                                 &task.platform,
                                 Debug,
@@ -1541,6 +1560,11 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                     } else {
                         // Warp starved: drop back to Deciding so a future warp-eligible peer
                         // can re-trigger CommitWarpAhead instead of locking in AllForksOnly.
+                        // Re-suppress: no mode chosen yet, no subscribers drained.
+                        task.sync
+                            .as_mut()
+                            .unwrap_or_else(|| unreachable!())
+                            .set_warp_completion_suppressed(true);
                         task.mode = ModeState::Deciding;
                         task.deciding_packets_seen = 0;
                         task.mode_decision_deadline = future::Either::Left(Box::pin(
@@ -1599,6 +1623,12 @@ struct Task<TPlat: PlatformRef> {
     sync: Option<all::AllSync<future::AbortHandle, (libp2p::PeerId, codec::Role), ()>>,
 
     mode: ModeState,
+
+    /// `false` until the chosen bootstrap mode has delivered its first `initialized` event to
+    /// subscribers. While `false`, warp completion is suppressed at the [`all::AllSync`] layer
+    /// so a stray `WarpSyncFinished` cannot rebuild `all_forks` and `Stop` queued subscribers.
+    /// Once `true`, warp may re-engage and any later completion is allowed to fire a `Stop`.
+    bootstrap_complete: bool,
 
     /// Below-gap packets observed while [`ModeState::Deciding`]; gates AllForksOnly commit.
     deciding_packets_seen: usize,
@@ -1768,18 +1798,19 @@ fn drain_pending_subscriptions<TPlat: PlatformRef>(task: &mut Task<TPlat>) {
     }
 }
 
-/// Commits to AllForksOnly mode: cancels warp-sync, flips network-state flags to trigger
-/// the first GrandPa announce (without it peers won't gossip commits to us), drains queued
-/// subscribers.
+/// Commits to AllForksOnly mode: aborts any in-flight warp request, flips network-state
+/// flags to trigger the first GrandPa announce (without it peers won't gossip commits to
+/// us), drains queued subscribers, and lifts warp-completion suppression so warp may
+/// re-engage if the node ever falls back behind by `warp_sync_minimum_gap`.
 fn commit_all_forks_only<TPlat: PlatformRef>(task: &mut Task<TPlat>) {
     task.mode = ModeState::Ready;
     task.mode_decision_deadline = future::Either::Right(future::pending()).fuse();
 
-    let aborted = task
-        .sync
-        .as_mut()
-        .unwrap_or_else(|| unreachable!())
-        .cancel_warp_sync();
+    let sync = task.sync.as_mut().unwrap_or_else(|| unreachable!());
+    let aborted = sync.abort_in_flight_warp_requests();
+    // Drop any warp result completed while suppressed; else unsuppressing below would
+    // immediately rebuild all_forks from stale chain_info.
+    sync.discard_pending_warp_completion();
     let n = aborted.len();
     for handle in aborted {
         handle.abort();
@@ -1789,7 +1820,7 @@ fn commit_all_forks_only<TPlat: PlatformRef>(task: &mut Task<TPlat>) {
             &task.platform,
             Debug,
             &task.log_target,
-            "warp-sync-cancelled",
+            "warp-sync-aborted",
             in_flight_aborted = n,
         );
     }
@@ -1798,6 +1829,11 @@ fn commit_all_forks_only<TPlat: PlatformRef>(task: &mut Task<TPlat>) {
     task.network_up_to_date_best = false;
 
     drain_pending_subscriptions(task);
+    task.bootstrap_complete = true;
+    task.sync
+        .as_mut()
+        .unwrap_or_else(|| unreachable!())
+        .set_warp_completion_suppressed(false);
 }
 
 #[cfg(test)]
@@ -1927,14 +1963,13 @@ mod tests {
         assert!(!warp_sync_can_proceed(&sync));
     }
 
-    // Status::Sync arm after cancel_warp_sync.
+    // abort_in_flight_warp_requests keeps warp alive; progress is still possible.
     #[test]
-    fn cannot_proceed_after_cancel() {
+    fn proceeds_after_abort_in_flight() {
         let mut sync = fresh_sync();
         let _ = add_peer(&mut sync, 100);
-        let _ = sync.cancel_warp_sync();
-        assert!(matches!(sync.status(), Status::Sync));
-        assert!(!warp_sync_can_proceed(&sync));
+        let _ = sync.abort_in_flight_warp_requests();
+        assert!(warp_sync_can_proceed(&sync));
     }
 
     #[test]

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -43,11 +43,6 @@ use smoldot::{
     sync::all,
 };
 
-/// Peer-finalized minus local-finalized gap at/above which we commit to WarpAhead.
-/// Matches `warp_sync_minimum_gap` so the decision aligns with warp-sync's own
-/// willingness to engage a source.
-const MODE_DECISION_WARP_GAP_THRESHOLD: u64 = 32;
-
 /// Maximum wait for the first GrandpaNeighborPacket before falling back to AllForksOnly.
 /// Sized for cold-start peer discovery (DNS + libp2p handshake + gossip-open), which can
 /// stretch to ~20s on light clients.
@@ -846,9 +841,6 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                     .unwrap_or_else(|| unreachable!())
                     .update_source_finality_state(sync_source_id, finalized_block_height);
 
-                // Gate on peer_finalized, not peer_best: warp_sync only fires when
-                // peer_finalized - local >= 32, so deciding on best leaves warp_sync
-                // stalled waiting for finality to catch up (~6s/block on Polkadot).
                 if matches!(task.mode, ModeState::Deciding) {
                     let local_finalized = task
                         .sync
@@ -856,7 +848,7 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                         .unwrap_or_else(|| unreachable!())
                         .finalized_block_number();
                     let gap = finalized_block_height.saturating_sub(local_finalized);
-                    if gap >= MODE_DECISION_WARP_GAP_THRESHOLD {
+                    if warp_sync_can_proceed(task.sync.as_ref().unwrap_or_else(|| unreachable!())) {
                         task.mode = ModeState::AwaitingWarp {
                             target_finalized: finalized_block_height,
                         };
@@ -1503,22 +1495,7 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                     commit_all_forks_only(&mut task);
                 }
                 ModeState::AwaitingWarp { .. } => {
-                    // Re-arm while warp can still progress (downloading/building, or a
-                    // qualifying source exists); fall back to all-forks only when starved.
-                    let warp_can_proceed = {
-                        let Some(sync) = task.sync.as_ref() else {
-                            unreachable!()
-                        };
-                        match sync.status() {
-                            all::Status::WarpSyncFragments { source: Some(_), .. }
-                            | all::Status::WarpSyncChainInformation { .. } => true,
-                            _ => sync.desired_requests().any(|(_, _, rq)| {
-                                matches!(rq, all::DesiredRequest::WarpSync { .. })
-                            }),
-                        }
-                    };
-
-                    if warp_can_proceed {
+                    if warp_sync_can_proceed(task.sync.as_ref().unwrap_or_else(|| unreachable!())) {
                         task.mode_decision_deadline = future::Either::Left(Box::pin(
                             task.platform.sleep(MODE_DECISION_TIMEOUT),
                         ))
@@ -1690,6 +1667,24 @@ fn respond_subscribe_all<TPlat: PlatformRef>(
         non_finalized_blocks_ancestry_order,
         new_blocks,
     });
+}
+
+/// Warp is downloading/building, or a qualifying source is available for the next request.
+fn warp_sync_can_proceed(
+    sync: &all::AllSync<future::AbortHandle, (libp2p::PeerId, codec::Role), ()>,
+) -> bool {
+    match sync.status() {
+        all::Status::WarpSyncFragments {
+            source: Some(_), ..
+        }
+        | all::Status::WarpSyncChainInformation { .. } => true,
+        // At the mode-decision point no warp request is dispatched yet, so this arm decides.
+        // The caller already fed the source's finalized height (update_source_finality_state),
+        // so desired_requests() is expected to already include a warp request when the gap > 32.
+        _ => sync
+            .desired_requests()
+            .any(|(_, _, rq)| matches!(rq, all::DesiredRequest::WarpSync { .. })),
+    }
 }
 
 /// Responds to every queued `SubscribeAll` request. Each response allocates a fresh

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -462,6 +462,8 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                         );
                         // `BlockNumberNotIncrementing` means a finality proof overtook the
                         // fragment mid-flight; the peer isn't at fault.
+                        // TODO: malicious peers could abuse this to avoid bans.
+                        // https://github.com/paritytech/smoldot/pull/3268#discussion_r3319607065
                         let peer_at_fault =
                             !matches!(err, all::VerifyFragmentError::BlockNumberNotIncrementing);
                         if let Some(sender_if_still_connected) = sender_if_still_connected {
@@ -1546,6 +1548,8 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                     commit_all_forks_only(&mut task);
                 }
                 ModeState::AwaitingWarp { .. } => {
+                    // TODO: warp never reaching `is_finished=true` keeps subscribe_all queued.
+                    // https://github.com/paritytech/smoldot/pull/3268#discussion_r3319656011
                     if warp_sync_can_proceed(task.sync.as_ref().unwrap_or_else(|| unreachable!())) {
                         task.mode_decision_deadline = future::Either::Left(Box::pin(
                             task.platform.sleep(MODE_DECISION_TIMEOUT),

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -860,8 +860,11 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                         task.mode = ModeState::AwaitingWarp {
                             target_finalized: finalized_block_height,
                         };
-                        task.mode_decision_deadline =
-                            future::Either::Right(future::pending()).fuse();
+                        // Keep the deadline armed as a warp-stall fallback.
+                        task.mode_decision_deadline = future::Either::Left(Box::pin(
+                            task.platform.sleep(MODE_DECISION_TIMEOUT),
+                        ))
+                        .fuse();
                         log!(
                             &task.platform,
                             Debug,
@@ -1488,9 +1491,9 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                 };
             }
 
-            WakeUpReason::ModeDecisionDeadline => {
-                task.mode_decision_deadline = future::Either::Right(future::pending()).fuse();
-                if matches!(task.mode, ModeState::Deciding) {
+            WakeUpReason::ModeDecisionDeadline => match task.mode {
+                ModeState::Deciding => {
+                    task.mode_decision_deadline = future::Either::Right(future::pending()).fuse();
                     log!(
                         &task.platform,
                         Debug,
@@ -1499,7 +1502,49 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                     );
                     commit_all_forks_only(&mut task);
                 }
-            }
+                ModeState::AwaitingWarp { .. } => {
+                    // Re-arm while warp can still progress (downloading/building, or a
+                    // qualifying source exists); fall back to all-forks only when starved.
+                    let warp_can_proceed = {
+                        let Some(sync) = task.sync.as_ref() else {
+                            unreachable!()
+                        };
+                        match sync.status() {
+                            all::Status::WarpSyncFragments { source: Some(_), .. }
+                            | all::Status::WarpSyncChainInformation { .. } => true,
+                            _ => sync.desired_requests().any(|(_, _, rq)| {
+                                matches!(rq, all::DesiredRequest::WarpSync { .. })
+                            }),
+                        }
+                    };
+
+                    if warp_can_proceed {
+                        task.mode_decision_deadline = future::Either::Left(Box::pin(
+                            task.platform.sleep(MODE_DECISION_TIMEOUT),
+                        ))
+                        .fuse();
+                        log!(
+                            &task.platform,
+                            Debug,
+                            &task.log_target,
+                            "mode-decision; awaiting-warp deadline re-armed",
+                        );
+                    } else {
+                        task.mode_decision_deadline =
+                            future::Either::Right(future::pending()).fuse();
+                        log!(
+                            &task.platform,
+                            Debug,
+                            &task.log_target,
+                            "mode-decision; committed=AllForksOnly (warp starved)",
+                        );
+                        commit_all_forks_only(&mut task);
+                    }
+                }
+                ModeState::Ready => {
+                    task.mode_decision_deadline = future::Either::Right(future::pending()).fuse();
+                }
+            },
         }
     }
 }

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -1540,15 +1540,20 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                             "mode-decision; awaiting-warp deadline re-armed",
                         );
                     } else {
-                        task.mode_decision_deadline =
-                            future::Either::Right(future::pending()).fuse();
+                        // Warp starved: drop back to Deciding so a future warp-eligible peer
+                        // can re-trigger CommitWarpAhead instead of locking in AllForksOnly.
+                        task.mode = ModeState::Deciding;
+                        task.deciding_packets_seen = 0;
+                        task.mode_decision_deadline = future::Either::Left(Box::pin(
+                            task.platform.sleep(MODE_DECISION_TIMEOUT),
+                        ))
+                        .fuse();
                         log!(
                             &task.platform,
                             Debug,
                             &task.log_target,
-                            "mode-decision; committed=AllForksOnly (warp starved)",
+                            "mode-decision; warp starved, back to Deciding",
                         );
-                        commit_all_forks_only(&mut task);
                     }
                 }
                 ModeState::Ready => {

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -378,7 +378,10 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                 // must be cleared.
                 task.all_notifications.clear();
 
-                if matches!(task.mode, ModeState::AwaitingWarp | ModeState::Deciding) {
+                if matches!(
+                    task.mode,
+                    ModeState::AwaitingWarp { .. } | ModeState::Deciding
+                ) {
                     task.mode = ModeState::Ready;
                     task.mode_decision_deadline = future::Either::Right(future::pending()).fuse();
                     log!(
@@ -441,14 +444,20 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                                 }
                             )
                         );
+                        // `BlockNumberNotIncrementing` means a finality proof overtook the
+                        // fragment mid-flight; the peer isn't at fault.
+                        let peer_at_fault =
+                            !matches!(err, all::VerifyFragmentError::BlockNumberNotIncrementing);
                         if let Some(sender_if_still_connected) = sender_if_still_connected {
-                            task.network_service
-                                .ban_and_disconnect(
-                                    sender_if_still_connected,
-                                    network_service::BanSeverity::High,
-                                    "bad-warp-sync-fragment",
-                                )
-                                .await;
+                            if peer_at_fault {
+                                task.network_service
+                                    .ban_and_disconnect(
+                                        sender_if_still_connected,
+                                        network_service::BanSeverity::High,
+                                        "bad-warp-sync-fragment",
+                                    )
+                                    .await;
+                            }
                         }
                     }
                 }
@@ -587,7 +596,24 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                             pruned_blocks,
                         });
 
+                        let new_finalized = sync.finalized_block_number();
                         task.sync = Some(sync);
+
+                        // Finality reached the warp target; otherwise the next fragment fails
+                        // `BlockNumberNotIncrementing` and the node stalls in `AwaitingWarp`.
+                        if let ModeState::AwaitingWarp { target_finalized } = task.mode {
+                            if new_finalized >= target_finalized {
+                                log!(
+                                    &task.platform,
+                                    Debug,
+                                    &task.log_target,
+                                    "mode-decision; transition=Ready (CaughtUpViaFinality)",
+                                    local_finalized = new_finalized,
+                                    warp_target = target_finalized,
+                                );
+                                commit_all_forks_only(&mut task);
+                            }
+                        }
                     }
 
                     (
@@ -831,7 +857,9 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                         .finalized_block_number();
                     let gap = finalized_block_height.saturating_sub(local_finalized);
                     if gap >= MODE_DECISION_WARP_GAP_THRESHOLD {
-                        task.mode = ModeState::AwaitingWarp;
+                        task.mode = ModeState::AwaitingWarp {
+                            target_finalized: finalized_block_height,
+                        };
                         task.mode_decision_deadline =
                             future::Either::Right(future::pending()).fuse();
                         log!(
@@ -1482,8 +1510,9 @@ enum ModeState {
     /// No GrandpaNeighborPacket received yet and the deadline has not fired.
     /// `SubscribeAll` requests are queued.
     Deciding,
-    /// Committed to WarpAhead; awaiting `WarpSyncFinished` before responding to subscribers.
-    AwaitingWarp,
+    /// Committed to WarpAhead; awaiting `WarpSyncFinished` or finality catching up to
+    /// `target_finalized` (the peer-claimed height that triggered the decision).
+    AwaitingWarp { target_finalized: u64 },
     /// First finalized block is authoritative; queued subscribers are drained.
     Ready,
 }
@@ -1516,7 +1545,7 @@ struct Task<TPlat: PlatformRef> {
     mode_decision_deadline:
         future::Fuse<future::Either<Pin<Box<TPlat::Delay>>, future::Pending<()>>>,
 
-    /// `SubscribeAll` requests queued during [`ModeState::Deciding`] / [`ModeState::AwaitingWarp`].
+    /// `SubscribeAll` requests queued during [`ModeState::Deciding`] / `AwaitingWarp`.
     pending_subscriptions: VecDeque<PendingSubscribeAll>,
 
     /// If `Some`, contains the runtime of the current finalized block.

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -50,6 +50,12 @@ use smoldot::{
 // https://github.com/paritytech/smoldot/pull/3268#discussion_r3311751768
 const MODE_DECISION_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Minimum number of below-gap GrandpaNeighborPackets observed while `Deciding` before
+/// committing to AllForksOnly. Guards against a single lagging first peer wrongly locking
+/// us into the slow path when our local finalized is an old chain-spec checkpoint.
+/// See https://github.com/paritytech/smoldot/pull/3268#discussion_r3311637661
+const MODE_DECISION_MIN_PACKETS: usize = 2;
+
 /// Starts a sync service background task to synchronize a chain (relay chain or not) that is
 /// built with Substrate.
 pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
@@ -113,6 +119,7 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
         ))
         .fuse(),
         mode: ModeState::Deciding,
+        deciding_packets_seen: 0,
         mode_decision_deadline: future::Either::Left(Box::pin(
             platform.sleep(MODE_DECISION_TIMEOUT),
         ))
@@ -869,16 +876,31 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                             gap,
                         );
                     } else {
-                        log!(
-                            &task.platform,
-                            Debug,
-                            &task.log_target,
-                            "mode-decision; committed=AllForksOnly",
-                            local_finalized,
-                            peer_finalized = finalized_block_height,
-                            gap,
-                        );
-                        commit_all_forks_only(&mut task);
+                        task.deciding_packets_seen += 1;
+                        if task.deciding_packets_seen >= MODE_DECISION_MIN_PACKETS {
+                            log!(
+                                &task.platform,
+                                Debug,
+                                &task.log_target,
+                                "mode-decision; committed=AllForksOnly",
+                                local_finalized,
+                                peer_finalized = finalized_block_height,
+                                gap,
+                                packets_seen = task.deciding_packets_seen,
+                            );
+                            commit_all_forks_only(&mut task);
+                        } else {
+                            log!(
+                                &task.platform,
+                                Debug,
+                                &task.log_target,
+                                "mode-decision; deciding (no warp-eligible peer yet)",
+                                local_finalized,
+                                peer_finalized = finalized_block_height,
+                                gap,
+                                packets_seen = task.deciding_packets_seen,
+                            );
+                        }
                     }
                 }
             }
@@ -1492,7 +1514,8 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                         &task.platform,
                         Debug,
                         &task.log_target,
-                        "mode-decision; committed=AllForksOnly (timeout, no peers)",
+                        "mode-decision; committed=AllForksOnly (timeout)",
+                        packets_seen = task.deciding_packets_seen,
                     );
                     commit_all_forks_only(&mut task);
                 }
@@ -1564,6 +1587,10 @@ struct Task<TPlat: PlatformRef> {
     sync: Option<all::AllSync<future::AbortHandle, (libp2p::PeerId, codec::Role), ()>>,
 
     mode: ModeState,
+
+    /// Number of below-gap GrandpaNeighborPackets observed while in [`ModeState::Deciding`].
+    /// Only meaningful in that state; gates the early commit to AllForksOnly.
+    deciding_packets_seen: usize,
 
     /// Replaced with `pending` on mode commit so it never fires again.
     mode_decision_deadline:

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -1731,3 +1731,140 @@ fn commit_all_forks_only<TPlat: PlatformRef>(task: &mut Task<TPlat>) {
 
     drain_pending_subscriptions(task);
 }
+
+#[cfg(test)]
+mod tests {
+    // TODO follow-up:
+    // - move fixtures to a shared `smoldot-test-support` crate
+    //   cross-crate `cfg(test)` doesn't propagate,
+    // - add a `Status::WarpSyncChainInformation` case
+    //   (see https://github.com/paritytech/smoldot/pull/3268#discussion_r3311390876)
+    //   needs a test-only AllSync setter or crypto-correct warp fragments
+    use super::*;
+    use smoldot::{
+        chain::chain_information,
+        libp2p::peer_id::{PeerId, PublicKey},
+        sync::all::{
+            AddSource, AllSync, Config, DesiredRequest, RequestDetail, SourceId, Status,
+        },
+    };
+
+    type TestSync = AllSync<future::AbortHandle, (PeerId, codec::Role), ()>;
+
+    fn aura_grandpa_genesis() -> chain_information::ValidChainInformation {
+        chain_information::ValidChainInformation::try_from(chain_information::ChainInformation {
+            finalized_block_header: Box::new(header::Header {
+                parent_hash: [0; 32],
+                number: 0,
+                state_root: [0; 32],
+                extrinsics_root: [0; 32],
+                digest: header::Digest::from(header::DigestRef::empty()),
+            }),
+            consensus: chain_information::ChainInformationConsensus::Aura {
+                finalized_authorities_list: Vec::new(),
+                slot_duration: NonZero::new(6000).unwrap(),
+            },
+            finality: chain_information::ChainInformationFinality::Grandpa {
+                after_finalized_block_authorities_set_id: 0,
+                finalized_triggered_authorities: Vec::new(),
+                finalized_scheduled_change: None,
+            },
+        })
+        .unwrap()
+    }
+
+    fn fresh_sync() -> TestSync {
+        AllSync::new(Config {
+            chain_information: aura_grandpa_genesis(),
+            block_number_bytes: 4,
+            allow_unknown_consensus_engines: false,
+            sources_capacity: 4,
+            blocks_capacity: 4,
+            max_disjoint_headers: 4,
+            max_requests_per_block: NonZero::new(1).unwrap(),
+            download_ahead_blocks: NonZero::new(1).unwrap(),
+            download_bodies: false,
+            download_all_chain_information_storage_proofs: false,
+            code_trie_node_hint: None,
+        })
+    }
+
+    fn test_peer() -> PeerId {
+        PeerId::from_public_key(&PublicKey::Ed25519([42u8; 32]))
+    }
+
+    fn add_peer(sync: &mut TestSync, finalized: u64) -> SourceId {
+        let source_id = match sync.prepare_add_source(finalized, [1; 32]) {
+            AddSource::UnknownBestBlock(s) => {
+                s.add_source_and_insert_block((test_peer(), codec::Role::Full), ())
+            }
+            _ => unreachable!(),
+        };
+        sync.update_source_finality_state(source_id, finalized);
+        source_id
+    }
+
+    fn dispatch_warp(sync: &mut TestSync, source_id: SourceId) {
+        let sync_start_block_hash = sync
+            .desired_requests()
+            .find_map(|(_, _, rq)| match rq {
+                DesiredRequest::WarpSync {
+                    sync_start_block_hash,
+                } => Some(sync_start_block_hash),
+                _ => None,
+            })
+            .expect("warp request should be desired");
+        let (handle, _reg) = future::AbortHandle::new_pair();
+        let _ = sync.add_request(
+            source_id,
+            RequestDetail::WarpSync {
+                sync_start_block_hash,
+            },
+            handle,
+        );
+    }
+
+    // Status::WarpSyncFragments { source: Some(_), .. } arm.
+    #[test]
+    fn proceeds_with_inflight_fragment_download() {
+        let mut sync = fresh_sync();
+        let src = add_peer(&mut sync, 100);
+        dispatch_warp(&mut sync, src);
+        assert!(
+            !sync
+                .desired_requests()
+                .any(|(_, _, rq)| matches!(rq, DesiredRequest::WarpSync { .. }))
+        );
+        assert!(matches!(
+            sync.status(),
+            Status::WarpSyncFragments { source: Some(_), .. }
+        ));
+        assert!(warp_sync_can_proceed(&sync));
+    }
+
+    // Fall-through arm with a desired WarpSync request.
+    #[test]
+    fn proceeds_with_eligible_source_before_dispatch() {
+        let mut sync = fresh_sync();
+        let _ = add_peer(&mut sync, 100);
+        assert!(warp_sync_can_proceed(&sync));
+    }
+
+    // Fall-through arm, no eligible source: genuine stall.
+    #[test]
+    fn cannot_proceed_with_source_below_gap() {
+        let mut sync = fresh_sync();
+        let _ = add_peer(&mut sync, 10);
+        assert!(!warp_sync_can_proceed(&sync));
+    }
+
+    // Status::Sync arm after cancel_warp_sync.
+    #[test]
+    fn cannot_proceed_after_cancel() {
+        let mut sync = fresh_sync();
+        let _ = add_peer(&mut sync, 100);
+        let _ = sync.cancel_warp_sync();
+        assert!(matches!(sync.status(), Status::Sync));
+        assert!(!warp_sync_can_proceed(&sync));
+    }
+}

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -24,12 +24,14 @@ use crate::{log, network_service, platform::PlatformRef, util};
 use alloc::{
     borrow::{Cow, ToOwned as _},
     boxed::Box,
+    collections::VecDeque,
     format,
     string::String,
     sync::Arc,
     vec::Vec,
 };
 use core::{cmp, iter, num::NonZero, pin::Pin, time::Duration};
+use futures_channel::oneshot;
 use futures_lite::FutureExt as _;
 use futures_util::{FutureExt as _, StreamExt as _, future, stream};
 use hashbrown::HashMap;
@@ -40,6 +42,16 @@ use smoldot::{
     network::{self, codec},
     sync::all,
 };
+
+/// Peer-finalized minus local-finalized gap at/above which we commit to WarpAhead.
+/// Matches `warp_sync_minimum_gap` so the decision aligns with warp-sync's own
+/// willingness to engage a source.
+const MODE_DECISION_WARP_GAP_THRESHOLD: u64 = 32;
+
+/// Maximum wait for the first GrandpaNeighborPacket before falling back to AllForksOnly.
+/// Sized for cold-start peer discovery (DNS + libp2p handshake + gossip-open), which can
+/// stretch to ~20s on light clients.
+const MODE_DECISION_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Starts a sync service background task to synchronize a chain (relay chain or not) that is
 /// built with Substrate.
@@ -103,6 +115,12 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
             platform.sleep(Duration::from_secs(10)),
         ))
         .fuse(),
+        mode: ModeState::Deciding,
+        mode_decision_deadline: future::Either::Left(Box::pin(
+            platform.sleep(MODE_DECISION_TIMEOUT),
+        ))
+        .fuse(),
+        pending_subscriptions: VecDeque::new(),
         all_notifications: Vec::<async_channel::Sender<Notification>>::new(),
         log_target,
         from_network_service: None,
@@ -143,6 +161,7 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
             ObsoleteRequest(all::RequestId),
             RequestFinished(all::RequestId, Result<RequestOutcome, future::Aborted>),
             WarpSyncTakingLongTimeWarning,
+            ModeDecisionDeadline,
         }
 
         let wake_up_reason = {
@@ -192,6 +211,10 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                     future::Either::Left(Box::pin(task.platform.sleep(Duration::from_secs(10))))
                         .fuse();
                 WakeUpReason::WarpSyncTakingLongTimeWarning
+            })
+            .or(async {
+                (&mut task.mode_decision_deadline).await;
+                WakeUpReason::ModeDecisionDeadline
             })
             .or({
                 let sync = &mut task.sync;
@@ -354,6 +377,18 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                 // Since there is a gap in the blocks, all active notifications to all blocks
                 // must be cleared.
                 task.all_notifications.clear();
+
+                if matches!(task.mode, ModeState::AwaitingWarp | ModeState::Deciding) {
+                    task.mode = ModeState::Ready;
+                    task.mode_decision_deadline = future::Either::Right(future::pending()).fuse();
+                    log!(
+                        &task.platform,
+                        Debug,
+                        &task.log_target,
+                        "mode-decision; transition=Ready (WarpSyncFinished)",
+                    );
+                    drain_pending_subscriptions(&mut task);
+                }
             }
 
             WakeUpReason::SyncProcess(all::ProcessOne::VerifyWarpSyncFragment(verify)) => {
@@ -784,6 +819,43 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                     .as_mut()
                     .unwrap_or_else(|| unreachable!())
                     .update_source_finality_state(sync_source_id, finalized_block_height);
+
+                // Gate on peer_finalized, not peer_best: warp_sync only fires when
+                // peer_finalized - local >= 32, so deciding on best leaves warp_sync
+                // stalled waiting for finality to catch up (~6s/block on Polkadot).
+                if matches!(task.mode, ModeState::Deciding) {
+                    let local_finalized = task
+                        .sync
+                        .as_ref()
+                        .unwrap_or_else(|| unreachable!())
+                        .finalized_block_number();
+                    let gap = finalized_block_height.saturating_sub(local_finalized);
+                    if gap >= MODE_DECISION_WARP_GAP_THRESHOLD {
+                        task.mode = ModeState::AwaitingWarp;
+                        task.mode_decision_deadline =
+                            future::Either::Right(future::pending()).fuse();
+                        log!(
+                            &task.platform,
+                            Debug,
+                            &task.log_target,
+                            "mode-decision; committed=WarpAhead",
+                            local_finalized,
+                            peer_finalized = finalized_block_height,
+                            gap,
+                        );
+                    } else {
+                        log!(
+                            &task.platform,
+                            Debug,
+                            &task.log_target,
+                            "mode-decision; committed=AllForksOnly",
+                            local_finalized,
+                            peer_finalized = finalized_block_height,
+                            gap,
+                        );
+                        commit_all_forks_only(&mut task);
+                    }
+                }
             }
 
             WakeUpReason::NetworkEvent(network_service::Event::GrandpaCommitMessage {
@@ -911,40 +983,18 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                 buffer_size,
                 runtime_interest,
             }) => {
-                // Frontend would like to subscribe to events.
-
-                let Some(sync) = &task.sync else {
-                    unreachable!()
-                };
-
-                let (tx, new_blocks) = async_channel::bounded(buffer_size.saturating_sub(1));
-                task.all_notifications.push(tx);
-
-                let non_finalized_blocks_ancestry_order = {
-                    sync.non_finalized_blocks_ancestry_order()
-                        .map(|h| {
-                            let scale_encoding = h.scale_encoding_vec(sync.block_number_bytes());
-                            BlockNotification {
-                                is_new_best: header::hash_from_scale_encoded_header(
-                                    &scale_encoding,
-                                ) == *sync.best_block_hash(),
-                                scale_encoded_header: scale_encoding,
-                                parent_hash: *h.parent_hash,
-                            }
-                        })
-                        .collect()
-                };
-
-                let _ = send_back.send(SubscribeAll {
-                    finalized_block_scale_encoded_header: sync.finalized_block_header().to_owned(),
-                    finalized_block_runtime: if runtime_interest {
-                        task.known_finalized_runtime.take()
-                    } else {
-                        None
-                    },
-                    non_finalized_blocks_ancestry_order,
-                    new_blocks,
-                });
+                // While the mode-decision is pending, the sync's finalized block is the
+                // chain-spec checkpoint and may not be authoritative (warp-sync may
+                // overwrite it). Queue subscribers until the mode is committed.
+                if matches!(task.mode, ModeState::Ready) {
+                    respond_subscribe_all(&mut task, send_back, buffer_size, runtime_interest);
+                } else {
+                    task.pending_subscriptions.push_back(PendingSubscribeAll {
+                        send_back,
+                        buffer_size,
+                        runtime_interest,
+                    });
+                }
             }
 
             WakeUpReason::ForegroundMessage(ToBackground::PeersAssumedKnowBlock {
@@ -1409,8 +1459,39 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                     }
                 };
             }
+
+            WakeUpReason::ModeDecisionDeadline => {
+                task.mode_decision_deadline = future::Either::Right(future::pending()).fuse();
+                if matches!(task.mode, ModeState::Deciding) {
+                    log!(
+                        &task.platform,
+                        Debug,
+                        &task.log_target,
+                        "mode-decision; committed=AllForksOnly (timeout, no peers)",
+                    );
+                    commit_all_forks_only(&mut task);
+                }
+            }
         }
     }
+}
+
+/// Bootstrap mode decision.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum ModeState {
+    /// No GrandpaNeighborPacket received yet and the deadline has not fired.
+    /// `SubscribeAll` requests are queued.
+    Deciding,
+    /// Committed to WarpAhead; awaiting `WarpSyncFinished` before responding to subscribers.
+    AwaitingWarp,
+    /// First finalized block is authoritative; queued subscribers are drained.
+    Ready,
+}
+
+struct PendingSubscribeAll {
+    send_back: oneshot::Sender<SubscribeAll>,
+    buffer_size: usize,
+    runtime_interest: bool,
 }
 
 struct Task<TPlat: PlatformRef> {
@@ -1428,6 +1509,15 @@ struct Task<TPlat: PlatformRef> {
     ///
     /// Always `Some`, except for temporary extraction.
     sync: Option<all::AllSync<future::AbortHandle, (libp2p::PeerId, codec::Role), ()>>,
+
+    mode: ModeState,
+
+    /// Replaced with `pending` on mode commit so it never fires again.
+    mode_decision_deadline:
+        future::Fuse<future::Either<Pin<Box<TPlat::Delay>>, future::Pending<()>>>,
+
+    /// `SubscribeAll` requests queued during [`ModeState::Deciding`] / [`ModeState::AwaitingWarp`].
+    pending_subscriptions: VecDeque<PendingSubscribeAll>,
 
     /// If `Some`, contains the runtime of the current finalized block.
     known_finalized_runtime: Option<FinalizedBlockRuntime>,
@@ -1488,4 +1578,87 @@ impl<TPlat: PlatformRef> Task<TPlat> {
             self.all_notifications.push(subscription);
         }
     }
+}
+
+fn respond_subscribe_all<TPlat: PlatformRef>(
+    task: &mut Task<TPlat>,
+    send_back: oneshot::Sender<SubscribeAll>,
+    buffer_size: usize,
+    runtime_interest: bool,
+) {
+    let Some(sync) = &task.sync else {
+        unreachable!()
+    };
+
+    let (tx, new_blocks) = async_channel::bounded(buffer_size.saturating_sub(1));
+    task.all_notifications.push(tx);
+
+    let non_finalized_blocks_ancestry_order = sync
+        .non_finalized_blocks_ancestry_order()
+        .map(|h| {
+            let scale_encoding = h.scale_encoding_vec(sync.block_number_bytes());
+            BlockNotification {
+                is_new_best: header::hash_from_scale_encoded_header(&scale_encoding)
+                    == *sync.best_block_hash(),
+                scale_encoded_header: scale_encoding,
+                parent_hash: *h.parent_hash,
+            }
+        })
+        .collect();
+
+    let _ = send_back.send(SubscribeAll {
+        finalized_block_scale_encoded_header: sync.finalized_block_header().to_owned(),
+        finalized_block_runtime: if runtime_interest {
+            task.known_finalized_runtime.take()
+        } else {
+            None
+        },
+        non_finalized_blocks_ancestry_order,
+        new_blocks,
+    });
+}
+
+/// Responds to every queued `SubscribeAll` request. Each response allocates a fresh
+/// notification channel and pushes its sender into `task.all_notifications`.
+fn drain_pending_subscriptions<TPlat: PlatformRef>(task: &mut Task<TPlat>) {
+    while let Some(pending) = task.pending_subscriptions.pop_front() {
+        respond_subscribe_all(
+            task,
+            pending.send_back,
+            pending.buffer_size,
+            pending.runtime_interest,
+        );
+    }
+}
+
+/// Commits to AllForksOnly mode: cancels warp-sync, flips network-state flags to trigger
+/// the first GrandPa announce (without it peers won't gossip commits to us), drains queued
+/// subscribers.
+fn commit_all_forks_only<TPlat: PlatformRef>(task: &mut Task<TPlat>) {
+    task.mode = ModeState::Ready;
+    task.mode_decision_deadline = future::Either::Right(future::pending()).fuse();
+
+    let aborted = task
+        .sync
+        .as_mut()
+        .unwrap_or_else(|| unreachable!())
+        .cancel_warp_sync();
+    let n = aborted.len();
+    for handle in aborted {
+        handle.abort();
+    }
+    if n > 0 {
+        log!(
+            &task.platform,
+            Debug,
+            &task.log_target,
+            "warp-sync-cancelled",
+            in_flight_aborted = n,
+        );
+    }
+
+    task.network_up_to_date_finalized = false;
+    task.network_up_to_date_best = false;
+
+    drain_pending_subscriptions(task);
 }

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -50,10 +50,9 @@ use smoldot::{
 // https://github.com/paritytech/smoldot/pull/3268#discussion_r3311751768
 const MODE_DECISION_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Minimum number of below-gap GrandpaNeighborPackets observed while `Deciding` before
-/// committing to AllForksOnly. Guards against a single lagging first peer wrongly locking
-/// us into the slow path when our local finalized is an old chain-spec checkpoint.
-/// See https://github.com/paritytech/smoldot/pull/3268#discussion_r3311637661
+/// Below-gap packets to observe before committing AllForksOnly. Avoids one lagging
+/// first peer locking us into the slow path when our local finalized is a stale checkpoint.
+/// https://github.com/paritytech/smoldot/pull/3268#discussion_r3311637661
 const MODE_DECISION_MIN_PACKETS: usize = 2;
 
 /// Starts a sync service background task to synchronize a chain (relay chain or not) that is
@@ -850,34 +849,41 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                     .unwrap_or_else(|| unreachable!())
                     .update_source_finality_state(sync_source_id, finalized_block_height);
 
-                if matches!(task.mode, ModeState::Deciding) {
+                let outcome = neighbor_packet_outcome(
+                    &task.mode,
+                    task.sync.as_ref().unwrap_or_else(|| unreachable!()),
+                    task.deciding_packets_seen,
+                );
+                if !matches!(outcome, NeighborPacketOutcome::Ignore) {
                     let local_finalized = task
                         .sync
                         .as_ref()
                         .unwrap_or_else(|| unreachable!())
                         .finalized_block_number();
                     let gap = finalized_block_height.saturating_sub(local_finalized);
-                    if warp_sync_can_proceed(task.sync.as_ref().unwrap_or_else(|| unreachable!())) {
-                        task.mode = ModeState::AwaitingWarp {
-                            target_finalized: finalized_block_height,
-                        };
-                        // Keep the deadline armed as a warp-stall fallback.
-                        task.mode_decision_deadline = future::Either::Left(Box::pin(
-                            task.platform.sleep(MODE_DECISION_TIMEOUT),
-                        ))
-                        .fuse();
-                        log!(
-                            &task.platform,
-                            Debug,
-                            &task.log_target,
-                            "mode-decision; committed=WarpAhead",
-                            local_finalized,
-                            peer_finalized = finalized_block_height,
-                            gap,
-                        );
-                    } else {
-                        task.deciding_packets_seen += 1;
-                        if task.deciding_packets_seen >= MODE_DECISION_MIN_PACKETS {
+                    match outcome {
+                        NeighborPacketOutcome::Ignore => unreachable!(),
+                        NeighborPacketOutcome::CommitWarpAhead => {
+                            task.mode = ModeState::AwaitingWarp {
+                                target_finalized: finalized_block_height,
+                            };
+                            // Keep the deadline armed as a warp-stall fallback.
+                            task.mode_decision_deadline = future::Either::Left(Box::pin(
+                                task.platform.sleep(MODE_DECISION_TIMEOUT),
+                            ))
+                            .fuse();
+                            log!(
+                                &task.platform,
+                                Debug,
+                                &task.log_target,
+                                "mode-decision; committed=WarpAhead",
+                                local_finalized,
+                                peer_finalized = finalized_block_height,
+                                gap,
+                            );
+                        }
+                        NeighborPacketOutcome::CommitAllForksOnly => {
+                            task.deciding_packets_seen += 1;
                             log!(
                                 &task.platform,
                                 Debug,
@@ -889,7 +895,9 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                                 packets_seen = task.deciding_packets_seen,
                             );
                             commit_all_forks_only(&mut task);
-                        } else {
+                        }
+                        NeighborPacketOutcome::StayDeciding => {
+                            task.deciding_packets_seen += 1;
                             log!(
                                 &task.platform,
                                 Debug,
@@ -1588,8 +1596,7 @@ struct Task<TPlat: PlatformRef> {
 
     mode: ModeState,
 
-    /// Number of below-gap GrandpaNeighborPackets observed while in [`ModeState::Deciding`].
-    /// Only meaningful in that state; gates the early commit to AllForksOnly.
+    /// Below-gap packets observed while [`ModeState::Deciding`]; gates AllForksOnly commit.
     deciding_packets_seen: usize,
 
     /// Replaced with `pending` on mode commit so it never fires again.
@@ -1696,6 +1703,34 @@ fn respond_subscribe_all<TPlat: PlatformRef>(
         non_finalized_blocks_ancestry_order,
         new_blocks,
     });
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum NeighborPacketOutcome {
+    Ignore,
+    CommitWarpAhead,
+    CommitAllForksOnly,
+    StayDeciding,
+}
+
+/// `packets_seen` excludes the current packet. Caller must have already fed the new
+/// packet's finalized height into `sync`.
+fn neighbor_packet_outcome(
+    mode: &ModeState,
+    sync: &all::AllSync<future::AbortHandle, (libp2p::PeerId, codec::Role), ()>,
+    packets_seen: usize,
+) -> NeighborPacketOutcome {
+    if !matches!(mode, ModeState::Deciding) {
+        return NeighborPacketOutcome::Ignore;
+    }
+    if warp_sync_can_proceed(sync) {
+        return NeighborPacketOutcome::CommitWarpAhead;
+    }
+    if packets_seen + 1 >= MODE_DECISION_MIN_PACKETS {
+        NeighborPacketOutcome::CommitAllForksOnly
+    } else {
+        NeighborPacketOutcome::StayDeciding
+    }
 }
 
 /// Warp is downloading/building, or a qualifying source is available for the next request.
@@ -1896,5 +1931,62 @@ mod tests {
         let _ = sync.cancel_warp_sync();
         assert!(matches!(sync.status(), Status::Sync));
         assert!(!warp_sync_can_proceed(&sync));
+    }
+
+    #[test]
+    fn neighbor_packet_ignored_outside_deciding() {
+        let mut sync = fresh_sync();
+        let _ = add_peer(&mut sync, 100);
+        assert_eq!(
+            neighbor_packet_outcome(&ModeState::Ready, &sync, 0),
+            NeighborPacketOutcome::Ignore,
+        );
+        assert_eq!(
+            neighbor_packet_outcome(
+                &ModeState::AwaitingWarp { target_finalized: 100 },
+                &sync,
+                0,
+            ),
+            NeighborPacketOutcome::Ignore,
+        );
+    }
+
+    #[test]
+    fn neighbor_packet_commits_warp_with_eligible_peer() {
+        let mut sync = fresh_sync();
+        let _ = add_peer(&mut sync, 100);
+        assert_eq!(
+            neighbor_packet_outcome(&ModeState::Deciding, &sync, 0),
+            NeighborPacketOutcome::CommitWarpAhead,
+        );
+        // Eligible peer wins even with packets already buffered.
+        assert_eq!(
+            neighbor_packet_outcome(&ModeState::Deciding, &sync, 5),
+            NeighborPacketOutcome::CommitWarpAhead,
+        );
+    }
+
+    #[test]
+    fn neighbor_packet_stays_deciding_below_min() {
+        let mut sync = fresh_sync();
+        let _ = add_peer(&mut sync, 10);
+        assert_eq!(
+            neighbor_packet_outcome(&ModeState::Deciding, &sync, 0),
+            NeighborPacketOutcome::StayDeciding,
+        );
+    }
+
+    #[test]
+    fn neighbor_packet_commits_all_forks_at_min_packets() {
+        let mut sync = fresh_sync();
+        let _ = add_peer(&mut sync, 10);
+        assert_eq!(
+            neighbor_packet_outcome(
+                &ModeState::Deciding,
+                &sync,
+                MODE_DECISION_MIN_PACKETS - 1,
+            ),
+            NeighborPacketOutcome::CommitAllForksOnly,
+        );
     }
 }

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -46,6 +46,8 @@ use smoldot::{
 /// Maximum wait for the first GrandpaNeighborPacket before falling back to AllForksOnly.
 /// Sized for cold-start peer discovery (DNS + libp2p handshake + gossip-open), which can
 /// stretch to ~20s on light clients.
+// TODO follow-up: integration test that fires this timeout.
+// https://github.com/paritytech/smoldot/pull/3268#discussion_r3311751768
 const MODE_DECISION_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Starts a sync service background task to synchronize a chain (relay chain or not) that is
@@ -1744,9 +1746,7 @@ mod tests {
     use smoldot::{
         chain::chain_information,
         libp2p::peer_id::{PeerId, PublicKey},
-        sync::all::{
-            AddSource, AllSync, Config, DesiredRequest, RequestDetail, SourceId, Status,
-        },
+        sync::all::{AddSource, AllSync, Config, DesiredRequest, RequestDetail, SourceId, Status},
     };
 
     type TestSync = AllSync<future::AbortHandle, (PeerId, codec::Role), ()>;
@@ -1837,7 +1837,10 @@ mod tests {
         );
         assert!(matches!(
             sync.status(),
-            Status::WarpSyncFragments { source: Some(_), .. }
+            Status::WarpSyncFragments {
+                source: Some(_),
+                ..
+            }
         ));
         assert!(warp_sync_can_proceed(&sync));
     }

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -50,9 +50,8 @@ use smoldot::{
 // https://github.com/paritytech/smoldot/pull/3268#discussion_r3311751768
 const MODE_DECISION_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Below-gap packets to observe before committing AllForksOnly. Avoids one lagging
+/// Below warp sync minimum gap packets to observe before committing AllForksOnly. Avoids one lagging
 /// first peer locking us into the slow path when our local finalized is a stale checkpoint.
-/// https://github.com/paritytech/smoldot/pull/3268#discussion_r3311637661
 const MODE_DECISION_MIN_PACKETS: usize = 2;
 
 /// Starts a sync service background task to synchronize a chain (relay chain or not) that is
@@ -1948,7 +1947,9 @@ mod tests {
         );
         assert_eq!(
             neighbor_packet_outcome(
-                &ModeState::AwaitingWarp { target_finalized: 100 },
+                &ModeState::AwaitingWarp {
+                    target_finalized: 100
+                },
                 &sync,
                 0,
             ),
@@ -1986,11 +1987,7 @@ mod tests {
         let mut sync = fresh_sync();
         let _ = add_peer(&mut sync, 10);
         assert_eq!(
-            neighbor_packet_outcome(
-                &ModeState::Deciding,
-                &sync,
-                MODE_DECISION_MIN_PACKETS - 1,
-            ),
+            neighbor_packet_outcome(&ModeState::Deciding, &sync, MODE_DECISION_MIN_PACKETS - 1,),
             NeighborPacketOutcome::CommitAllForksOnly,
         );
     }


### PR DESCRIPTION
## Summary

Reintroduces the goal of https://github.com/paritytech/smoldot/pull/3246

Coordinates `warp_sync` and `all_forks` at startup so RPC consumers receive an authoritative finalized block instead of a stale chain-spec checkpoint hash.

On the first `GrandpaNeighborPacket`, compute `gap = peer_finalized - local_finalized`:
- `gap >= 32` → **WarpAhead**: hold subscribers; once `WarpSyncFinished` fires, reply with the post-warp finalized header.
- `gap < 32` → **AllForksOnly**: cancel warp-sync, announce GrandPa state, reply to subscribers with the chain-spec finalized header.

If no peers reports within 30s deadline then fallback to **AllForksOnly**.

After the commit both paths converge: normal all-forks block-by-block following. The decision is one-shot per startup.

Parachain bootstrap consumes the SubscribeAll snapshot's finalized header directly — the mode-decision gate makes it authoritative.

## Test plan
- Added 'chainhead_v1_follow' conformance tests in CI
