### PR TITLE
network_service: prefer bootnodes for gossip slots until a chain connects

### DIFF
--- a/lib/src/network/basic_peering_strategy.rs
+++ b/lib/src/network/basic_peering_strategy.rs
@@ -462,6 +462,18 @@ where
         chain: &TChainId,
         now: &TInstant,
     ) -> AssignablePeer<'_, TInstant> {
+        self.pick_assignable_peer_filtered(chain, now, |_| true)
+    }
+
+    /// Same as [`BasicPeeringStrategy::pick_assignable_peer`], except that only peers for which
+    /// `filter` returns `true` are taken into account. The [`AssignablePeer::AllPeersBanned`] and
+    /// [`AssignablePeer::NoPeer`] return values thus concern only the filtered subset of peers.
+    pub fn pick_assignable_peer_filtered(
+        &mut self,
+        chain: &TChainId,
+        now: &TInstant,
+        mut filter: impl FnMut(&PeerId) -> bool,
+    ) -> AssignablePeer<'_, TInstant> {
         let Some(&chain_index) = self.chains_indices.get(chain) else {
             return AssignablePeer::NoPeer;
         };
@@ -478,6 +490,7 @@ where
                         usize::MAX,
                     ),
             )
+            .filter(|(_, _, peer_id_index)| filter(&self.peer_ids[*peer_id_index]))
             .choose(&mut self.randomness)
         {
             return AssignablePeer::Assignable(&self.peer_ids[*peer_id_index]);
@@ -495,6 +508,7 @@ where
                 )),
                 ops::Bound::Excluded((chain_index, PeerChainState::Slot, usize::MIN)),
             ))
+            .filter(|(_, _, peer_id_index)| filter(&self.peer_ids[*peer_id_index]))
             .next()
         {
             let PeerChainState::Banned { expires } = state else {
@@ -1012,8 +1026,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        BasicPeeringStrategy, Config, InsertAddressConnectionsResult, InsertAddressResult,
-        InsertChainPeerResult,
+        AssignablePeer, BasicPeeringStrategy, Config, InsertAddressConnectionsResult,
+        InsertAddressResult, InsertChainPeerResult,
     };
     use crate::network::service::{PeerId, peer_id::PublicKey};
     use core::time::Duration;
@@ -1025,6 +1039,43 @@ mod tests {
         assert!(PeerChainState::Assignable < PeerChainState::Banned { expires: 0 });
         assert!(PeerChainState::Banned { expires: 5 } < PeerChainState::Banned { expires: 7 });
         assert!(PeerChainState::Banned { expires: u32::MAX } < PeerChainState::Slot);
+    }
+
+    #[test]
+    fn pick_assignable_peer_filtered_restricts_to_subset() {
+        let mut bps = BasicPeeringStrategy::<u32, Duration>::new(Config {
+            randomness_seed: [0; 32],
+            peers_capacity: 0,
+            chains_capacity: 0,
+        });
+
+        let bootnode = PeerId::from_public_key(&PublicKey::Ed25519([1; 32]));
+        let discovered = PeerId::from_public_key(&PublicKey::Ed25519([2; 32]));
+        for p in [&bootnode, &discovered] {
+            assert!(matches!(
+                bps.insert_chain_peer(0, p.clone(), usize::MAX),
+                InsertChainPeerResult::Inserted { peer_removed: None }
+            ));
+        }
+
+        // Filtering to the bootnode only ever yields the bootnode, regardless of randomness.
+        for _ in 0..20 {
+            assert!(matches!(
+                bps.pick_assignable_peer_filtered(&0, &Duration::ZERO, |p| *p == bootnode),
+                AssignablePeer::Assignable(p) if *p == bootnode
+            ));
+        }
+
+        // A filter excluding every peer reports no assignable peer even though peers exist...
+        assert!(matches!(
+            bps.pick_assignable_peer_filtered(&0, &Duration::ZERO, |_| false),
+            AssignablePeer::NoPeer
+        ));
+        // ...whereas the unfiltered pick still finds one.
+        assert!(matches!(
+            bps.pick_assignable_peer(&0, &Duration::ZERO),
+            AssignablePeer::Assignable(_)
+        ));
     }
 
     #[test]

--- a/lib/src/network/basic_peering_strategy.rs
+++ b/lib/src/network/basic_peering_strategy.rs
@@ -472,7 +472,7 @@ where
         &mut self,
         chain: &TChainId,
         now: &TInstant,
-        mut filter: impl FnMut(&PeerId) -> bool,
+        mut filter_fn: impl FnMut(&PeerId) -> bool,
     ) -> AssignablePeer<'_, TInstant> {
         let Some(&chain_index) = self.chains_indices.get(chain) else {
             return AssignablePeer::NoPeer;
@@ -490,7 +490,7 @@ where
                         usize::MAX,
                     ),
             )
-            .filter(|(_, _, peer_id_index)| filter(&self.peer_ids[*peer_id_index]))
+            .filter(|(_, _, peer_id_index)| filter_fn(&self.peer_ids[*peer_id_index]))
             .choose(&mut self.randomness)
         {
             return AssignablePeer::Assignable(&self.peer_ids[*peer_id_index]);
@@ -508,7 +508,7 @@ where
                 )),
                 ops::Bound::Excluded((chain_index, PeerChainState::Slot, usize::MIN)),
             ))
-            .filter(|(_, _, peer_id_index)| filter(&self.peer_ids[*peer_id_index]))
+            .filter(|(_, _, peer_id_index)| filter_fn(&self.peer_ids[*peer_id_index]))
             .next()
         {
             let PeerChainState::Banned { expires } = state else {

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -1290,10 +1290,30 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                                 continue;
                             }
 
-                            match task
-                                .peering_strategy
-                                .pick_assignable_peer(&chain_id, &task.platform.now())
-                            {
+                            let now = task.platform.now();
+
+                            // Until the chain has an open gossip link, prefer a bootnode (curated
+                            // and reachable); afterwards fill slots from the general pool.
+                            let has_open_gossip_link = task
+                                .open_gossip_links
+                                .keys()
+                                .any(|(link_chain_id, _)| *link_chain_id == chain_id);
+                            if !has_open_gossip_link {
+                                if let basic_peering_strategy::AssignablePeer::Assignable(peer_id) =
+                                    task.peering_strategy.pick_assignable_peer_filtered(
+                                        &chain_id,
+                                        &now,
+                                        |peer_id| task.important_nodes.contains(peer_id),
+                                    )
+                                {
+                                    break 'search WakeUpReason::CanAssignSlot(
+                                        peer_id.clone(),
+                                        chain_id,
+                                    );
+                                }
+                            }
+
+                            match task.peering_strategy.pick_assignable_peer(&chain_id, &now) {
                                 basic_peering_strategy::AssignablePeer::Assignable(peer_id) => {
                                     break 'search WakeUpReason::CanAssignSlot(
                                         peer_id.clone(),

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -254,6 +254,7 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
             next_recent_connection_restore: None,
             platform: config.platform.clone(),
             open_gossip_links: BTreeMap::new(),
+            chains_ever_gossip_connected: HashSet::with_capacity_and_hasher(4, Default::default()),
             v2_statement_peers: HashMap::with_capacity_and_hasher(4, Default::default()),
             current_affinity_filter: HashMap::with_capacity_and_hasher(4, Default::default()),
             event_pending_send: None,
@@ -1060,15 +1061,18 @@ struct BackgroundTask<TPlat: PlatformRef> {
     // TODO: using this data structure unfortunately means that PeerIds are cloned a lot, maybe some user data in ChainNetwork is better? not sure
     open_gossip_links: BTreeMap<(ChainId, PeerId), OpenGossipLinkState>,
 
+    /// Chains for which a gossip link has been opened at least once. Used to prefer bootnodes for
+    /// out slots only until the chain first connects.
+    chains_ever_gossip_connected: HashSet<ChainId, fnv::FnvBuildHasher>,
+
     /// Connected peers using statement protocol V2, per chain.
     v2_statement_peers: HashMap<ChainId, HashSet<PeerId, fnv::FnvBuildHasher>, fnv::FnvBuildHasher>,
 
     /// Current topic affinity filter per chain, sent to V2 peers on connect.
     current_affinity_filter: HashMap<ChainId, AffinityFilter, fnv::FnvBuildHasher>,
 
-    /// Nodes that are considered important, per chain. These nodes get additional logging, and
-    /// until a chain has an open gossip link its out slots are preferentially assigned to them. In
-    /// practice this is the set of bootnodes (see [`NetworkServiceChain::discover`]).
+    /// Important nodes per chain (in practice the bootnodes; see [`NetworkServiceChain::discover`]).
+    /// They get extra logging, and slot preference until the chain first connects.
     // TODO: should also detect whenever we fail to open a block announces substream with any of these peers
     important_nodes: HashMap<ChainId, HashSet<PeerId, fnv::FnvBuildHasher>, fnv::FnvBuildHasher>,
 
@@ -1294,14 +1298,9 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
 
                             let now = task.platform.now();
 
-                            // Until the chain has an open gossip link, prefer assigning slots to
-                            // important nodes (in practice the chain's bootnodes); afterwards fill
-                            // slots from the general pool of discovered peers.
-                            let has_open_gossip_link = task
-                                .open_gossip_links
-                                .keys()
-                                .any(|(link_chain_id, _)| *link_chain_id == chain_id);
-                            if !has_open_gossip_link {
+                            // Until the chain first connects, prefer slots for important nodes
+                            // (the bootnodes); otherwise use the general pool.
+                            if !task.chains_ever_gossip_connected.contains(&chain_id) {
                                 if let basic_peering_strategy::AssignablePeer::Assignable(peer_id) =
                                     task.peering_strategy.pick_assignable_peer_filtered(
                                         &chain_id,
@@ -1613,6 +1612,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                 task.v2_statement_peers.remove(&chain_id);
                 task.current_affinity_filter.remove(&chain_id);
                 task.important_nodes.remove(&chain_id);
+                task.chains_ever_gossip_connected.remove(&chain_id);
                 task.network.remove_chain(chain_id).unwrap();
                 task.peering_strategy.remove_chain_peers(&chain_id);
             }
@@ -2516,6 +2516,8 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     },
                 );
                 debug_assert!(_prev_value.is_none());
+
+                task.chains_ever_gossip_connected.insert(chain_id);
 
                 debug_assert!(task.event_pending_send.is_none());
                 task.event_pending_send = Some((

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -262,7 +262,7 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
             bitswap_event_pending_send: None,
             bitswap_event_senders: either::Left(Vec::new()),
             pending_new_bitswap_subscriptions: Vec::new(),
-            important_nodes: HashSet::with_capacity_and_hasher(16, Default::default()),
+            important_nodes: HashMap::with_capacity_and_hasher(16, Default::default()),
             main_messages_rx: Box::pin(main_messages_rx),
             messages_rx: stream::SelectAll::new(),
             blocks_requests: HashMap::with_capacity_and_hasher(8, Default::default()),
@@ -1066,9 +1066,11 @@ struct BackgroundTask<TPlat: PlatformRef> {
     /// Current topic affinity filter per chain, sent to V2 peers on connect.
     current_affinity_filter: HashMap<ChainId, AffinityFilter, fnv::FnvBuildHasher>,
 
-    /// List of nodes that are considered as important for logging purposes.
+    /// Nodes that are considered important, per chain. These nodes get additional logging, and
+    /// until a chain has an open gossip link its out slots are preferentially assigned to them. In
+    /// practice this is the set of bootnodes (see [`NetworkServiceChain::discover`]).
     // TODO: should also detect whenever we fail to open a block announces substream with any of these peers
-    important_nodes: HashSet<PeerId, fnv::FnvBuildHasher>,
+    important_nodes: HashMap<ChainId, HashSet<PeerId, fnv::FnvBuildHasher>, fnv::FnvBuildHasher>,
 
     /// Event about to be sent on the senders of [`BackgroundTask::event_senders`].
     event_pending_send: Option<(ChainId, Event)>,
@@ -1292,8 +1294,9 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
 
                             let now = task.platform.now();
 
-                            // Until the chain has an open gossip link, prefer a bootnode (curated
-                            // and reachable); afterwards fill slots from the general pool.
+                            // Until the chain has an open gossip link, prefer assigning slots to
+                            // important nodes (in practice the chain's bootnodes); afterwards fill
+                            // slots from the general pool of discovered peers.
                             let has_open_gossip_link = task
                                 .open_gossip_links
                                 .keys()
@@ -1303,7 +1306,11 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                                     task.peering_strategy.pick_assignable_peer_filtered(
                                         &chain_id,
                                         &now,
-                                        |peer_id| task.important_nodes.contains(peer_id),
+                                        |peer_id| {
+                                            task.important_nodes
+                                                .get(&chain_id)
+                                                .map_or(false, |nodes| nodes.contains(peer_id))
+                                        },
                                     )
                                 {
                                     break 'search WakeUpReason::CanAssignSlot(
@@ -1605,6 +1612,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                 );
                 task.v2_statement_peers.remove(&chain_id);
                 task.current_affinity_filter.remove(&chain_id);
+                task.important_nodes.remove(&chain_id);
                 task.network.remove_chain(chain_id).unwrap();
                 task.peering_strategy.remove_chain_peers(&chain_id);
             }
@@ -2166,7 +2174,10 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
             ) => {
                 for (peer_id, addrs) in list {
                     if important_nodes {
-                        task.important_nodes.insert(peer_id.clone());
+                        task.important_nodes
+                            .entry(chain_id)
+                            .or_default()
+                            .insert(peer_id.clone());
                     }
 
                     // Note that we must call this function before `insert_address`, as documented


### PR DESCRIPTION
On warm rest, the relay out-slots get filled from the restored peer book, which is full of DHT-discovered nodes advertising unreachable private/link-local endpoints. They time out and churn the slots for many seconds, delaying the first relay gossip.

This is not the case for cold start, where relay out-slots get filled from the chain-spec bootnodes.

Fix: Attempt to mimic cold approach by picking bootnodes if possible while a chain has no open gossip link.
