### PR TITLE
npm smoldot v3.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "1.1.4"
+version = "1.2.0"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light-wasm"
-version = "3.1.4"
+version = "3.2.0"
 dependencies = [
  "async-lock",
  "async-task",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -7283,7 +7283,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -7360,7 +7360,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smoldot 1.1.3",
+ "smoldot 1.2.0",
  "tar",
  "tempfile",
  "tokio",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -7243,7 +7243,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -7305,7 +7305,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smoldot 1.1.3",
+ "smoldot 1.2.0",
  "tar",
  "tempfile",
  "tokio",

--- a/e2e-tests/js/package-lock.json
+++ b/e2e-tests/js/package-lock.json
@@ -10,7 +10,7 @@
     },
     "../../wasm-node/javascript": {
       "name": "smoldot",
-      "version": "3.1.3",
+      "version": "3.2.0",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot"
-version = "1.1.3"
+version = "1.2.0"
 description = "Primitives to build a client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot"
 keywords = ["blockchain", "peer-to-peer"]

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light"
-version = "1.1.4"
+version = "1.2.0"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot-light"
 authors.workspace = true

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## Unreleased
 
+## 3.2.0 - 2026-06-02
+
 ### Added
 
-- Implement the `ext_trie_blake2_256_verify_proof_version_1` and `ext_trie_blake2_256_verify_proof_version_2` host functions. The verifier handles Substrate's compact proof format (as produced by `sp_trie::generate_trie_proof`): path children are replaced by an empty inline placeholder and the target leaf's value is reconstructed from the caller-supplied expected value (hashed for state version V1 values of 33 bytes or more, matching `sp_trie`'s threshold).
+- `chainHead_v1_storage` can now read child-trie storage (the default child trie), letting callers read e.g. contract storage directly without going through a runtime call. ([#3278](https://github.com/paritytech/smoldot/pull/3278))
+- Implement the `ext_trie_blake2_256_verify_proof_version_1` and `ext_trie_blake2_256_verify_proof_version_2` host functions. The verifier handles Substrate's compact proof format (as produced by `sp_trie::generate_trie_proof`): path children are replaced by an empty inline placeholder and the target leaf's value is reconstructed from the caller-supplied expected value (hashed for state version V1 values of 33 bytes or more, matching `sp_trie`'s threshold). ([#3263](https://github.com/paritytech/smoldot/pull/3263))
 
 ### Fixed
 
-- `ext_transaction_index_index_version_1` and `ext_transaction_index_renew_version_1` now consume their parameters with the correct wasm value types (3xI32 and 2xI32 respectively). The previous code read the first parameter as a packed pointer-size (I64), which crashed the wasm executor as soon as a substrate runtime actually called either function (e.g. `pallet-transaction-storage::store` / `renew`). Behavior remains a no-op since smoldot is a light client and has no offchain transaction index to update.
+- `ext_transaction_index_index_version_1` and `ext_transaction_index_renew_version_1` now consume their parameters with the correct wasm value types (3xI32 and 2xI32 respectively). The previous code read the first parameter as a packed pointer-size (I64), which crashed the wasm executor as soon as a substrate runtime actually called either function (e.g. `pallet-transaction-storage::store` / `renew`). Behavior remains a no-op since smoldot is a light client and has no offchain transaction index to update. ([#3263](https://github.com/paritytech/smoldot/pull/3263))
 
 ## 3.1.4 - 2026-05-29
 

--- a/wasm-node/javascript/package-lock.json
+++ b/wasm-node/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smoldot",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smoldot",
-      "version": "3.1.4",
+      "version": "3.2.0",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/wasm-node/javascript/package.json
+++ b/wasm-node/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoldot",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "description": "Light client that connects to Polkadot and Substrate-based blockchains",
   "contributors": [
     "Parity Technologies <admin@parity.io>",

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light-wasm"
-version = "3.1.4"
+version = "3.2.0"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
This is to:
- publish `smoldot-v3.2.0` npm.
- publish crates `smoldot-light v1.2.0`, `smoldot v1.2.0`

## Changes

### Added

- `chainHead_v1_storage` can now read child-trie storage (the default child trie), letting callers read e.g. contract storage directly without going through a runtime call. ([#3278](https://github.com/paritytech/smoldot/pull/3278))
- Implement the `ext_trie_blake2_256_verify_proof_version_1` and `ext_trie_blake2_256_verify_proof_version_2` host functions. The verifier handles Substrate's compact proof format (as produced by `sp_trie::generate_trie_proof`). ([#3263](https://github.com/paritytech/smoldot/pull/3263))

### Fixed

- `ext_transaction_index_index_version_1` and `ext_transaction_index_renew_version_1` now consume their parameters with the correct wasm value types (3xI32 and 2xI32 respectively), fixing a wasm-executor crash when a substrate runtime calls either function. Behavior remains a no-op since smoldot is a light client. ([#3263](https://github.com/paritytech/smoldot/pull/3263))
