### PR TITLE
statement-store: index subscriptions by topic for efficient statement matching

### DIFF
--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -238,9 +238,8 @@ struct Background<TPlat: PlatformRef> {
     /// `None` if the statement protocol is disabled.
     max_seen_statements: Option<NonZero<usize>>,
 
-    /// Active statement subscriptions. Maps subscription ID to subscription state.
-    statement_subscriptions:
-        hashbrown::HashMap<String, super::statement::StatementSubscription, fnv::FnvBuildHasher>,
+    /// Active statement subscriptions, indexed by topic for efficient matching.
+    statement_subscriptions: super::statement::StatementSubscriptions,
 
     statement_affinity_stale: bool,
     next_statement_affinity_update: Option<Pin<Box<TPlat::Delay>>>,
@@ -624,10 +623,7 @@ pub(super) async fn run<TPlat: PlatformRef>(
         genesis_block_hash: config.genesis_block_hash,
         printed_legacy_json_rpc_warning: false,
         max_seen_statements: config.max_seen_statements,
-        statement_subscriptions: hashbrown::HashMap::with_capacity_and_hasher(
-            16,
-            Default::default(),
-        ),
+        statement_subscriptions: super::statement::StatementSubscriptions::with_capacity(16),
         statement_affinity_stale: false,
         next_statement_affinity_update: None,
         last_statement_affinity_update: None,
@@ -814,8 +810,7 @@ pub(super) async fn run<TPlat: PlatformRef>(
                 me.statement_affinity_stale = false;
                 me.last_statement_affinity_update = Some(me.platform.now());
 
-                let combined_filter = super::statement::build_combined_affinity_filter(
-                    &me.statement_subscriptions,
+                let combined_filter = me.statement_subscriptions.build_combined_affinity_filter(
                     me.statement_protocol_config
                         .as_ref()
                         .expect("statement affinity requires statement protocol; qed"),
@@ -835,27 +830,12 @@ pub(super) async fn run<TPlat: PlatformRef>(
                     continue;
                 }
 
-                // TODO: O(n_statements * n_subscriptions * n_topics_in_filter * n_topics_in_statement) complexity.
-                // Create a reverse index `topic` -> `subscription` for adequate complexity.
-                for (sub_id, sub) in me.statement_subscriptions.iter_mut() {
-                    let matching: Vec<methods::HexString> = statements
-                        .iter()
-                        .filter_map(|(hash, s)| {
-                            if !sub.accept(hash, s) {
-                                return None;
-                            }
-                            Some(methods::HexString(codec::encode_statement(s).expect(
-                                "re-encoding a decoded statement always succeeds; qed",
-                            )))
-                        })
-                        .collect();
-
-                    if matching.is_empty() {
-                        continue;
-                    }
-
+                // The reverse `topic` -> `subscription` index inside `statement_subscriptions`
+                // keeps this proportional to the number of subscriptions sharing a topic with the
+                // incoming statements, rather than the total number of subscriptions.
+                for (sub_id, matching) in me.statement_subscriptions.matching(&statements) {
                     let notification = methods::ServerToClient::statement_statement {
-                        subscription: Cow::Borrowed(sub_id),
+                        subscription: Cow::Owned(sub_id),
                         result: methods::StatementEvent::NewStatements {
                             statements: matching,
                             remaining: None,
@@ -2984,10 +2964,8 @@ pub(super) async fn run<TPlat: PlatformRef>(
 
                         me.statement_subscriptions.insert(
                             subscription_id.clone(),
-                            super::statement::StatementSubscription::new(
-                                filter,
-                                me.max_seen_statements,
-                            ),
+                            filter,
+                            me.max_seen_statements,
                         );
 
                         me.schedule_statement_affinity_update();
@@ -3004,7 +2982,7 @@ pub(super) async fn run<TPlat: PlatformRef>(
                     }
 
                     methods::MethodCall::statement_unsubscribeStatement { subscription } => {
-                        let existed = me.statement_subscriptions.remove(&subscription).is_some();
+                        let existed = me.statement_subscriptions.remove(&subscription);
 
                         if existed {
                             me.schedule_statement_affinity_update();

--- a/light-base/src/json_rpc_service/statement.rs
+++ b/light-base/src/json_rpc_service/statement.rs
@@ -478,10 +478,16 @@ mod tests {
         ]);
 
         let matches = subs.matching(&[batch_entry(0x01, vec![[7u8; 32]])]);
-        assert_eq!(matched_ids(&matches), vec!["all".to_string(), "any".to_string()]);
+        assert_eq!(
+            matched_ids(&matches),
+            vec!["all".to_string(), "any".to_string()]
+        );
 
         let matches = subs.matching(&[batch_entry(0x02, vec![])]);
-        assert_eq!(matched_ids(&matches), vec!["all".to_string(), "any".to_string()]);
+        assert_eq!(
+            matched_ids(&matches),
+            vec!["all".to_string(), "any".to_string()]
+        );
     }
 
     #[test]

--- a/light-base/src/json_rpc_service/statement.rs
+++ b/light-base/src/json_rpc_service/statement.rs
@@ -220,7 +220,7 @@ impl StatementSubscriptions {
             for id in &candidates {
                 let sub = subscriptions
                     .get_mut(*id)
-                    .expect("by_topic/wildcard only reference live subscriptions; qed");
+                    .expect("`candidates` is a subset of `subscriptions`; qed");
                 if sub.accept(hash, statement) {
                     let encoded = encoded.get_or_insert_with(|| {
                         HexString(

--- a/light-base/src/json_rpc_service/statement.rs
+++ b/light-base/src/json_rpc_service/statement.rs
@@ -19,7 +19,7 @@ use crate::network_service::{self, BroadcastStatementResult};
 use alloc::{string::String, vec::Vec};
 use core::num::NonZero;
 use smoldot::json_rpc::methods::{
-    InternalError, InvalidReason, StatementSubmitResult, TopicFilter,
+    HexString, InternalError, InvalidReason, StatementSubmitResult, TopicFilter,
 };
 use smoldot::network::codec;
 
@@ -78,28 +78,189 @@ impl StatementSubscription {
     }
 }
 
-pub(super) fn build_combined_affinity_filter(
-    subscriptions: &hashbrown::HashMap<String, StatementSubscription, fnv::FnvBuildHasher>,
-    config: &network_service::StatementProtocolConfig,
-) -> network_service::AffinityFilter {
-    let mut all_topics: Vec<&[u8; 32]> = Vec::new();
+/// Set of active statement subscriptions together with a reverse index mapping each topic to the
+/// subscriptions that reference it.
+///
+/// The reverse index lets statement matching scale with the number of subscriptions that share a
+/// topic with the incoming statement, rather than with the total number of subscriptions.
+pub(super) struct StatementSubscriptions {
+    /// Maps subscription ID to its state.
+    subscriptions: hashbrown::HashMap<String, StatementSubscription, fnv::FnvBuildHasher>,
 
-    for sub in subscriptions.values() {
-        match &sub.topic_filter {
-            TopicFilter::Any => {
-                return network_service::AffinityFilter::match_all(config.bloom_seed());
-            }
-            TopicFilter::MatchAll(topics) | TopicFilter::MatchAny(topics) => {
-                all_topics.extend(topics.iter());
-            }
+    /// Reverse index: maps a topic to the IDs of all subscriptions whose filter references it.
+    /// Only populated for `MatchAny`/`MatchAll` filters with a non-empty topic list.
+    by_topic: hashbrown::HashMap<
+        [u8; 32],
+        hashbrown::HashSet<String, fnv::FnvBuildHasher>,
+        fnv::FnvBuildHasher,
+    >,
+
+    /// IDs of subscriptions that match every statement irrespective of its topics: either
+    /// `TopicFilter::Any`, or a `TopicFilter::MatchAll` whose topic list is empty.
+    wildcard: hashbrown::HashSet<String, fnv::FnvBuildHasher>,
+}
+
+impl StatementSubscriptions {
+    pub(super) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            subscriptions: hashbrown::HashMap::with_capacity_and_hasher(
+                capacity,
+                Default::default(),
+            ),
+            by_topic: hashbrown::HashMap::with_hasher(Default::default()),
+            wildcard: hashbrown::HashSet::with_hasher(Default::default()),
         }
     }
 
-    network_service::AffinityFilter::from_topics(
-        all_topics.into_iter(),
-        config.bloom_seed(),
-        config.false_positive_rate(),
-    )
+    pub(super) fn is_empty(&self) -> bool {
+        self.subscriptions.is_empty()
+    }
+
+    /// Inserts a new subscription and updates the reverse index.
+    pub(super) fn insert(
+        &mut self,
+        id: String,
+        topic_filter: TopicFilter,
+        max_seen: Option<NonZero<usize>>,
+    ) {
+        match &topic_filter {
+            TopicFilter::Any => {
+                self.wildcard.insert(id.clone());
+            }
+            // An empty `MatchAll` filter matches every statement.
+            TopicFilter::MatchAll(topics) if topics.is_empty() => {
+                self.wildcard.insert(id.clone());
+            }
+            TopicFilter::MatchAll(topics) | TopicFilter::MatchAny(topics) => {
+                for topic in topics {
+                    self.by_topic
+                        .entry(*topic)
+                        .or_insert_with(|| hashbrown::HashSet::with_hasher(Default::default()))
+                        .insert(id.clone());
+                }
+            }
+        }
+
+        self.subscriptions
+            .insert(id, StatementSubscription::new(topic_filter, max_seen));
+    }
+
+    /// Removes a subscription and cleans up the reverse index. Returns whether it existed.
+    pub(super) fn remove(&mut self, id: &str) -> bool {
+        let Some(sub) = self.subscriptions.remove(id) else {
+            return false;
+        };
+
+        match &sub.topic_filter {
+            TopicFilter::Any => {
+                self.wildcard.remove(id);
+            }
+            TopicFilter::MatchAll(topics) if topics.is_empty() => {
+                self.wildcard.remove(id);
+            }
+            TopicFilter::MatchAll(topics) | TopicFilter::MatchAny(topics) => {
+                for topic in topics {
+                    if let Some(ids) = self.by_topic.get_mut(topic) {
+                        ids.remove(id);
+                        if ids.is_empty() {
+                            self.by_topic.remove(topic);
+                        }
+                    }
+                }
+            }
+        }
+
+        true
+    }
+
+    pub(super) fn shrink_to_fit(&mut self) {
+        self.subscriptions.shrink_to_fit();
+        for ids in self.by_topic.values_mut() {
+            ids.shrink_to_fit();
+        }
+        self.by_topic.shrink_to_fit();
+        self.wildcard.shrink_to_fit();
+    }
+
+    /// Matches a batch of statements against the subscriptions.
+    ///
+    /// Returns, for every subscription that accepts at least one statement, the list of re-encoded
+    /// matching statements. Uses the reverse index to only consider subscriptions that either match
+    /// everything or share a topic with the statement; the precise per-subscription filter and
+    /// deduplication is then applied via [`StatementSubscription::accept`].
+    pub(super) fn matching(
+        &mut self,
+        statements: &[([u8; 32], codec::Statement)],
+    ) -> Vec<(String, Vec<HexString>)> {
+        // Disjoint borrows: `subscriptions` is mutated while `by_topic`/`wildcard` are only read.
+        let Self {
+            subscriptions,
+            by_topic,
+            wildcard,
+        } = self;
+
+        // Subscription ID -> its matching re-encoded statements.
+        let mut out: hashbrown::HashMap<&str, Vec<HexString>, fnv::FnvBuildHasher> =
+            hashbrown::HashMap::with_hasher(Default::default());
+        // Reused across statements to avoid reallocating.
+        let mut candidates: hashbrown::HashSet<&str, fnv::FnvBuildHasher> =
+            hashbrown::HashSet::with_hasher(Default::default());
+
+        for (hash, statement) in statements {
+            candidates.clear();
+            candidates.extend(wildcard.iter().map(String::as_str));
+            for topic in &statement.topics {
+                if let Some(ids) = by_topic.get(topic) {
+                    candidates.extend(ids.iter().map(String::as_str));
+                }
+            }
+
+            // Re-encoded lazily on first match and reused for every matching subscription.
+            let mut encoded: Option<HexString> = None;
+            for id in &candidates {
+                let sub = subscriptions
+                    .get_mut(*id)
+                    .expect("by_topic/wildcard only reference live subscriptions; qed");
+                if sub.accept(hash, statement) {
+                    let encoded = encoded.get_or_insert_with(|| {
+                        HexString(
+                            codec::encode_statement(statement)
+                                .expect("re-encoding a decoded statement always succeeds; qed"),
+                        )
+                    });
+                    out.entry(*id).or_default().push(encoded.clone());
+                }
+            }
+        }
+
+        out.into_iter()
+            .map(|(id, matching)| (String::from(id), matching))
+            .collect()
+    }
+
+    pub(super) fn build_combined_affinity_filter(
+        &self,
+        config: &network_service::StatementProtocolConfig,
+    ) -> network_service::AffinityFilter {
+        let mut all_topics: Vec<&[u8; 32]> = Vec::new();
+
+        for sub in self.subscriptions.values() {
+            match &sub.topic_filter {
+                TopicFilter::Any => {
+                    return network_service::AffinityFilter::match_all(config.bloom_seed());
+                }
+                TopicFilter::MatchAll(topics) | TopicFilter::MatchAny(topics) => {
+                    all_topics.extend(topics.iter());
+                }
+            }
+        }
+
+        network_service::AffinityFilter::from_topics(
+            all_topics.into_iter(),
+            config.bloom_seed(),
+            config.false_positive_rate(),
+        )
+    }
 }
 
 #[cfg(test)]
@@ -123,12 +284,12 @@ mod tests {
 
     fn make_subscriptions(
         entries: Vec<(&str, TopicFilter, Option<NonZero<usize>>)>,
-    ) -> hashbrown::HashMap<String, StatementSubscription, fnv::FnvBuildHasher> {
-        let mut map = hashbrown::HashMap::with_hasher(fnv::FnvBuildHasher::default());
+    ) -> StatementSubscriptions {
+        let mut subs = StatementSubscriptions::with_capacity(entries.len());
         for (id, filter, max_seen) in entries {
-            map.insert(id.to_string(), StatementSubscription::new(filter, max_seen));
+            subs.insert(id.to_string(), filter, max_seen);
         }
-        map
+        subs
     }
 
     fn statement_with_topics(topics: Vec<[u8; 32]>) -> codec::Statement {
@@ -194,7 +355,7 @@ mod tests {
     fn build_combined_affinity_empty_subscriptions() {
         let config = test_config();
         let subs = make_subscriptions(vec![]);
-        let filter = build_combined_affinity_filter(&subs, &config);
+        let filter = subs.build_combined_affinity_filter(&config);
 
         // Empty subscription set: no topics are ever in the filter.
         assert!(!filter.contains(&[1u8; 32]));
@@ -207,7 +368,7 @@ mod tests {
     fn build_combined_affinity_any_filter_matches_everything() {
         let config = test_config();
         let subs = make_subscriptions(vec![("s", TopicFilter::Any, None)]);
-        let filter = build_combined_affinity_filter(&subs, &config);
+        let filter = subs.build_combined_affinity_filter(&config);
 
         // TopicFilter::Any returns the broadcast `match_all` filter: every topic matches.
         assert!(filter.contains(&[1u8; 32]));
@@ -225,7 +386,7 @@ mod tests {
             ("a", TopicFilter::match_any(vec![t1]).unwrap(), None),
             ("b", TopicFilter::match_any(vec![t2]).unwrap(), None),
         ]);
-        let filter = build_combined_affinity_filter(&subs, &config);
+        let filter = subs.build_combined_affinity_filter(&config);
 
         assert!(filter.contains(&t1));
         assert!(filter.contains(&t2));
@@ -276,5 +437,129 @@ mod tests {
         assert!(!sub_a.accept(&hash, &stmt));
         // Same hash on a different subscription is still fresh: caches are independent.
         assert!(sub_b.accept(&hash, &stmt));
+    }
+
+    /// Builds a `(hash, statement)` batch entry from a list of topics.
+    fn batch_entry(hash: u8, topics: Vec<[u8; 32]>) -> ([u8; 32], codec::Statement) {
+        ([hash; 32], statement_with_topics(topics))
+    }
+
+    /// Collects the IDs of all subscriptions that matched at least once.
+    fn matched_ids(matches: &[(String, Vec<HexString>)]) -> Vec<String> {
+        let mut ids: Vec<String> = matches.iter().map(|(id, _)| id.clone()).collect();
+        ids.sort();
+        ids
+    }
+
+    #[test]
+    fn matching_match_any_only_returns_relevant_subscriptions() {
+        let t1 = [1u8; 32];
+        let t2 = [2u8; 32];
+        let mut subs = make_subscriptions(vec![
+            ("a", TopicFilter::match_any(vec![t1]).unwrap(), None),
+            ("b", TopicFilter::match_any(vec![t2]).unwrap(), None),
+        ]);
+
+        // A statement carrying only `t1` must match `a` and not `b`.
+        let matches = subs.matching(&[batch_entry(0xaa, vec![t1])]);
+        assert_eq!(matched_ids(&matches), vec!["a".to_string()]);
+
+        // A statement with an unrelated topic matches nothing.
+        let matches = subs.matching(&[batch_entry(0xbb, vec![[9u8; 32]])]);
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn matching_wildcard_filters_match_every_statement() {
+        // `Any` and an empty `MatchAll` both match every statement, with or without topics.
+        let mut subs = make_subscriptions(vec![
+            ("any", TopicFilter::Any, None),
+            ("all", TopicFilter::match_all(vec![]).unwrap(), None),
+        ]);
+
+        let matches = subs.matching(&[batch_entry(0x01, vec![[7u8; 32]])]);
+        assert_eq!(matched_ids(&matches), vec!["all".to_string(), "any".to_string()]);
+
+        let matches = subs.matching(&[batch_entry(0x02, vec![])]);
+        assert_eq!(matched_ids(&matches), vec!["all".to_string(), "any".to_string()]);
+    }
+
+    #[test]
+    fn matching_match_all_requires_every_topic() {
+        let t1 = [1u8; 32];
+        let t2 = [2u8; 32];
+        let mut subs = make_subscriptions(vec![(
+            "all",
+            TopicFilter::match_all(vec![t1, t2]).unwrap(),
+            None,
+        )]);
+
+        // A statement carrying only one of the required topics is a candidate via the reverse
+        // index but must be rejected by the precise re-check.
+        let matches = subs.matching(&[batch_entry(0xaa, vec![t1])]);
+        assert!(matches.is_empty());
+
+        // A statement carrying both topics matches.
+        let matches = subs.matching(&[batch_entry(0xbb, vec![t1, t2])]);
+        assert_eq!(matched_ids(&matches), vec!["all".to_string()]);
+    }
+
+    #[test]
+    fn matching_empty_match_any_never_matches() {
+        let mut subs = make_subscriptions(vec![(
+            "none",
+            TopicFilter::match_any(vec![]).unwrap(),
+            None,
+        )]);
+
+        let matches = subs.matching(&[batch_entry(0x01, vec![[1u8; 32]])]);
+        assert!(matches.is_empty());
+        let matches = subs.matching(&[batch_entry(0x02, vec![])]);
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn matching_dedup_applies_across_batches() {
+        let t1 = [1u8; 32];
+        let mut subs = make_subscriptions(vec![(
+            "a",
+            TopicFilter::match_any(vec![t1]).unwrap(),
+            NonZero::new(8),
+        )]);
+
+        let entry = batch_entry(0xaa, vec![t1]);
+        let matches = subs.matching(&[entry.clone()]);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].1.len(), 1);
+
+        // The same statement hash is deduplicated and produces no further notification.
+        let matches = subs.matching(&[entry]);
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn matching_groups_multiple_statements_per_subscription() {
+        let t1 = [1u8; 32];
+        let mut subs =
+            make_subscriptions(vec![("a", TopicFilter::match_any(vec![t1]).unwrap(), None)]);
+
+        let matches = subs.matching(&[batch_entry(0x01, vec![t1]), batch_entry(0x02, vec![t1])]);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].0, "a");
+        assert_eq!(matches[0].1.len(), 2);
+    }
+
+    #[test]
+    fn remove_cleans_reverse_index() {
+        let t1 = [1u8; 32];
+        let mut subs =
+            make_subscriptions(vec![("a", TopicFilter::match_any(vec![t1]).unwrap(), None)]);
+
+        assert!(subs.remove("a"));
+        assert!(!subs.remove("a"));
+        assert!(subs.is_empty());
+        // The topic entry must have been cleaned up, so a matching statement finds nothing.
+        let matches = subs.matching(&[batch_entry(0xaa, vec![t1])]);
+        assert!(matches.is_empty());
     }
 }


### PR DESCRIPTION
Closes #3144
Closes #3147

Statements from the network were matched against every active subscription, giving `O(n_statements × n_subscriptions × topic_factors)` complexity — a node re-scanned all subscriptions even for statements no one filtered on.

Add a reverse `topic -> subscriptions` index (plus a `wildcard` set for `Any` and empty `MatchAll`, which match everything). For each statement, matching now considers only the wildcard subscriptions and those sharing one of its topics, then applies the exact per-subscription filter and dedup via `accept`. Filter semantics are unchanged; the index only narrows the candidate set.