### PR TITLE
npm smoldot v3.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light-wasm"
-version = "3.1.3"
+version = "3.1.4"
 dependencies = [
  "async-lock",
  "async-task",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -7283,7 +7283,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -7360,7 +7360,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smoldot 1.1.2",
+ "smoldot 1.1.3",
  "tar",
  "tempfile",
  "tokio",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -7243,7 +7243,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -7305,7 +7305,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smoldot 1.1.2",
+ "smoldot 1.1.3",
  "tar",
  "tempfile",
  "tokio",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot"
-version = "1.1.2"
+version = "1.1.3"
 description = "Primitives to build a client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot"
 keywords = ["blockchain", "peer-to-peer"]

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light"
-version = "1.1.3"
+version = "1.1.4"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot-light"
 authors.workspace = true

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## 3.1.4 - 2026-05-29
+
+### Changed
+
+- Revert the immediate parachain block delivery introduced in 3.1.3. ([#3267](https://github.com/paritytech/smoldot/pull/3267))
+- Decide the parachain bootstrap mode up front so `chainHead_v1_follow` subscribers receive an authoritative finalized block instead of a stale chain-spec checkpoint. ([#3268](https://github.com/paritytech/smoldot/pull/3268))
+- Prefer chain-spec bootnodes for relay-chain gossip slots until a chain has an open gossip link, speeding up the first relay-chain gossip after a warm restart. ([#3273](https://github.com/paritytech/smoldot/pull/3273))
+- Shorten handshake and peer-ban timeouts to speed up peer discovery after a restart. ([#3269](https://github.com/paritytech/smoldot/pull/3269))
+
+### Fixed
+
+- Fix `forbidNonLocalWs` auto-detection in browsers, which previously never forbade non-local WebSocket connections on secure origins. ([#3262](https://github.com/paritytech/smoldot/pull/3262))
+- Avoid banning peers that send justifications targeting not-yet-downloaded blocks during post-warp-sync catch-up, removing sync delays. ([#3257](https://github.com/paritytech/smoldot/pull/3257))
+- Floor the statement-distribution affinity bloom filter size so sparse topic subscriptions still produce a realistically-sized filter. ([#3265](https://github.com/paritytech/smoldot/pull/3265))
+
 ## 3.1.3 - 2026-05-13
 
 ### Changed

--- a/wasm-node/javascript/package-lock.json
+++ b/wasm-node/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smoldot",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smoldot",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/wasm-node/javascript/package.json
+++ b/wasm-node/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoldot",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Light client that connects to Polkadot and Substrate-based blockchains",
   "contributors": [
     "Parity Technologies <admin@parity.io>",

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light-wasm"
-version = "3.1.3"
+version = "3.1.4"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
This is to:
- publish `smoldot-v3.1.4` npm.
- publish crates `smoldot-light v1.1.4`, `smoldot v1.1.3`

## Changes

### Changed

- Revert the immediate parachain block delivery introduced in 3.1.3. ([#3267](https://github.com/paritytech/smoldot/pull/3267))
- Decide the parachain bootstrap mode up front so `chainHead_v1_follow` subscribers receive an authoritative finalized block instead of a stale chain-spec checkpoint. ([#3268](https://github.com/paritytech/smoldot/pull/3268))
- Prefer chain-spec bootnodes for relay-chain gossip slots until a chain has an open gossip link, speeding up the first relay-chain gossip after a warm restart. ([#3273](https://github.com/paritytech/smoldot/pull/3273))
- Shorten handshake and peer-ban timeouts to speed up peer discovery after a restart. ([#3269](https://github.com/paritytech/smoldot/pull/3269))

### Fixed

- Fix \`forbidNonLocalWs\` auto-detection in browsers, which previously never forbade non-local WebSocket connections on secure origins. ([#3262](https://github.com/paritytech/smoldot/pull/3262))
- Avoid banning peers that send justifications targeting not-yet-downloaded blocks during post-warp-sync catch-up, removing sync delays. ([#3257](https://github.com/paritytech/smoldot/pull/3257))
- Floor the statement-distribution affinity bloom filter size so sparse topic subscriptions still produce a realistically-sized filter. ([#3265](https://github.com/paritytech/smoldot/pull/3265))