### PR TITLE
light-base: opt-in optimistic parachain bootstrap with gated reads

### DIFF
--- a/.config/smoldot.dic
+++ b/.config/smoldot.dic
@@ -1,4 +1,4 @@
-153
+155
 ABI
 ACK
 API
@@ -68,6 +68,7 @@ Westend
 Yamux
 aborter
 allocator
+allowlist/S
 amongst
 authorable
 backend/S
@@ -120,6 +121,7 @@ noncomprehending
 opcode
 orthogonally
 parachain/S
+parahead/S
 parathread/S
 parsers
 pluggable

--- a/lib/src/network/codec/storage_call_proof.rs
+++ b/lib/src/network/codec/storage_call_proof.rs
@@ -174,7 +174,8 @@ pub fn build_child_storage_proof_request<'a>(
     // `InvalidChildStorageKey`. `ChildStorageProofRequestConfig::child_trie` is the bare name,
     // so the prefix is prepended here.
     const PREFIX: &[u8] = b":child_storage:default:";
-    let mut prefixed_child_trie = Vec::with_capacity(PREFIX.len() + config.child_trie.as_ref().len());
+    let mut prefixed_child_trie =
+        Vec::with_capacity(PREFIX.len() + config.child_trie.as_ref().len());
     prefixed_child_trie.extend_from_slice(PREFIX);
     prefixed_child_trie.extend_from_slice(config.child_trie.as_ref());
 

--- a/lib/src/network/codec/storage_call_proof.rs
+++ b/lib/src/network/codec/storage_call_proof.rs
@@ -168,16 +168,26 @@ pub fn build_child_storage_proof_request<'a>(
         impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + 'a,
     >,
 ) -> impl Iterator<Item = impl AsRef<[u8]>> {
+    // The remote expects the child storage key in field 3 to be the full prefixed key
+    // (`:child_storage:default:<child_trie>`). It strips the prefix via
+    // `ChildType::from_prefixed_key` and rejects a bare child trie name with
+    // `InvalidChildStorageKey`. `ChildStorageProofRequestConfig::child_trie` is the bare name,
+    // so the prefix is prepended here.
+    const PREFIX: &[u8] = b":child_storage:default:";
+    let mut prefixed_child_trie = Vec::with_capacity(PREFIX.len() + config.child_trie.as_ref().len());
+    prefixed_child_trie.extend_from_slice(PREFIX);
+    prefixed_child_trie.extend_from_slice(config.child_trie.as_ref());
+
     // Message format for RemoteReadChildRequest (tag 4 in Request oneof):
     // - Field 2: block hash
-    // - Field 3: child storage key (child trie name)
+    // - Field 3: child storage key (prefixed child trie key)
     // - Field 6: keys to fetch
     protobuf::message_tag_encode(
         4,
         protobuf::bytes_tag_encode(2, config.block_hash)
             .map(either::Left)
             .chain(
-                protobuf::bytes_tag_encode(3, config.child_trie)
+                protobuf::bytes_tag_encode(3, prefixed_child_trie)
                     .map(either::Left)
                     .map(either::Right),
             )

--- a/light-base/examples/basic.rs
+++ b/light-base/examples/basic.rs
@@ -83,6 +83,9 @@ fn main() {
 
             // Statement protocol is not used in this example.
             statement_protocol_config: None,
+
+            // Optimistic parachain bootstrap is not used in this example.
+            optimistic_parachain_bootstrap: smoldot_light::OptimisticParachainBootstrap::Disabled,
         })
         .unwrap();
     // The Polkadot chain is now properly initialized.
@@ -118,6 +121,7 @@ fn main() {
             // previously been created is completely appropriate.
             potential_relay_chains: [polkadot_chain_id].into_iter(),
             statement_protocol_config: None,
+            optimistic_parachain_bootstrap: smoldot_light::OptimisticParachainBootstrap::Disabled,
         })
         .unwrap();
     // The Assethub chain is now properly initialized.

--- a/light-base/examples/statement_test.rs
+++ b/light-base/examples/statement_test.rs
@@ -56,6 +56,8 @@ fn main() {
         } = client
             .add_chain(smoldot_light::AddChainConfig {
                 specification: &relay_chain_spec,
+                optimistic_parachain_bootstrap:
+                    smoldot_light::OptimisticParachainBootstrap::Disabled,
                 json_rpc: smoldot_light::AddChainConfigJsonRpc::Enabled {
                     max_pending_requests: NonZero::<u32>::new(128).unwrap(),
                     max_subscriptions: 1024,
@@ -84,6 +86,8 @@ fn main() {
             } = client
                 .add_chain(smoldot_light::AddChainConfig {
                     specification: &para_spec,
+                    optimistic_parachain_bootstrap:
+                        smoldot_light::OptimisticParachainBootstrap::Disabled,
                     json_rpc: smoldot_light::AddChainConfigJsonRpc::Enabled {
                         max_pending_requests: NonZero::<u32>::new(128).unwrap(),
                         max_subscriptions: 1024,

--- a/light-base/examples/test_asset_hub.rs
+++ b/light-base/examples/test_asset_hub.rs
@@ -44,6 +44,7 @@ fn main() {
             database_content: "",
             user_data: (),
             statement_protocol_config: None,
+            optimistic_parachain_bootstrap: smoldot_light::OptimisticParachainBootstrap::Disabled,
         })
         .unwrap();
 
@@ -62,6 +63,7 @@ fn main() {
             database_content: "",
             user_data: (),
             statement_protocol_config: None,
+            optimistic_parachain_bootstrap: smoldot_light::OptimisticParachainBootstrap::Disabled,
         })
         .unwrap();
 

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -51,6 +51,7 @@ use alloc::{
     format,
     string::{String, ToString as _},
     sync::Arc,
+    vec::Vec,
 };
 use core::{num::NonZero, pin::Pin};
 use futures_lite::StreamExt as _;
@@ -126,6 +127,21 @@ pub struct Config<TPlat: PlatformRef> {
     /// Maximum number of seen statement hashes tracked per subscription for dedup.
     /// `None` if the statement protocol is disabled.
     pub max_seen_statements: Option<NonZero<usize>>,
+
+    /// `Some` iff the chain was added with
+    /// [`crate::OptimisticParachainBootstrap::Enabled`]. While the contained `gate_open` is
+    /// still `false`, `chainHead_v1_storage` is gated by `allowed_storage_prefixes` and
+    /// `chainHead_v1_call` / `transaction_v1_broadcast` / `transactionWatch_v1_submitAndWatch`
+    /// are rejected with `-32802`. The gate flips to `true` when the parachain sync service
+    /// applies its first real `Notification::Finalized` from the relay chain.
+    pub optimistic_state: Option<OptimisticState>,
+}
+
+/// See [`Config::optimistic_state`].
+#[derive(Clone)]
+pub struct OptimisticState {
+    pub gate_open: Arc<core::sync::atomic::AtomicBool>,
+    pub allowed_storage_prefixes: Arc<Vec<Vec<u8>>>,
 }
 
 /// Creates a new JSON-RPC service with the given configuration.
@@ -167,6 +183,7 @@ pub fn service<TPlat: PlatformRef>(config: Config<TPlat>) -> Frontend<TPlat> {
                 genesis_block_hash: config.genesis_block_hash,
                 statement_protocol_config: config.statement_protocol_config,
                 max_seen_statements: config.max_seen_statements,
+                optimistic_state: config.optimistic_state,
             },
             requests_rx,
             responses_tx,

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -96,6 +96,9 @@ pub(super) struct Config<TPlat: PlatformRef> {
     /// Maximum number of seen statement hashes tracked per subscription for dedup.
     /// `None` if the statement protocol is disabled.
     pub max_seen_statements: Option<NonZero<usize>>,
+
+    /// See [`crate::json_rpc_service::Config::optimistic_state`].
+    pub optimistic_state: Option<crate::json_rpc_service::OptimisticState>,
 }
 
 /// Fields used to process JSON-RPC requests in the background.
@@ -127,6 +130,9 @@ struct Background<TPlat: PlatformRef> {
     randomness: ChaCha20Rng,
 
     statement_protocol_config: Option<network_service::StatementProtocolConfig>,
+
+    /// See [`Config::optimistic_state`].
+    optimistic_state: Option<crate::json_rpc_service::OptimisticState>,
 
     /// See [`Config::network_service`].
     network_service: Arc<network_service::NetworkServiceChain<TPlat>>,
@@ -251,6 +257,18 @@ struct Background<TPlat: PlatformRef> {
 }
 
 impl<TPlat: PlatformRef> Background<TPlat> {
+    /// Returns the optimistic-bootstrap state while its gate is still closed.
+    ///
+    /// Returns `None` once the gate has opened on the first real relay finalization, or when the
+    /// chain was not added with [`crate::OptimisticParachainBootstrap::Enabled`]. While `Some`,
+    /// `chainHead_v1_call` and transaction submission are rejected, and `chainHead_v1_storage` is
+    /// restricted to [`crate::json_rpc_service::OptimisticState::allowed_storage_prefixes`].
+    fn optimistic_gate(&self) -> Option<&crate::json_rpc_service::OptimisticState> {
+        self.optimistic_state
+            .as_ref()
+            .filter(|s| !s.gate_open.load(core::sync::atomic::Ordering::Acquire))
+    }
+
     /// Marks the statement affinity as stale and schedules the next update.
     /// If no update was ever sent, or the last update was more than the configured
     /// affinity update interval ago, the update fires immediately.
@@ -562,6 +580,7 @@ pub(super) async fn run<TPlat: PlatformRef>(
             seed
         }),
         statement_protocol_config: config.statement_protocol_config,
+        optimistic_state: config.optimistic_state,
         next_garbage_collection: Box::pin(config.platform.sleep(Duration::new(0, 0))),
         network_service: config.network_service.clone(),
         sync_service: config.sync_service.clone(),
@@ -2039,6 +2058,25 @@ pub(super) async fn run<TPlat: PlatformRef>(
                         function,
                         call_parameters: methods::HexString(call_parameters),
                     } => {
+                        // Reject during the optimistic-bootstrap window. Runtime calls execute
+                        // arbitrary WASM that can read anything, which the storage allowlist
+                        // cannot constrain.
+                        if me.optimistic_gate().is_some() {
+                            let _ = me
+                                .responses_tx
+                                .send(parse::build_error_response(
+                                    request_id_json,
+                                    parse::ErrorResponse::ApplicationDefined(
+                                        -32802,
+                                        "chainHead_v1_call rejected during \
+                                         optimistic-parachain-bootstrap window",
+                                    ),
+                                    None,
+                                ))
+                                .await;
+                            continue;
+                        }
+
                         let Some(subscription) = me
                             .chain_head_follow_subscriptions
                             .get_mut(&*follow_subscription)
@@ -2227,6 +2265,46 @@ pub(super) async fn run<TPlat: PlatformRef>(
                         items,
                         child_trie,
                     } => {
+                        // Allowlist gate for the optimistic-bootstrap window. While the gate
+                        // is closed, the call must stay within the configured prefixes or it is
+                        // rejected. For a main-trie query every item key is checked. For a
+                        // child-trie query the child trie's prefixed name
+                        // `:child_storage:default:<child_trie>` is checked, which lets a caller
+                        // allow whole classes of child tries without enumerating individual slot
+                        // keys.
+                        if let Some(s) = me.optimistic_gate() {
+                            let any_disallowed = if let Some(child_trie) = child_trie.as_ref() {
+                                const PREFIX: &[u8] = b":child_storage:default:";
+                                let mut prefixed =
+                                    Vec::with_capacity(PREFIX.len() + child_trie.0.len());
+                                prefixed.extend_from_slice(PREFIX);
+                                prefixed.extend_from_slice(&child_trie.0);
+                                !s.allowed_storage_prefixes
+                                    .iter()
+                                    .any(|prefix| prefixed.starts_with(prefix))
+                            } else {
+                                items.iter().any(|item| {
+                                    !s.allowed_storage_prefixes
+                                        .iter()
+                                        .any(|prefix| item.key.0.starts_with(prefix))
+                                })
+                            };
+                            if any_disallowed {
+                                let _ = me
+                                    .responses_tx
+                                    .send(parse::build_error_response(
+                                        request_id_json,
+                                        parse::ErrorResponse::ApplicationDefined(
+                                            -32802,
+                                            "storage key outside optimistic-bootstrap allowlist",
+                                        ),
+                                        None,
+                                    ))
+                                    .await;
+                                continue;
+                            }
+                        }
+
                         let Some(subscription) = me
                             .chain_head_follow_subscriptions
                             .get_mut(&*follow_subscription)
@@ -2270,26 +2348,29 @@ pub(super) async fn run<TPlat: PlatformRef>(
                             }
                         };
 
-                        if child_trie.is_some() {
-                            // TODO: implement this
+                        // Child-trie queries only support value and hash reads. The descendants
+                        // and merkle-value variants resolve against a trie root that, for a child
+                        // trie, isn't known until its proof arrives.
+                        if child_trie.is_some()
+                            && items.iter().any(|item| {
+                                !matches!(
+                                    item.ty,
+                                    methods::ChainHeadStorageType::Value
+                                        | methods::ChainHeadStorageType::Hash
+                                )
+                            })
+                        {
                             let _ = me
                                 .responses_tx
                                 .send(parse::build_error_response(
                                     request_id_json,
                                     parse::ErrorResponse::ServerError(
                                         -32000,
-                                        "Child key storage queries not supported yet",
+                                        "child-trie storage queries only support value and hash reads",
                                     ),
                                     None,
                                 ))
                                 .await;
-                            log!(
-                                &me.platform,
-                                Warn,
-                                &me.log_target,
-                                "chainHead_v1_storage has been called with a non-null childTrie. \
-                                This isn't supported by smoldot yet."
-                            );
                             continue;
                         }
 
@@ -2341,15 +2422,28 @@ pub(super) async fn run<TPlat: PlatformRef>(
                         }
 
                         // Initialize the storage query operation.
-                        let fetch_operation = me.sync_service.clone().storage_query(
-                            block_number,
-                            hash.0,
-                            block_state_trie_root,
-                            storage_operations.into_iter(),
-                            3,
-                            Duration::from_secs(20),
-                            NonZero::<u32>::new(2).unwrap(),
-                        );
+                        let fetch_operation = if let Some(child_trie) = child_trie {
+                            me.sync_service.clone().child_storage_query(
+                                block_number,
+                                hash.0,
+                                block_state_trie_root,
+                                child_trie.0,
+                                storage_operations.into_iter(),
+                                3,
+                                Duration::from_secs(20),
+                                NonZero::<u32>::new(2).unwrap(),
+                            )
+                        } else {
+                            me.sync_service.clone().storage_query(
+                                block_number,
+                                hash.0,
+                                block_state_trie_root,
+                                storage_operations.into_iter(),
+                                3,
+                                Duration::from_secs(20),
+                                NonZero::<u32>::new(2).unwrap(),
+                            )
+                        };
 
                         let operation_id = {
                             let mut operation_id = [0u8; 32];
@@ -2817,6 +2911,26 @@ pub(super) async fn run<TPlat: PlatformRef>(
                                 )
                                 .to_json_response(request_id_json),
                             )
+                            .await;
+                    }
+
+                    methods::MethodCall::transaction_v1_broadcast { .. }
+                    | methods::MethodCall::transactionWatch_v1_submitAndWatch { .. }
+                        if me.optimistic_gate().is_some() =>
+                    {
+                        // Reject during the optimistic-bootstrap window. A wallet must not
+                        // sign against state that may be on a relay fork that loses.
+                        let _ = me
+                            .responses_tx
+                            .send(parse::build_error_response(
+                                request_id_json,
+                                parse::ErrorResponse::ApplicationDefined(
+                                    -32802,
+                                    "transaction submission rejected during \
+                                     optimistic-parachain-bootstrap window",
+                                ),
+                                None,
+                            ))
                             .await;
                     }
 

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -1000,13 +1000,12 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                 genesis_block_hash,
                 statement_protocol_config,
                 max_seen_statements,
-                optimistic_state: services
-                    .optimistic_state
-                    .as_ref()
-                    .map(|s| json_rpc_service::OptimisticState {
+                optimistic_state: services.optimistic_state.as_ref().map(|s| {
+                    json_rpc_service::OptimisticState {
                         gate_open: s.gate_open.clone(),
                         allowed_storage_prefixes: s.allowed_storage_prefixes.clone(),
-                    }),
+                    }
+                }),
             });
 
             Some(frontend)
@@ -1256,10 +1255,11 @@ fn start_services<TPlat: platform::PlatformRef>(
             // Optimistic state is created here when the embedder opted in. The Arc is shared
             // between sync_service (which flips the gate on first real finalization) and
             // json_rpc_service (which reads it to decide whether to gate handlers).
-            optimistic_state = optimistic_allowed_storage_prefixes.map(|prefixes| OptimisticState {
-                gate_open: Arc::new(core::sync::atomic::AtomicBool::new(false)),
-                allowed_storage_prefixes: Arc::new(prefixes),
-            });
+            optimistic_state =
+                optimistic_allowed_storage_prefixes.map(|prefixes| OptimisticState {
+                    gate_open: Arc::new(core::sync::atomic::AtomicBool::new(false)),
+                    allowed_storage_prefixes: Arc::new(prefixes),
+                });
 
             // The sync service is leveraging the network service, downloads block headers,
             // and verifies them, to determine what are the best and finalized blocks of the

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -161,19 +161,18 @@ pub enum OptimisticParachainBootstrap {
     /// before deriving the initial parachain head.
     Disabled,
 
-    /// The parachain's initial finalized head is derived from the relay chain's current best
-    /// block instead of waiting for the next finalized relay block. This removes the wait for
-    /// the next relay finalization from cold start, at the cost of the derived parahead being
-    /// unverified until a real relay finalization confirms it.
+    /// The parachain's initial head is taken from the relay chain's current finalized block
+    /// rather than by waiting for a new one. This removes the wait from cold start, and because
+    /// that block is already final the derived parahead never reorgs.
     ///
-    /// Until the first real `Notification::Finalized` arrives, the JSON-RPC interface is gated
-    /// to bound the blast radius. `chainHead_v1_storage` is restricted to `allowed_storage_prefixes`
-    /// while `chainHead_v1_call` and transaction submission are rejected outright, all with error
-    /// `-32802`. The gates lift on the first real relay finalization.
+    /// Until the parachain observes its first new relay finalization, the JSON-RPC interface is
+    /// restricted while the chain catches up from the bootstrap block: `chainHead_v1_storage` is
+    /// limited to `allowed_storage_prefixes`, and `chainHead_v1_call` and transaction submission
+    /// are rejected with error `-32802`. The restrictions lift at that point.
     Enabled {
         /// Allowlist of storage-key prefixes (raw bytes, not hex) readable via
-        /// `chainHead_v1_storage` during the optimistic window. An empty list disallows all
-        /// storage reads. A child-trie query matches against the prefixed child trie name
+        /// `chainHead_v1_storage` during the bootstrap window. An empty list disallows all
+        /// reads. A child-trie query matches against the prefixed child trie name
         /// `:child_storage:default:<child_trie>` rather than the keys within it.
         allowed_storage_prefixes: Vec<Vec<u8>>,
     },

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -146,6 +146,37 @@ pub struct AddChainConfig<'a, TChain, TRelays> {
 
     /// If `Some`, enables the statement store networking protocol.
     pub statement_protocol_config: Option<network_service::StatementProtocolConfig>,
+
+    /// Configures optimistic parachain bootstrap. Ignored for relay chains. Defaults to
+    /// [`OptimisticParachainBootstrap::Disabled`].
+    ///
+    /// See <https://github.com/paritytech/smoldot/issues/3237>.
+    pub optimistic_parachain_bootstrap: OptimisticParachainBootstrap,
+}
+
+/// See [`AddChainConfig::optimistic_parachain_bootstrap`].
+#[derive(Debug, Clone)]
+pub enum OptimisticParachainBootstrap {
+    /// Default. The parachain awaits the next `Notification::Finalized` on its relay chain
+    /// before deriving the initial parachain head.
+    Disabled,
+
+    /// The parachain's initial finalized head is derived from the relay chain's current best
+    /// block instead of waiting for the next finalized relay block. This removes the wait for
+    /// the next relay finalization from cold start, at the cost of the derived parahead being
+    /// unverified until a real relay finalization confirms it.
+    ///
+    /// Until the first real `Notification::Finalized` arrives, the JSON-RPC interface is gated
+    /// to bound the blast radius. `chainHead_v1_storage` is restricted to `allowed_storage_prefixes`
+    /// while `chainHead_v1_call` and transaction submission are rejected outright, all with error
+    /// `-32802`. The gates lift on the first real relay finalization.
+    Enabled {
+        /// Allowlist of storage-key prefixes (raw bytes, not hex) readable via
+        /// `chainHead_v1_storage` during the optimistic window. An empty list disallows all
+        /// storage reads. A child-trie query matches against the prefixed child trie name
+        /// `:child_storage:default:<child_trie>` rather than the keys within it.
+        allowed_storage_prefixes: Vec<Vec<u8>>,
+    },
 }
 
 /// See [`AddChainConfig::json_rpc`].
@@ -291,6 +322,18 @@ struct ChainServices<TPlat: platform::PlatformRef> {
     runtime_service: Arc<runtime_service::RuntimeService<TPlat>>,
     transactions_service: Arc<transactions_service::TransactionsService<TPlat>>,
     bitswap_service: Arc<bitswap_service::BitswapService>,
+    /// `Some` if the chain was added with
+    /// [`OptimisticParachainBootstrap::Enabled`]. The flag inside the `Arc` is
+    /// flipped to `true` by the parachain sync service when the first real
+    /// `Notification::Finalized` arrives, at which point the JSON-RPC gates
+    /// lift.
+    optimistic_state: Option<OptimisticState>,
+}
+
+#[derive(Clone)]
+struct OptimisticState {
+    gate_open: Arc<core::sync::atomic::AtomicBool>,
+    allowed_storage_prefixes: Arc<Vec<Vec<u8>>>,
 }
 
 impl<TPlat: platform::PlatformRef> Clone for ChainServices<TPlat> {
@@ -301,6 +344,7 @@ impl<TPlat: platform::PlatformRef> Clone for ChainServices<TPlat> {
             runtime_service: self.runtime_service.clone(),
             transactions_service: self.transactions_service.clone(),
             bitswap_service: self.bitswap_service.clone(),
+            optimistic_state: self.optimistic_state.clone(),
         }
     }
 }
@@ -705,10 +749,20 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                         self.platform.client_version()
                     );
 
+                    // `None` disables optimistic bootstrap. `Some` enables it, the contained list
+                    // being the storage allowlist applied while the gate is closed.
+                    let optimistic_allowed_storage_prefixes =
+                        match &config.optimistic_parachain_bootstrap {
+                            OptimisticParachainBootstrap::Disabled => None,
+                            OptimisticParachainBootstrap::Enabled {
+                                allowed_storage_prefixes,
+                            } => Some(allowed_storage_prefixes.clone()),
+                        };
                     let config = match (&relay_chain, &chain_information) {
                         (Some((relay_chain, para_id, _)), _) => StartServicesChainTy::Parachain {
                             relay_chain,
                             para_id: *para_id,
+                            optimistic_allowed_storage_prefixes,
                         },
                         (None, Some(chain_information)) => {
                             StartServicesChainTy::SubstrateCompatible { chain_information }
@@ -946,6 +1000,13 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                 genesis_block_hash,
                 statement_protocol_config,
                 max_seen_statements,
+                optimistic_state: services
+                    .optimistic_state
+                    .as_ref()
+                    .map(|s| json_rpc_service::OptimisticState {
+                        gate_open: s.gate_open.clone(),
+                        allowed_storage_prefixes: s.allowed_storage_prefixes.clone(),
+                    }),
             });
 
             Some(frontend)
@@ -1117,6 +1178,7 @@ enum StartServicesChainTy<'a, TPlat: platform::PlatformRef> {
     Parachain {
         relay_chain: &'a ChainServices<TPlat>,
         para_id: u32,
+        optimistic_allowed_storage_prefixes: Option<Vec<Vec<u8>>>,
     },
 }
 
@@ -1181,12 +1243,23 @@ fn start_services<TPlat: platform::PlatformRef>(
         statement_protocol_config,
     });
 
+    let mut optimistic_state: Option<OptimisticState> = None;
+
     let (sync_service, runtime_service) = match config {
         StartServicesChainTy::Parachain {
             relay_chain,
             para_id,
+            optimistic_allowed_storage_prefixes,
         } => {
             // Chain is a parachain.
+
+            // Optimistic state is created here when the embedder opted in. The Arc is shared
+            // between sync_service (which flips the gate on first real finalization) and
+            // json_rpc_service (which reads it to decide whether to gate handlers).
+            optimistic_state = optimistic_allowed_storage_prefixes.map(|prefixes| OptimisticState {
+                gate_open: Arc::new(core::sync::atomic::AtomicBool::new(false)),
+                allowed_storage_prefixes: Arc::new(prefixes),
+            });
 
             // The sync service is leveraging the network service, downloads block headers,
             // and verifies them, to determine what are the best and finalized blocks of the
@@ -1202,6 +1275,9 @@ fn start_services<TPlat: platform::PlatformRef>(
                             para_id,
                             relay_chain_sync: relay_chain.runtime_service.clone(),
                         },
+                        optimistic_gate_open: optimistic_state
+                            .as_ref()
+                            .map(|s| s.gate_open.clone()),
                     },
                 ),
             }));
@@ -1294,5 +1370,6 @@ fn start_services<TPlat: platform::PlatformRef>(
         sync_service,
         transactions_service,
         bitswap_service,
+        optimistic_state,
     }
 }

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -112,7 +112,7 @@ pub struct ConfigParachain<TPlat: PlatformRef> {
     /// `Some` enables optimistic parachain bootstrap. See
     /// [`crate::AddChainConfig::optimistic_parachain_bootstrap`]. The contained `AtomicBool`
     /// is flipped from `false` to `true` by the parachain sync service when it processes its
-    /// first real `Notification::Finalized` from the relay chain, signalling that downstream
+    /// first real `Notification::Finalized` from the relay chain, signaling that downstream
     /// consumers can lift any optimistic-window restrictions.
     pub optimistic_gate_open: Option<Arc<core::sync::atomic::AtomicBool>>,
 }

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -108,6 +108,13 @@ pub struct ConfigSubstrateCompatibleRuntimeCodeHint {
 pub struct ConfigParachain<TPlat: PlatformRef> {
     /// Parameters of the relay chain.
     pub relay_chain: ConfigRelayChain<TPlat>,
+
+    /// `Some` enables optimistic parachain bootstrap. See
+    /// [`crate::AddChainConfig::optimistic_parachain_bootstrap`]. The contained `AtomicBool`
+    /// is flipped from `false` to `true` by the parachain sync service when it processes its
+    /// first real `Notification::Finalized` from the relay chain, signalling that downstream
+    /// consumers can lift any optimistic-window restrictions.
+    pub optimistic_gate_open: Option<Arc<core::sync::atomic::AtomicBool>>,
 }
 
 /// See [`ConfigParachain::relay_chain`].
@@ -152,6 +159,7 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
                 config.block_number_bytes,
                 config_parachain.relay_chain.relay_chain_sync.clone(),
                 config_parachain.relay_chain.para_id,
+                config_parachain.optimistic_gate_open,
                 from_foreground,
                 config.network_service.clone(),
             )),
@@ -423,6 +431,61 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
         timeout_per_request: Duration,
         max_parallel: NonZero<u32>,
     ) -> StorageQuery<TPlat> {
+        self.storage_query_inner(
+            block_number,
+            block_hash,
+            main_trie_root_hash,
+            None,
+            requests,
+            total_attempts,
+            timeout_per_request,
+            max_parallel,
+        )
+    }
+
+    /// Like [`SyncService::storage_query`], but reads from the child trie named `child_trie`
+    /// (the bytes after the `:child_storage:default:` prefix) instead of the main trie.
+    ///
+    /// The proof is fetched with a child-storage-proof network request. Verification is two
+    /// levels deep: the child trie's root is first resolved from `main_trie_root_hash` at
+    /// `:child_storage:default:<child_trie>`, then each requested key is verified against that
+    /// child root. Only [`StorageRequestItemTy::Value`] and [`StorageRequestItemTy::Hash`] are
+    /// supported here. The descendants and merkle-value variants are not, as they resolve
+    /// against a fixed root that isn't known for a child trie until the proof arrives.
+    pub fn child_storage_query(
+        self: Arc<Self>,
+        block_number: u64,
+        block_hash: [u8; 32],
+        main_trie_root_hash: [u8; 32],
+        child_trie: Vec<u8>,
+        requests: impl Iterator<Item = StorageRequestItem>,
+        total_attempts: u32,
+        timeout_per_request: Duration,
+        max_parallel: NonZero<u32>,
+    ) -> StorageQuery<TPlat> {
+        self.storage_query_inner(
+            block_number,
+            block_hash,
+            main_trie_root_hash,
+            Some(child_trie),
+            requests,
+            total_attempts,
+            timeout_per_request,
+            max_parallel,
+        )
+    }
+
+    fn storage_query_inner(
+        self: Arc<Self>,
+        block_number: u64,
+        block_hash: [u8; 32],
+        main_trie_root_hash: [u8; 32],
+        child_trie: Option<Vec<u8>>,
+        requests: impl Iterator<Item = StorageRequestItem>,
+        total_attempts: u32,
+        timeout_per_request: Duration,
+        max_parallel: NonZero<u32>,
+    ) -> StorageQuery<TPlat> {
         let total_attempts = usize::try_from(total_attempts).unwrap_or(usize::MAX);
 
         let requests = requests
@@ -459,6 +522,7 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
             block_number,
             block_hash,
             main_trie_root_hash,
+            child_trie,
             total_attempts,
             timeout_per_request,
             _max_parallel: max_parallel,
@@ -576,6 +640,10 @@ pub struct StorageQuery<TPlat: PlatformRef> {
     block_number: u64,
     block_hash: [u8; 32],
     main_trie_root_hash: [u8; 32],
+    /// `Some` for a child-trie query (the bytes after `:child_storage:default:`). When set,
+    /// requests are fetched via child-storage-proof requests and each key is verified against
+    /// the child trie root resolved from `main_trie_root_hash`, not against the main root.
+    child_trie: Option<Vec<u8>>,
     /// Requests that haven't been fulfilled yet.
     /// The `usize` is the index of the request in the original list of requests that the API user
     /// provided.
@@ -715,19 +783,47 @@ impl<TPlat: PlatformRef> StorageQuery<TPlat> {
                 keys
             };
 
-            let result = self
-                .sync_service
-                .network_service
-                .clone()
-                .storage_proof_request(
-                    target.clone(),
-                    codec::StorageProofRequestConfig {
-                        block_hash: self.block_hash,
-                        keys: keys_to_request.into_iter(),
-                    },
-                    self.timeout_per_request,
-                )
-                .await;
+            let result = if let Some(child_trie) = &self.child_trie {
+                self.sync_service
+                    .network_service
+                    .clone()
+                    .child_storage_proof_request(
+                        target.clone(),
+                        codec::ChildStorageProofRequestConfig {
+                            block_hash: self.block_hash,
+                            child_trie: &child_trie[..],
+                            keys: keys_to_request.into_iter(),
+                        },
+                        self.timeout_per_request,
+                    )
+                    .await
+                    // The two request errors are isomorphic. Normalize so the rest of the
+                    // function only deals with `StorageProofRequestError`.
+                    .map_err(|err| match err {
+                        network_service::ChildStorageProofRequestError::NoConnection => {
+                            network_service::StorageProofRequestError::NoConnection
+                        }
+                        network_service::ChildStorageProofRequestError::RequestTooLarge => {
+                            network_service::StorageProofRequestError::RequestTooLarge
+                        }
+                        network_service::ChildStorageProofRequestError::Request(err) => {
+                            network_service::StorageProofRequestError::Request(err)
+                        }
+                    })
+            } else {
+                self.sync_service
+                    .network_service
+                    .clone()
+                    .storage_proof_request(
+                        target.clone(),
+                        codec::StorageProofRequestConfig {
+                            block_hash: self.block_hash,
+                            keys: keys_to_request.into_iter(),
+                        },
+                        self.timeout_per_request,
+                    )
+                    .await
+            };
 
             let proof = match result {
                 Ok(r) => r,
@@ -785,6 +881,47 @@ impl<TPlat: PlatformRef> StorageQuery<TPlat> {
                         .push(StorageQueryErrorDetail::ProofVerification(err));
                     continue;
                 }
+            };
+
+            // Resolve the trie root that the requested keys are verified against. For a main-trie
+            // query this is `main_trie_root_hash`. For a child-trie query the child root is first
+            // read from the main trie at `:child_storage:default:<child_trie>`. `None` means the
+            // child trie doesn't exist, in which case every key has no value.
+            let effective_root: Option<[u8; 32]> = if let Some(child_trie) = &self.child_trie {
+                const PREFIX: &[u8] = b":child_storage:default:";
+                let mut child_root_key = Vec::with_capacity(PREFIX.len() + child_trie.len());
+                child_root_key.extend_from_slice(PREFIX);
+                child_root_key.extend_from_slice(child_trie);
+                match decoded_proof.storage_value(&self.main_trie_root_hash, &child_root_key) {
+                    Ok(Some((value, _))) => match <&[u8; 32]>::try_from(value) {
+                        Ok(hash) => Some(*hash),
+                        Err(_) => {
+                            // The stored child root isn't a 32-byte hash, which means a corrupt
+                            // proof. Ban the peer and count the failure.
+                            self.sync_service
+                                .network_service
+                                .ban_and_disconnect(
+                                    target,
+                                    network_service::BanSeverity::High,
+                                    "bad-child-trie-root",
+                                )
+                                .await;
+                            self.outcome_errors
+                                .push(StorageQueryErrorDetail::MissingProofEntry);
+                            continue;
+                        }
+                    },
+                    Ok(None) => None,
+                    Err(_) => {
+                        // The main-trie path to the child root is absent from the proof. Retry
+                        // against another peer.
+                        self.outcome_errors
+                            .push(StorageQueryErrorDetail::MissingProofEntry);
+                        continue;
+                    }
+                }
+            } else {
+                Some(self.main_trie_root_hash)
             };
 
             let mut proof_has_advanced_verification = false;
@@ -865,8 +1002,21 @@ impl<TPlat: PlatformRef> StorageQuery<TPlat> {
                         }
                     }
                     RequestImpl::ValueOrHash { key, hash } => {
+                        let Some(lookup_root) = effective_root.as_ref() else {
+                            // Child trie doesn't exist, so the key has no value.
+                            proof_has_advanced_verification = true;
+                            self.available_results.push_back((
+                                request_index,
+                                if hash {
+                                    StorageResultItem::Hash { key, hash: None }
+                                } else {
+                                    StorageResultItem::Value { key, value: None }
+                                },
+                            ));
+                            continue;
+                        };
                         match decoded_proof.trie_node_info(
-                            &self.main_trie_root_hash,
+                            lookup_root,
                             trie::bytes_to_nibbles(key.iter().copied()),
                         ) {
                             Ok(node_info) => match node_info.storage_value {

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -1104,10 +1104,9 @@ struct Task<TPlat: PlatformRef> {
     >,
 
     /// `Some` when the chain was added with optimistic-parachain-bootstrap enabled. The flag
-    /// inside the `Arc` is `false` while the parachain is still bootstrapped against the relay's
-    /// best block, and flipped to `true` when the first real `Notification::Finalized` from
-    /// paraheads is applied. Downstream consumers (JSON-RPC handlers) read this to decide
-    /// whether to gate methods.
+    /// inside the `Arc` is `false` during the bootstrap window, and flipped to `true` when the
+    /// first real `Notification::Finalized` from paraheads is applied. Downstream consumers
+    /// (JSON-RPC handlers) read this to decide whether to gate methods.
     optimistic_gate_open: Option<Arc<core::sync::atomic::AtomicBool>>,
 }
 
@@ -1135,13 +1134,12 @@ impl<TPlat: PlatformRef> Task<TPlat> {
 
 // Fetch the included parachain head from a relay chain block.
 //
-// When `optimistic_bootstrap` is `false` (the default), awaits the next
-// `Notification::Finalized` on the relay chain and derives the parahead from that finalized
-// block. When `true`, the first iteration instead uses the relay's current best block from the
-// initial subscription state, which is typically the warp-sync target on cold start. If the
-// runtime call against the optimistic block fails (block evicted, runtime error), the loop
-// falls back to the standard wait-for-finalized path. See
-// [`crate::AddChainConfig::optimistic_parachain_bootstrap`].
+// With `optimistic_bootstrap` `false` (the default), awaits the next `Notification::Finalized`
+// and derives the parahead from it. With `true`, the first iteration instead uses the relay's
+// current finalized block from the initial subscription state (typically the warp-sync target
+// on cold start), skipping that wait. The block is already final, so the parahead does not
+// reorg. If the runtime call against it fails (block evicted, runtime error), the loop falls
+// back to the default path. See [`crate::AddChainConfig::optimistic_parachain_bootstrap`].
 async fn fetch_parachain_head_from_relay<TPlat: PlatformRef>(
     log_target: &str,
     platform: &TPlat,
@@ -1154,22 +1152,14 @@ async fn fetch_parachain_head_from_relay<TPlat: PlatformRef>(
         .subscribe_all(32, NonZero::<usize>::new(usize::MAX).unwrap())
         .await;
 
-    // If optimistic, pick the relay's current best block from the initial subscription state
-    // to use on the first iteration of the outer loop, bypassing the wait for the next
-    // `Notification::Finalized`. Falls back to the subscription's finalized block when no
-    // non-finalized blocks are tracked yet (typical on cold start: best == finalized ==
-    // warp-sync target).
+    // If optimistic, bootstrap from the relay's current finalized block (already in the initial
+    // subscription state), skipping the wait for the next `Notification::Finalized`. The block
+    // is already final, so the derived parahead does not reorg and is safe to report as the
+    // parachain's finalized head.
     let mut optimistic_hash: Option<[u8; 32]> = if optimistic_bootstrap {
-        let best = subscription
-            .non_finalized_blocks_ancestry_order
-            .iter()
-            .find(|b| b.is_new_best)
-            .map(|b| header::hash_from_scale_encoded_header(&b.scale_encoded_header));
-        Some(best.unwrap_or_else(|| {
-            header::hash_from_scale_encoded_header(
-                &subscription.finalized_block_scale_encoded_header,
-            )
-        }))
+        Some(header::hash_from_scale_encoded_header(
+            &subscription.finalized_block_scale_encoded_header,
+        ))
     } else {
         None
     };
@@ -1179,7 +1169,7 @@ async fn fetch_parachain_head_from_relay<TPlat: PlatformRef>(
             platform,
             Info,
             log_target,
-            "Bootstrapping parachain from relay's current best block (optimistic)..."
+            "Bootstrapping parachain from relay's current finalized block (optimistic)..."
         );
     } else {
         log!(

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -45,9 +45,14 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
     block_number_bytes: usize,
     relay_chain_sync: Arc<runtime_service::RuntimeService<TPlat>>,
     parachain_id: u32,
+    optimistic_gate_open: Option<Arc<core::sync::atomic::AtomicBool>>,
     mut from_foreground: Pin<Box<async_channel::Receiver<ToBackground>>>,
     network_service: Arc<network_service::NetworkServiceChain<TPlat>>,
 ) {
+    // A closed gate (or no gate at all once optimistic bootstrap is off) is what distinguishes
+    // an optimistic bootstrap from the default behaviour.
+    let optimistic_bootstrap = optimistic_gate_open.is_some();
+
     // Phase 1: Fetch the current finalized parachain head from the relay chain.
     let effective_chain_info = fetch_parachain_head_from_relay(
         &log_target,
@@ -55,6 +60,7 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
         &relay_chain_sync,
         parachain_id,
         block_number_bytes,
+        optimistic_bootstrap,
     )
     .await;
 
@@ -171,6 +177,7 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
         known_finalized_runtime: Some(finalized_runtime),
         pending_requests: stream::FuturesUnordered::new(),
         all_notifications: Vec::<async_channel::Sender<Notification>>::new(),
+        optimistic_gate_open,
         log_target,
         from_network_service: None,
         network_service,
@@ -963,6 +970,20 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
                     hash = HashDisplay(&hash),
                 );
 
+                // First real `Notification::Finalized` from paraheads. Lift the optimistic
+                // window gate so downstream JSON-RPC handlers stop rejecting gated methods.
+                if let Some(gate) = task.optimistic_gate_open.as_ref()
+                    && !gate.load(core::sync::atomic::Ordering::Acquire)
+                {
+                    gate.store(true, core::sync::atomic::Ordering::Release);
+                    log!(
+                        &task.platform,
+                        Info,
+                        &task.log_target,
+                        "optimistic-window-closed, gating lifted on first real finalization"
+                    );
+                }
+
                 let sync = task.sync.as_mut().unwrap();
                 match sync.set_finalized_block(&hash) {
                     Ok(result) => {
@@ -1081,6 +1102,13 @@ struct Task<TPlat: PlatformRef> {
     pending_requests: stream::FuturesUnordered<
         future::BoxFuture<'static, (all::RequestId, Result<RequestOutcome, future::Aborted>)>,
     >,
+
+    /// `Some` when the chain was added with optimistic-parachain-bootstrap enabled. The flag
+    /// inside the `Arc` is `false` while the parachain is still bootstrapped against the relay's
+    /// best block, and flipped to `true` when the first real `Notification::Finalized` from
+    /// paraheads is applied. Downstream consumers (JSON-RPC handlers) read this to decide
+    /// whether to gate methods.
+    optimistic_gate_open: Option<Arc<core::sync::atomic::AtomicBool>>,
 }
 
 enum RequestOutcome {
@@ -1105,40 +1133,82 @@ impl<TPlat: PlatformRef> Task<TPlat> {
     }
 }
 
-// Fetch the included parachain head from a finalized relay chain block.
+// Fetch the included parachain head from a relay chain block.
+//
+// When `optimistic_bootstrap` is `false` (the default), awaits the next
+// `Notification::Finalized` on the relay chain and derives the parahead from that finalized
+// block. When `true`, the first iteration instead uses the relay's current best block from the
+// initial subscription state, which is typically the warp-sync target on cold start. If the
+// runtime call against the optimistic block fails (block evicted, runtime error), the loop
+// falls back to the standard wait-for-finalized path. See
+// [`crate::AddChainConfig::optimistic_parachain_bootstrap`].
 async fn fetch_parachain_head_from_relay<TPlat: PlatformRef>(
     log_target: &str,
     platform: &TPlat,
     relay_chain_sync: &Arc<runtime_service::RuntimeService<TPlat>>,
     para_id: u32,
     block_number_bytes: usize,
+    optimistic_bootstrap: bool,
 ) -> chain::chain_information::ValidChainInformation {
     let mut subscription = relay_chain_sync
         .subscribe_all(32, NonZero::<usize>::new(usize::MAX).unwrap())
         .await;
 
-    log!(
-        platform,
-        Info,
-        log_target,
-        "Waiting for relay chain to finalize a block..."
-    );
+    // If optimistic, pick the relay's current best block from the initial subscription state
+    // to use on the first iteration of the outer loop, bypassing the wait for the next
+    // `Notification::Finalized`. Falls back to the subscription's finalized block when no
+    // non-finalized blocks are tracked yet (typical on cold start: best == finalized ==
+    // warp-sync target).
+    let mut optimistic_hash: Option<[u8; 32]> = if optimistic_bootstrap {
+        let best = subscription
+            .non_finalized_blocks_ancestry_order
+            .iter()
+            .find(|b| b.is_new_best)
+            .map(|b| header::hash_from_scale_encoded_header(&b.scale_encoded_header));
+        Some(best.unwrap_or_else(|| {
+            header::hash_from_scale_encoded_header(
+                &subscription.finalized_block_scale_encoded_header,
+            )
+        }))
+    } else {
+        None
+    };
+
+    if optimistic_hash.is_some() {
+        log!(
+            platform,
+            Info,
+            log_target,
+            "Bootstrapping parachain from relay's current best block (optimistic)..."
+        );
+    } else {
+        log!(
+            platform,
+            Info,
+            log_target,
+            "Waiting for relay chain to finalize a block..."
+        );
+    }
 
     loop {
-        let finalized_hash = loop {
-            match subscription.new_blocks.next().await {
-                Some(runtime_service::Notification::Finalized { hash, .. }) => {
-                    break hash;
-                }
-                Some(_) => continue,
-                None => {
-                    // Subscription died. Re-subscribe.
-                    subscription = relay_chain_sync
-                        .subscribe_all(32, NonZero::<usize>::new(usize::MAX).unwrap())
-                        .await;
-                    break header::hash_from_scale_encoded_header(
-                        &subscription.finalized_block_scale_encoded_header,
-                    );
+        let source_hash = if let Some(h) = optimistic_hash.take() {
+            h
+        } else {
+            loop {
+                match subscription.new_blocks.next().await {
+                    Some(runtime_service::Notification::Finalized { hash, .. }) => {
+                        break hash;
+                    }
+                    Some(_) => continue,
+                    None => {
+                        // Subscription died. Re-subscribe.
+                        subscription = relay_chain_sync
+                            .subscribe_all(32, NonZero::<usize>::new(usize::MAX).unwrap())
+                            .await;
+                        break header::hash_from_scale_encoded_header(
+                            &subscription.finalized_block_scale_encoded_header,
+                        );
+                    }
                 }
             }
         };
@@ -1149,12 +1219,12 @@ async fn fetch_parachain_head_from_relay<TPlat: PlatformRef>(
             log_target,
             format!(
                 "Trying to fetch parachain head from relay block {}",
-                HashDisplay(&finalized_hash)
+                HashDisplay(&source_hash)
             )
         );
 
         let pinned = relay_chain_sync
-            .pin_pinned_block_runtime(subscription.new_blocks.id(), finalized_hash)
+            .pin_pinned_block_runtime(subscription.new_blocks.id(), source_hash)
             .await;
         let (pinned_runtime, block_state_trie_root, block_number) = match pinned {
             Ok(v) => v,
@@ -1164,7 +1234,7 @@ async fn fetch_parachain_head_from_relay<TPlat: PlatformRef>(
         let call_result = relay_chain_sync
             .runtime_call(
                 pinned_runtime,
-                finalized_hash,
+                source_hash,
                 block_number,
                 block_state_trie_root,
                 String::from(para::PERSISTED_VALIDATION_FUNCTION_NAME),

--- a/wasm-node/javascript/src/internals/client.ts
+++ b/wasm-node/javascript/src/internals/client.ts
@@ -540,6 +540,23 @@ export function start(options: ClientOptions, wasmModule: SmoldotBytecode | Prom
             if (options.databaseContent !== undefined && typeof options.databaseContent !== 'string')
                 throw new AddChainError("`databaseContent` is not a string");
 
+            // Validate the optimistic-parachain-bootstrap shape. Its presence means enabled.
+            const optimisticParachainBootstrap = options.optimisticParachainBootstrap;
+            if (optimisticParachainBootstrap !== undefined) {
+                if (!Array.isArray(optimisticParachainBootstrap.allowedStoragePrefixes)) {
+                    throw new AddChainError(
+                        "`optimisticParachainBootstrap.allowedStoragePrefixes` must be an array"
+                    );
+                }
+                for (const prefix of optimisticParachainBootstrap.allowedStoragePrefixes) {
+                    if (!(prefix instanceof Uint8Array)) {
+                        throw new AddChainError(
+                            "`optimisticParachainBootstrap.allowedStoragePrefixes` entries must be Uint8Array"
+                        );
+                    }
+                }
+            }
+
             const promise = new Promise<{ success: true, chainId: number } | { success: false, error: string }>((resolve) => state.addChainIdAllocations.push(resolve));
 
             state.instance.instance.addChain(
@@ -551,7 +568,8 @@ export function start(options: ClientOptions, wasmModule: SmoldotBytecode | Prom
                 jsonRpcMaxSubscriptions,
                 statementStoreMaxSeenStatements,
                 statementStoreFalsePositiveRate,
-                statementStoreAffinityUpdateIntervalMs
+                statementStoreAffinityUpdateIntervalMs,
+                optimisticParachainBootstrap
             );
 
             const outcome = await promise;

--- a/wasm-node/javascript/src/internals/local-instance.ts
+++ b/wasm-node/javascript/src/internals/local-instance.ts
@@ -90,7 +90,7 @@ export interface Instance {
      * indicate whether the initialization was actually successful. If `success` is `false`, then
      * the `chainId` becomes unallocated.
      */
-    addChain: (chainSpec: string, databaseContent: string, potentialRelayChains: number[], disableJsonRpc: boolean, jsonRpcMaxPendingRequests: number, jsonRpcMaxSubscriptions: number, statementStoreMaxSeenStatements: number, statementStoreFalsePositiveRate: number, statementStoreAffinityUpdateIntervalMs: number) => void,
+    addChain: (chainSpec: string, databaseContent: string, potentialRelayChains: number[], disableJsonRpc: boolean, jsonRpcMaxPendingRequests: number, jsonRpcMaxSubscriptions: number, statementStoreMaxSeenStatements: number, statementStoreFalsePositiveRate: number, statementStoreAffinityUpdateIntervalMs: number, optimisticParachainBootstrap: { allowedStoragePrefixes: Uint8Array[] } | undefined) => void,
     removeChain: (chainId: number) => void,
     /**
      * Notifies the background executor that it should stop. Once it has effectively stopped,
@@ -531,7 +531,7 @@ export async function startLocalInstance(config: Config, wasmModule: WebAssembly
             }
         },
 
-        addChain: (chainSpec: string, databaseContent: string, potentialRelayChains: number[], disableJsonRpc: boolean, jsonRpcMaxPendingRequests: number, jsonRpcMaxSubscriptions: number, statementStoreMaxSeenStatements: number, statementStoreFalsePositiveRate: number, statementStoreAffinityUpdateIntervalMs: number) => {
+        addChain: (chainSpec: string, databaseContent: string, potentialRelayChains: number[], disableJsonRpc: boolean, jsonRpcMaxPendingRequests: number, jsonRpcMaxSubscriptions: number, statementStoreMaxSeenStatements: number, statementStoreFalsePositiveRate: number, statementStoreAffinityUpdateIntervalMs: number, optimisticParachainBootstrap: { allowedStoragePrefixes: Uint8Array[] } | undefined) => {
             if (!state.instance) {
                 eventCallback({ ty: "add-chain-id-allocated", chainId: 0 });
                 eventCallback({ ty: "add-chain-result", chainId: 0, success: false, error: "Smoldot has crashed" });
@@ -554,9 +554,28 @@ export async function startLocalInstance(config: Config, wasmModule: WebAssembly
                 buffer.writeUInt32LE(potentialRelayChainsEncoded, idx * 4, potentialRelayChains[idx]!);
             }
             state.bufferIndices[2] = potentialRelayChainsEncoded
+            // Flatten the nested optimistic config to the flat form the wasm FFI takes. Encode
+            // the storage allowlist for `decode_prefix_list` in `wasm-node/rust/src/lib.rs`: a
+            // `[u32 LE count]` then that many `[u32 LE len][bytes]`. The buffer is always emitted
+            // so its index is valid, and Rust ignores it when the flag is off.
+            const allowedStoragePrefixes = optimisticParachainBootstrap?.allowedStoragePrefixes ?? []
+            let allowedTotalLen = 4
+            for (const prefix of allowedStoragePrefixes) {
+                allowedTotalLen += 4 + prefix.length
+            }
+            const allowedEncoded = new Uint8Array(allowedTotalLen)
+            buffer.writeUInt32LE(allowedEncoded, 0, allowedStoragePrefixes.length)
+            let cursor = 4
+            for (const prefix of allowedStoragePrefixes) {
+                buffer.writeUInt32LE(allowedEncoded, cursor, prefix.length)
+                cursor += 4
+                allowedEncoded.set(prefix, cursor)
+                cursor += prefix.length
+            }
+            state.bufferIndices[3] = allowedEncoded
             let chainId;
             try {
-                chainId = state.instance.exports.add_chain(0, 1, disableJsonRpc ? 0 : jsonRpcMaxPendingRequests, jsonRpcMaxSubscriptions, 2, statementStoreMaxSeenStatements, statementStoreFalsePositiveRate, statementStoreAffinityUpdateIntervalMs);
+                chainId = state.instance.exports.add_chain(0, 1, disableJsonRpc ? 0 : jsonRpcMaxPendingRequests, jsonRpcMaxSubscriptions, 2, statementStoreMaxSeenStatements, statementStoreFalsePositiveRate, statementStoreAffinityUpdateIntervalMs, optimisticParachainBootstrap !== undefined ? 1 : 0, 3);
             } catch (_error) {
                 eventCallback({ ty: "add-chain-id-allocated", chainId: 0 });
                 eventCallback({ ty: "add-chain-result", chainId: 0, success: false, error: "Smoldot has crashed" });
@@ -566,6 +585,7 @@ export async function startLocalInstance(config: Config, wasmModule: WebAssembly
             delete state.bufferIndices[0]
             delete state.bufferIndices[1]
             delete state.bufferIndices[2]
+            delete state.bufferIndices[3]
 
             eventCallback({ ty: "add-chain-id-allocated", chainId });
         },
@@ -656,7 +676,7 @@ interface SmoldotWasmExports extends WebAssembly.Exports {
     memory: WebAssembly.Memory,
     init: (maxLogLevel: number) => void,
     advance_execution: () => void,
-    add_chain: (chainSpecBufferIndex: number, databaseContentBufferIndex: number, jsonRpcMaxPendingRequests: number, jsonRpcMaxSubscriptions: number, potentialRelayChainsBufferIndex: number, statementStoreMaxSeenStatements: number, statementStoreFalsePositiveRate: number, statementStoreAffinityUpdateIntervalMs: number) => number;
+    add_chain: (chainSpecBufferIndex: number, databaseContentBufferIndex: number, jsonRpcMaxPendingRequests: number, jsonRpcMaxSubscriptions: number, potentialRelayChainsBufferIndex: number, statementStoreMaxSeenStatements: number, statementStoreFalsePositiveRate: number, statementStoreAffinityUpdateIntervalMs: number, optimisticParachainBootstrap: number, optimisticAllowedStoragePrefixesBufferIndex: number) => number;
     remove_chain: (chainId: number) => void,
     chain_is_ok: (chainId: number) => number,
     chain_error_len: (chainId: number) => number,

--- a/wasm-node/javascript/src/internals/remote-instance.ts
+++ b/wasm-node/javascript/src/internals/remote-instance.ts
@@ -159,8 +159,8 @@ export async function connectToInstanceServer(config: ConnectConfig): Promise<in
     };
 
     return {
-        async addChain(chainSpec, databaseContent, potentialRelayChains, disableJsonRpc, jsonRpcMaxPendingRequests, jsonRpcMaxSubscriptions, statementStoreMaxSeenStatements, statementStoreFalsePositiveRate, statementStoreAffinityUpdateIntervalMs) {
-            const msg: ClientToServer = { ty: "add-chain", chainSpec, databaseContent, potentialRelayChains, disableJsonRpc, jsonRpcMaxPendingRequests, jsonRpcMaxSubscriptions, statementStoreMaxSeenStatements, statementStoreFalsePositiveRate, statementStoreAffinityUpdateIntervalMs };
+        async addChain(chainSpec, databaseContent, potentialRelayChains, disableJsonRpc, jsonRpcMaxPendingRequests, jsonRpcMaxSubscriptions, statementStoreMaxSeenStatements, statementStoreFalsePositiveRate, statementStoreAffinityUpdateIntervalMs, optimisticParachainBootstrap) {
+            const msg: ClientToServer = { ty: "add-chain", chainSpec, databaseContent, potentialRelayChains, disableJsonRpc, jsonRpcMaxPendingRequests, jsonRpcMaxSubscriptions, statementStoreMaxSeenStatements, statementStoreFalsePositiveRate, statementStoreAffinityUpdateIntervalMs, optimisticParachainBootstrap };
             portToServer.postMessage(msg);
         },
 
@@ -342,7 +342,7 @@ export async function startInstanceServer(config: ServerConfig, initPortToClient
 
         switch (message.ty) {
             case "add-chain": {
-                state.instance!.addChain(message.chainSpec, message.databaseContent, message.potentialRelayChains, message.disableJsonRpc, message.jsonRpcMaxPendingRequests, message.jsonRpcMaxSubscriptions, message.statementStoreMaxSeenStatements, message.statementStoreFalsePositiveRate, message.statementStoreAffinityUpdateIntervalMs);
+                state.instance!.addChain(message.chainSpec, message.databaseContent, message.potentialRelayChains, message.disableJsonRpc, message.jsonRpcMaxPendingRequests, message.jsonRpcMaxSubscriptions, message.statementStoreMaxSeenStatements, message.statementStoreFalsePositiveRate, message.statementStoreAffinityUpdateIntervalMs, message.optimisticParachainBootstrap);
                 break;
             }
             case "remove-chain": {
@@ -444,7 +444,7 @@ type ServerToClient = Exclude<instance.Event, { ty: "json-rpc-responses-non-empt
 { ty: "json-rpc-response", chainId: number, response: string };
 
 type ClientToServer =
-    { ty: "add-chain", chainSpec: string, databaseContent: string, potentialRelayChains: number[], disableJsonRpc: boolean, jsonRpcMaxPendingRequests: number, jsonRpcMaxSubscriptions: number, statementStoreMaxSeenStatements: number, statementStoreFalsePositiveRate: number, statementStoreAffinityUpdateIntervalMs: number } |
+    { ty: "add-chain", chainSpec: string, databaseContent: string, potentialRelayChains: number[], disableJsonRpc: boolean, jsonRpcMaxPendingRequests: number, jsonRpcMaxSubscriptions: number, statementStoreMaxSeenStatements: number, statementStoreFalsePositiveRate: number, statementStoreAffinityUpdateIntervalMs: number, optimisticParachainBootstrap: { allowedStoragePrefixes: Uint8Array[] } | undefined } |
     { ty: "remove-chain", chainId: number } |
     { ty: "request", chainId: number, request: string } |
     { ty: "accept-more-json-rpc-answers", chainId: number } |

--- a/wasm-node/javascript/src/public-types.ts
+++ b/wasm-node/javascript/src/public-types.ts
@@ -474,4 +474,26 @@ export interface AddChainOptions {
         falsePositiveRate?: number,
         affinityUpdateIntervalMs?: number,
     }
+
+    /**
+     * If set, enables optimistic parachain bootstrap. The parachain's initial finalized head
+     * is derived from the relay chain's current best block instead of waiting for the next
+     * finalized relay block. This removes the wait for the next relay finalization from cold
+     * start, at the cost of the derived parahead being unverified until a real relay
+     * finalization confirms it.
+     *
+     * Until the first real relay finalization arrives, the JSON-RPC interface is gated to bound
+     * the blast radius. `chainHead_v1_storage` is restricted to `allowedStoragePrefixes` while
+     * `chainHead_v1_call` and transaction submission are rejected outright, all with error
+     * `-32802`. The gates lift on the first real relay finalization. Ignored for relay chains.
+     */
+    optimisticParachainBootstrap?: {
+        /**
+         * Allowlist of storage-key prefixes (raw bytes, not hex) readable via
+         * `chainHead_v1_storage` during the optimistic window. An empty array disallows all
+         * storage reads. A child-trie query matches against the prefixed child trie name
+         * `:child_storage:default:<childTrie>` rather than the keys within it.
+         */
+        allowedStoragePrefixes: Uint8Array[],
+    }
 }

--- a/wasm-node/javascript/src/public-types.ts
+++ b/wasm-node/javascript/src/public-types.ts
@@ -476,16 +476,16 @@ export interface AddChainOptions {
     }
 
     /**
-     * If set, enables optimistic parachain bootstrap. The parachain's initial finalized head
-     * is derived from the relay chain's current best block instead of waiting for the next
-     * finalized relay block. This removes the wait for the next relay finalization from cold
-     * start, at the cost of the derived parahead being unverified until a real relay
-     * finalization confirms it.
+     * If set, enables optimistic parachain bootstrap. The parachain's initial head is taken from
+     * the relay chain's current finalized block rather than by waiting for a new one. This
+     * removes the wait from cold start, and because that block is already final the derived
+     * parahead never reorgs.
      *
-     * Until the first real relay finalization arrives, the JSON-RPC interface is gated to bound
-     * the blast radius. `chainHead_v1_storage` is restricted to `allowedStoragePrefixes` while
-     * `chainHead_v1_call` and transaction submission are rejected outright, all with error
-     * `-32802`. The gates lift on the first real relay finalization. Ignored for relay chains.
+     * Until the parachain observes its first new relay finalization, the JSON-RPC interface is
+     * restricted while the chain catches up from the bootstrap block: `chainHead_v1_storage` is
+     * limited to `allowedStoragePrefixes`, and `chainHead_v1_call` and transaction submission
+     * are rejected with error `-32802`. The restrictions lift at that point. Ignored for relay
+     * chains.
      */
     optimisticParachainBootstrap?: {
         /**

--- a/wasm-node/rust/src/bindings.rs
+++ b/wasm-node/rust/src/bindings.rs
@@ -393,6 +393,8 @@ pub extern "C" fn add_chain(
     statement_store_max_seen_statements: u32,
     statement_store_false_positive_rate: f64,
     statement_store_affinity_update_interval_ms: u32,
+    optimistic_parachain_bootstrap: u32,
+    optimistic_allowed_storage_prefixes_buffer_index: u32,
 ) -> u32 {
     super::add_chain(
         get_buffer(chain_spec_buffer_index),
@@ -403,6 +405,8 @@ pub extern "C" fn add_chain(
         statement_store_max_seen_statements,
         statement_store_false_positive_rate,
         statement_store_affinity_update_interval_ms,
+        optimistic_parachain_bootstrap != 0,
+        get_buffer(optimistic_allowed_storage_prefixes_buffer_index),
     )
 }
 

--- a/wasm-node/rust/src/lib.rs
+++ b/wasm-node/rust/src/lib.rs
@@ -60,6 +60,8 @@ fn add_chain(
     statement_store_max_seen_statements: u32,
     statement_store_false_positive_rate: f64,
     statement_store_affinity_update_interval_ms: u32,
+    optimistic_parachain_bootstrap: bool,
+    optimistic_allowed_storage_prefixes_encoded: Box<[u8]>,
 ) -> u32 {
     let mut client_lock = CLIENT.try_lock().unwrap();
 
@@ -138,6 +140,15 @@ fn add_chain(
                         smoldot_light::AddChainConfigJsonRpc::Disabled
                     },
                     potential_relay_chains: potential_relay_chains.into_iter(),
+                    optimistic_parachain_bootstrap: if optimistic_parachain_bootstrap {
+                        smoldot_light::OptimisticParachainBootstrap::Enabled {
+                            allowed_storage_prefixes: decode_prefix_list(
+                                &optimistic_allowed_storage_prefixes_encoded,
+                            ),
+                        }
+                    } else {
+                        smoldot_light::OptimisticParachainBootstrap::Disabled
+                    },
                     statement_protocol_config: NonZero::<usize>::new(
                         usize::try_from(statement_store_max_seen_statements).unwrap_or(0),
                     )
@@ -192,6 +203,40 @@ fn add_chain(
     );
 
     outer_chain_id_u32
+}
+
+/// Decodes the SCALE-like encoding used by the JS bindings to carry an arbitrary list of
+/// byte-prefixes across the wasm boundary: `[u32 LE count]` followed by `count` repetitions of
+/// `[u32 LE length][length bytes]`. Returns an empty `Vec` for an empty input buffer.
+fn decode_prefix_list(encoded: &[u8]) -> Vec<Vec<u8>> {
+    if encoded.is_empty() {
+        return Vec::new();
+    }
+    let mut cursor = 0;
+    let count_bytes: [u8; 4] = match encoded.get(cursor..cursor + 4).and_then(|s| s.try_into().ok())
+    {
+        Some(b) => b,
+        None => return Vec::new(),
+    };
+    let count = u32::from_le_bytes(count_bytes) as usize;
+    cursor += 4;
+    let mut out = Vec::with_capacity(count);
+    for _ in 0..count {
+        let Some(len_bytes) = encoded
+            .get(cursor..cursor + 4)
+            .and_then(|s| <[u8; 4]>::try_from(s).ok())
+        else {
+            return out;
+        };
+        let len = u32::from_le_bytes(len_bytes) as usize;
+        cursor += 4;
+        let Some(bytes) = encoded.get(cursor..cursor + len) else {
+            return out;
+        };
+        out.push(bytes.to_vec());
+        cursor += len;
+    }
+    out
 }
 
 fn remove_chain(chain_id: u32) {

--- a/wasm-node/rust/src/lib.rs
+++ b/wasm-node/rust/src/lib.rs
@@ -213,7 +213,9 @@ fn decode_prefix_list(encoded: &[u8]) -> Vec<Vec<u8>> {
         return Vec::new();
     }
     let mut cursor = 0;
-    let count_bytes: [u8; 4] = match encoded.get(cursor..cursor + 4).and_then(|s| s.try_into().ok())
+    let count_bytes: [u8; 4] = match encoded
+        .get(cursor..cursor + 4)
+        .and_then(|s| s.try_into().ok())
     {
         Some(b) => b,
         None => return Vec::new(),


### PR DESCRIPTION
## Summary

- Bootstrap from most recent finalized block instead of next finalized blcok.
- Introduces optimistic parachain bootstrap. Example config:

```
client.addChain({
  chainSpec,
  potentialRelayChains: [relayChain],
  optimisticParachainBootstrap: {
    allowedStoragePrefixes: [
      concat(twox128("Revive"), twox128("AccountInfoOf")),
      new TextEncoder().encode(":child_storage:default:"),
    ],
  },
})
```
- Fixes `build_child_storage_proof_request`, which sent the bare child trie id where full nodes require the prefixed `:child_storage:default:<id>` key.