### PR TITLE
network_service: shorten handshake/ban timeouts to speed peer discovery

### DIFF
--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -2511,7 +2511,10 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     peer_id,
                     ?error,
                 );
-                let ban_duration = Duration::from_secs(3);
+                // Must exceed polkadot-sdk's 5s notification-reject ban; otherwise we retry
+                // into a still-active remote ban. 0.5s margin covers network delay and
+                // clock skew between the two sides' ban timers.
+                let ban_duration = Duration::from_millis(5500);
 
                 // Note that peer doesn't necessarily have an out slot, as this event might happen
                 // as a result of an inbound gossip connection.

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -206,7 +206,7 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
         let network = service::ChainNetwork::new(service::Config {
             chains_capacity: config.chains_capacity,
             connections_capacity: 32,
-            handshake_timeout: Duration::from_secs(8),
+            handshake_timeout: Duration::from_secs(4),
             randomness_seed: {
                 let mut seed = [0; 32];
                 config.platform.fill_random_bytes(&mut seed);
@@ -2333,7 +2333,14 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                 // another existing connection or connection attempt with that same peer. However,
                 // it is not possible to be sure that we will reach 0 connections or connection
                 // attempts, and thus we ban the peer every time.
-                let ban_duration = Duration::from_secs(5);
+                // Pre-handshake failures get a shorter ban: many parallel dials time out
+                // before any handshake completes, and a long slot-hold there dominates
+                // peer-discovery latency on restarts.
+                let ban_duration = if handshake_finished {
+                    Duration::from_secs(5)
+                } else {
+                    Duration::from_secs(2)
+                };
                 task.network.gossip_remove_desired_all(
                     &peer_id,
                     service::GossipKind::ConsensusTransactions,

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -2504,7 +2504,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     peer_id,
                     ?error,
                 );
-                let ban_duration = Duration::from_secs(15);
+                let ban_duration = Duration::from_secs(3);
 
                 // Note that peer doesn't necessarily have an out slot, as this event might happen
                 // as a result of an inbound gossip connection.

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -206,6 +206,7 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
         let network = service::ChainNetwork::new(service::Config {
             chains_capacity: config.chains_capacity,
             connections_capacity: 32,
+            // Shortened from 8s: parallel dials hold slots until this fires.
             handshake_timeout: Duration::from_secs(4),
             randomness_seed: {
                 let mut seed = [0; 32];


### PR DESCRIPTION
Tightens three timeouts in `light-base/src/network_service.rs` that  dominated peer-discovery latency on cold and warm restarts:

- `handshake_timeout`: 8s → 4s.
A handshake either completes quickly or it is not going to complete; 8s mostly served as a slot-hold for dead peers.
- Pre-handshake ban (dial / connection-attempt failure): 5s → 2s.
Many parallel dials time out before any handshake completes, and a 5s ban keeps peer slots tied up across the whole discovery burst.  Banning only briefly is enough to avoid immediate retry storms.
- Gossip-open-failed ban: 15s → 3s. 
Transient gossip failures should not lock out otherwise healthy peers for 15s — that is long enough to materially delay reaching usable peer count after a restart.

Post-handshake failures keep the 5s ban (the `handshake_finished` branch), since at that point we have stronger evidence the peer is misbehaving rather than just unreachable.

NOTE!
Values have been adjusted arbitrarily basing on the observations from `smoldot` startup times.