### PR TITLE
Report full finalized ancestry in chainHead Finalized events

### DIFF
--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -14,20 +14,11 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli 0.31.1",
-]
-
-[[package]]
-name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
- "gimli 0.32.3",
+ "gimli",
 ]
 
 [[package]]
@@ -54,7 +45,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -452,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "ark-vrf"
-version = "0.1.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d63e9780640021b74d02b32895d8cec1b4abe8e5547b560a6bda6b14b78c6da"
+checksum = "f69f34cb5a7d5d4627792c7a6343508becc19deab59a87ef73367cc112dfd02c"
 dependencies = [
  "ark-bls12-381 0.5.0",
  "ark-ec 0.5.0",
@@ -463,7 +454,7 @@ dependencies = [
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
  "digest 0.10.7",
- "rand_chacha 0.3.1",
+ "generic-array",
  "sha2 0.10.9",
  "w3f-ring-proof",
  "zeroize",
@@ -776,11 +767,11 @@ version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
- "addr2line 0.25.1",
+ "addr2line",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.37.3",
+ "object",
  "rustc-demangle",
  "windows-link",
 ]
@@ -854,7 +845,9 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -875,26 +868,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
-name = "bitcoin-internals"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
-
-[[package]]
 name = "bitcoin-io"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
-dependencies = [
- "bitcoin-internals",
- "hex-conservative 0.1.2",
-]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -903,7 +880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
 dependencies = [
  "bitcoin-io",
- "hex-conservative 0.2.2",
+ "hex-conservative",
 ]
 
 [[package]]
@@ -958,31 +935,6 @@ dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
  "constant_time_eq 0.4.2",
-]
-
-[[package]]
-name = "blake2s_simd"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee29928bad1e3f94c9d1528da29e07a1d3d04817ae8332de1e8b846c8439f4b3"
-dependencies = [
- "arrayref",
- "arrayvec 0.7.6",
- "constant_time_eq 0.4.2",
-]
-
-[[package]]
-name = "blake3"
-version = "1.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
-dependencies = [
- "arrayref",
- "arrayvec 0.7.6",
- "cc",
- "cfg-if",
- "constant_time_eq 0.4.2",
- "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1103,7 +1055,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -1131,19 +1083,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "cid"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b68e3193982cd54187d71afdb2a271ad4cf8af157858e9cb911b91321de143"
-dependencies = [
- "core2",
- "multibase",
- "multihash 0.17.0",
- "serde",
- "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -1255,6 +1194,15 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
@@ -1316,46 +1264,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "cranelift-assembler-x64"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae7b60ec3fd7162427d3b3801520a1908bef7c035b52983cd3ca11b8e7deb51"
+checksum = "de2be1bdbf929c2a2242cbbe15d6583c56f1cc723c6c8452d0179362de28c9d5"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6511c200fed36452697b4b6b161eae57d917a2044e6333b1c1389ed63ccadeee"
+checksum = "9a0336914de11298290783a95a9a7154b894da601659eb5f8f8bc62d1bea98f8"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7086a645aa58bae979312f64e3029ac760ac1b577f5cd2417844842a2ca07f"
+checksum = "fb972cba51a52c1b2a329fec993b911e4d1f9cfab3795811a319b6746c28e014"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5225b4dec45f3f3dbf383f12560fac5ce8d780f399893607e21406e12e77f491"
+checksum = "642c920666bfed9aebca39d8c6e7cb76f09314cc7a4074b1db5edcccdde771b9"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1363,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "858fb3331e53492a95979378d6df5208dd1d0d315f19c052be8115f4efc888e0"
+checksum = "0e1231caaeee3d2363d9b2dba9d6c1f7ff835b8ede6612fba98120af73df44bd"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1376,7 +1315,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli 0.31.1",
+ "gimli",
  "hashbrown 0.15.5",
  "log",
  "pulley-interpreter",
@@ -1390,36 +1329,37 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456715b9d5f12398f156d5081096e7b5d039f01b9ecc49790a011c8e43e65b5f"
+checksum = "eb83e89be8b413e4f7a4215a02d5c5f3e6f04b1060f5db293dd1007b2871dcf5"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
  "cranelift-srcgen",
+ "heck",
  "pulley-interpreter",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0306041099499833f167a0ddb707e1e54100f1a84eab5631bc3dad249708f482"
+checksum = "9d14f8068a98f0a85ffa63dc5fe73cb486a955adbe7311465d13cde54c656d5f"
 
 [[package]]
 name = "cranelift-control"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1672945e1f9afc2297f49c92623f5eabc64398e2cb0d824f8f72a2db2df5af23"
+checksum = "c070aee9312b9736028e99b58d45e1099683386082af38529d5e2ce8c76648f3"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa3cd55eb5f3825b9ae5de1530887907360a6334caccdc124c52f6d75246c98a"
+checksum = "f2d619bb3d14251e96dc9b6a846d6955d78048a168cc3876eb2b789b855c1c22"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1428,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781f9905f8139b8de22987b66b522b416fe63eb76d823f0b3a8c02c8fd9500c7"
+checksum = "2350fcff24d78be5e4201e1eeb4b306e474b9f21e452722b21ffc4f773e8d49a"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1440,15 +1380,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05337a2b02c3df00b4dd9a263a027a07b3dff49f61f7da3b5d195c21eaa633d"
+checksum = "8bdc2b14d7491c53c2989b967b4c07511374733abbc01a895fb01ea31e97bfc8"
 
 [[package]]
 name = "cranelift-native"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eee7a496dd66380082c9c5b6f2d5fa149cec0ec383feec5caf079ca2b3671c2"
+checksum = "e98dbe1326d0001a17b3b0675e3adafcfbd0e7f25f1f845a2f1bb9ce3029f359"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1457,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.122.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b530783809a55cb68d070e0de60cfbb3db0dc94c8850dd5725411422bedcf6bb"
+checksum = "36d7af563cd300c8a1e4e64387929b40e32867112143f0a0e1ce90f977ce4a41"
 
 [[package]]
 name = "crc32fast"
@@ -1589,7 +1529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -1702,6 +1642,15 @@ checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
 ]
 
 [[package]]
@@ -1820,7 +1769,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -2057,6 +2006,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "enum-display"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02058bb25d8d0605829af88230427dd5cd50661590bd2b09d1baf7c64c417f24"
+dependencies = [
+ "enum-display-macro",
+]
+
+[[package]]
+name = "enum-display-macro"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4be2cf2fe7b971b1865febbacd4d8df544aa6bd377cca011a6d69dcf4c60d94"
+dependencies = [
+ "convert_case 0.6.0",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2506,6 +2475,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "fxprof-processed-profile"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
+dependencies = [
+ "bitflags 2.11.0",
+ "debugid",
+ "fxhash",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2578,20 +2569,14 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator",
  "indexmap",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob-match"
@@ -2721,12 +2706,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex-conservative"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
 name = "hex-conservative"
@@ -3435,6 +3414,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "ittapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "jam-codec"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,7 +3665,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -4318,19 +4317,21 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "litep2p"
-version = "0.10.0"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c666ef772d123a7643323ad4979c30dd825e9c68ec1aa5b387a6c9a9871c11ea"
+checksum = "cbf3924cf539a761465543592b34c4198d60db2cda16594769edd43451e5ab41"
 dependencies = [
  "async-trait",
  "bs58",
  "bytes",
- "cid 0.11.2",
+ "cid",
  "ed25519-dalek",
+ "enum-display",
  "futures",
  "futures-timer",
  "hickory-resolver 0.25.2",
  "indexmap",
+ "ip_network",
  "libc",
  "mockall",
  "multiaddr 0.17.1",
@@ -4339,8 +4340,9 @@ dependencies = [
  "parking_lot 0.12.5",
  "pin-project",
  "prost 0.13.5",
- "prost-build",
+ "prost-build 0.14.3",
  "rand 0.8.6",
+ "ring 0.17.14",
  "serde",
  "sha2 0.10.9",
  "simple-dns",
@@ -4617,8 +4619,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
 dependencies = [
  "blake2b_simd",
- "blake2s_simd",
- "blake3",
  "core2",
  "digest 0.10.7",
  "multihash-derive",
@@ -4877,15 +4877,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
+name = "num_enum"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
- "crc32fast",
- "hashbrown 0.15.5",
- "indexmap",
- "memchr",
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4894,6 +4904,9 @@ version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap",
  "memchr",
 ]
 
@@ -4994,19 +5007,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "parity-bip39"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
-dependencies = [
- "bitcoin_hashes 0.13.0",
- "rand 0.8.6",
- "rand_core 0.6.4",
- "serde",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -5211,6 +5211,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
+
+[[package]]
+name = "picosimd"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08357da6268f1d15e41f5e54ec7c9e17b65e54e9a6c22fbaf5ebba61ddf8d18"
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5277,12 +5294,13 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "polkavm"
-version = "0.26.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa028f713d0613f0f08b8b3367402cb859218854f6b96fcbe39a501862894d6f"
+checksum = "d90ece49c68657299648e20469517e22c6ec38321307bb14a69c27a33927a491"
 dependencies = [
  "libc",
  "log",
+ "picosimd",
  "polkavm-assembler",
  "polkavm-common",
  "polkavm-linux-raw",
@@ -5290,37 +5308,38 @@ dependencies = [
 
 [[package]]
 name = "polkavm-assembler"
-version = "0.26.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4859a29e1f4ad64610c4bc2bfc40bb9a535068a034933a5b56b5e7a0febf105a"
+checksum = "00010f7924647dbf6f468d85d0fcfe4c3587cfb4557ef13f3682dbece8fd57f0"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "polkavm-common"
-version = "0.26.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a5794b695626ba70d29e66e3f4f4835767452a6723f3a0bc20884b07088fe8"
+checksum = "9e44a9487003cf5b9fc4462bbcf105cc37d5d9b18b40edf5ed50dd20ed1fdb27"
 dependencies = [
  "log",
+ "picosimd",
  "polkavm-assembler",
 ]
 
 [[package]]
 name = "polkavm-derive"
-version = "0.26.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95282a203ae1f6828a04ff334145c3f6dc718bba6d3959805d273358b45eab93"
+checksum = "3ef966bc8518a66ce12d4edb73f2c4094cae72bb23258bc9e9b2802cc9d6cd79"
 dependencies = [
  "polkavm-derive-impl-macro",
 ]
 
 [[package]]
 name = "polkavm-derive-impl"
-version = "0.26.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6069dc7995cde6e612b868a02ce48b54397c6d2582bd1b97b63aabbe962cd779"
+checksum = "f0c2166ad71dd7f51dcdd0d91b70d408a8b3610fa6e94d8202dd4b7185607181"
 dependencies = [
  "polkavm-common",
  "proc-macro2",
@@ -5330,9 +5349,9 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive-impl-macro"
-version = "0.26.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581d34cafec741dc5ffafbb341933c205b6457f3d76257a9d99fb56687219c91"
+checksum = "c7ac2ac8ec5b938e249fa97b5ebb1e6fa47000c81a25eba6bf0f13edb8d430e4"
 dependencies = [
  "polkavm-derive-impl",
  "syn 2.0.117",
@@ -5340,9 +5359,9 @@ dependencies = [
 
 [[package]]
 name = "polkavm-linux-raw"
-version = "0.26.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28919f542476f4158cc71e6c072b1051f38f4b514253594ac3ad80e3c0211fc8"
+checksum = "42063d4a1c52e569f7794df27dab3e19c9fa8946184023257bdbb43eb4a94be5"
 
 [[package]]
 name = "polling"
@@ -5364,7 +5383,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "opaque-debug",
  "universal-hash",
 ]
@@ -5376,7 +5395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "opaque-debug",
  "universal-hash",
 ]
@@ -5625,6 +5644,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.3",
+]
+
+[[package]]
 name = "prost-build"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5635,10 +5664,29 @@ dependencies = [
  "log",
  "multimap",
  "once_cell",
- "petgraph",
+ "petgraph 0.7.1",
  "prettyplease",
  "prost 0.13.5",
- "prost-types",
+ "prost-types 0.13.5",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph 0.8.3",
+ "prettyplease",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "regex",
  "syn 2.0.117",
  "tempfile",
@@ -5671,6 +5719,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5680,10 +5741,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulley-interpreter"
-version = "35.0.0"
+name = "prost-types"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c4319786b16c1a6a38ee04788d32c669b61ba4b69da2162c868c18be99c1b"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost 0.14.3",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "36.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "329f575a931601f71fbcb3b31d32d16273da5ba7f532fc10be2e432e710b02de"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -5693,9 +5763,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938543690519c20c3a480d20a8efcc8e69abeb44093ab1df4e7c1f81f26c677a"
+checksum = "8bccae89ed67a40989e780105fab43e6c71a077b9fc8ae4c805ff5f73d2a79c8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6318,9 +6388,9 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
-version = "34.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01733879c581defda6f49ff4076033c675d7127bfab6fd0bd0e6cf10696d0564"
+checksum = "c0d3f1e8a1ed997d5fa6f86c005fb47c10b64184c68e611b1f310e3d039e44c7"
 dependencies = [
  "log",
  "sp-core",
@@ -6330,9 +6400,9 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec"
-version = "46.0.0"
+version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5962282c6d40861610814dac5159a99a5b4251d89269bb4e828ff766956f1833"
+checksum = "124e67d20414d12f73640ba2586a5d44d7646ec58ea41d2f1dfd5d98ff56b1aa"
 dependencies = [
  "array-bytes",
  "docify",
@@ -6369,9 +6439,9 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "42.0.0"
+version = "46.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6de05f4f496f2261981b7d293ff4f5ba804bdfa924bf0cd1b48252a8a7051913"
+checksum = "f9736f1d5bf62be76f7a2f629be4443c4a14896f7eefc9987a68a0b4fd023538"
 dependencies = [
  "fnv",
  "futures",
@@ -6396,9 +6466,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.45.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90511c3ab41be12af1ce88753de8993e0b8a5fc0453c0f48069ace06eb4a99d"
+checksum = "cef04379da853c1c14df0ebe8a394ddc6c042ff6e164d285db137edccf6eca14"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -6420,9 +6490,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-common"
-version = "0.41.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81bc77ad5df120ef1ffab877d71539aae878e916c0946a067e8d6b0508a7ea5"
+checksum = "f06c9a86b3475f8182b4e69b75c2b8563e6c71398ddce742f326ba1c2a136efd"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -6434,21 +6504,22 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-polkavm"
-version = "0.38.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8976f310f09818f42ec389e727c91c0a75a8c363a29e3ac97d56492d83fc144f"
+checksum = "10bb402bec955b45c3a7882c8f3de3764dff9ce7705a4936ee7deb7c8ce01377"
 dependencies = [
  "log",
  "polkavm",
  "sc-executor-common",
+ "sp-runtime-interface",
  "sp-wasm-interface",
 ]
 
 [[package]]
 name = "sc-executor-wasmtime"
-version = "0.41.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8f9b2a912f0cb435d2b8e33d67010e494b07f5c6e497d8756a8c21abad199e"
+checksum = "fe2b72c4c65ae32931f36979dd0ca27055f24a556f0308083b2101c1fddf09d1"
 dependencies = [
  "anyhow",
  "log",
@@ -6457,22 +6528,23 @@ dependencies = [
  "sc-allocator",
  "sc-executor-common",
  "sp-runtime-interface",
+ "sp-virtualization",
  "sp-wasm-interface",
  "wasmtime",
 ]
 
 [[package]]
 name = "sc-network"
-version = "0.53.1"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71350e21abf285249978eaedcca8b9a368118b8903571a27cb9501dd0e6072c8"
+checksum = "fc0ac2bd45f377dec09ed4ff99aebaec8cad8c042dedd796766b0e4f1bf99ff9"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
  "async-trait",
  "asynchronous-codec 0.6.2",
  "bytes",
- "cid 0.9.0",
+ "cid",
  "either",
  "fnv",
  "futures",
@@ -6488,7 +6560,7 @@ dependencies = [
  "partial_sort",
  "pin-project",
  "prost 0.12.6",
- "prost-build",
+ "prost-build 0.13.5",
  "rand 0.8.6",
  "sc-client-api",
  "sc-network-common",
@@ -6514,9 +6586,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.51.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7419cbc4a107ec4f430b263408db1527f2ce5fd6ed136c279f22057d3d202965"
+checksum = "0143967106a7ad82e11667c4522519d78e204147369e7d0b9dc2d345ca52c855"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -6525,9 +6597,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-types"
-version = "0.19.0"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79011e96426caf5240631af9c4d0f841a752ee2be606d782406745e76b1123dd"
+checksum = "7dad571c070fc5d7665b443a4b5f7c4644270159d92c19e9cc43ecb490c266fb"
 dependencies = [
  "bs58",
  "bytes",
@@ -6547,9 +6619,9 @@ dependencies = [
 
 [[package]]
 name = "sc-telemetry"
-version = "30.0.1"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b14e2a6c9b1542c6e94aa463f6365f7e4ce75ccd8abe4a55717235d2275477"
+checksum = "7d8e894e2929df91a5b42cd98533673cd4846fd7a1ebd6fab2076a7bd24f6726"
 dependencies = [
  "chrono",
  "futures",
@@ -6567,9 +6639,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "42.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04c8e6a886fd4563be1cfe487af2f11280ea797298b8d831e1ee5a273cc17d"
+checksum = "1cd995c2b649e05d26f911326ab001ef62ed624caa213b5589a20f81f3ebf79c"
 dependencies = [
  "async-trait",
  "futures",
@@ -6580,14 +6652,15 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-runtime",
+ "strum",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-utils"
-version = "20.1.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "347bdbd75c82b548636988199a24c402c942aade1f092026503a636e4d52fbca"
+checksum = "00454290e81f64bad3377a099543449bc4c6c909e1ade78ca307e20007c9b12c"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -6830,7 +6903,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes",
  "rand 0.8.6",
  "secp256k1-sys 0.10.1",
 ]
@@ -7055,7 +7128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
 ]
 
@@ -7067,7 +7140,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -7079,7 +7152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
 ]
 
@@ -7136,9 +7209,9 @@ checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simple-dns"
-version = "0.9.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
+checksum = "7a75cbde1bf934313596a004973e462f9a82caa814dcf1a5f507bdf51597eeb4"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -7402,9 +7475,9 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "39.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc9635cc2a860eff0b2d8b05ba217085c8292f41793f9cadfd931dc54976c00"
+checksum = "8977f83b4672cff5fff35a89a042e925d02f2a7dbfd63b7f4d12c80a2581f16b"
 dependencies = [
  "docify",
  "hash-db",
@@ -7425,9 +7498,9 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "25.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d832cd107113d389340dc80a632330fe7ed7d20f3db50aeeb6abe40e23b6f4e"
+checksum = "32c95e3a2cadf60408a228d175d10bbacacdd2b1cd4a15115bc97e8d667ab0eb"
 dependencies = [
  "Inflector",
  "blake2",
@@ -7440,9 +7513,9 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "43.0.0"
+version = "46.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6067f30cf3fb9270471cf24a65d73b33330f32573abab2d97196f83fc076de0"
+checksum = "fb47c341b52ca668e68929c982c9f4698b467012e1760b71f5be6cf8cf0fb49a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7468,9 +7541,9 @@ dependencies = [
 
 [[package]]
 name = "sp-blockchain"
-version = "42.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082c634447671551ea1cb8f1182d1b8a7109f7316a044b974ad9e663935f56c8"
+checksum = "282bf400700c98decd130b61afd95a15c6d3064ad0366871bb400720ae203455"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -7488,27 +7561,31 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.45.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cdbfa4f10a4c0aac84f9fa3327386988aea983c503b9ec7f0bd8aa8c34c3f01"
+checksum = "e0151233b7598dbacd8a29982444e26240ea32cdf28370a844f3fa25d727187a"
 dependencies = [
  "async-trait",
  "futures",
  "log",
+ "sp-api",
+ "sp-externalities",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
+ "sp-trie",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sp-core"
-version = "38.1.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707602208776d0e19d4269bb3f68c5306cacbdfabbb2e4d8d499af7b907bb0a3"
+checksum = "571e6da2db8de83fa2a6f9fab2a86befdcd004c90cfa19c641b072d3f322a60d"
 dependencies = [
  "ark-vrf",
  "array-bytes",
+ "bip39",
  "bitflags 1.3.2",
  "blake2",
  "bounded-collections",
@@ -7524,7 +7601,6 @@ dependencies = [
  "libsecp256k1",
  "log",
  "merlin",
- "parity-bip39",
  "parity-scale-codec",
  "parking_lot 0.12.5",
  "paste",
@@ -7586,10 +7662,11 @@ dependencies = [
 
 [[package]]
 name = "sp-debug-derive"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d09fa0a5f7299fb81ee25ae3853d26200f7a348148aed6de76be905c007dbe"
+checksum = "d61809bf52be994e4d0a0485bb18a78509ed185e1418736c1ff9011bd1528999"
 dependencies = [
+ "proc-macro-warning",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7597,9 +7674,9 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cbf059dce180a8bf8b6c8b08b6290fa3d1c7f069a60f1df038ab5dd5fc0ba6"
+checksum = "ccab635fdf03594e8bec6213457df38389ad54ac15ce12fea22e9a88ba039c2f"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -7608,9 +7685,9 @@ dependencies = [
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.20.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f929edd118b6332b016e0e5a3eb962b8568b14eee024f818685f8ea5f80d53"
+checksum = "2cee8b7ba45f4b2d8a5720248e024489daf58a9b795ac3e24ac9a697938b0254"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7621,9 +7698,9 @@ dependencies = [
 
 [[package]]
 name = "sp-inherents"
-version = "39.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2522693c705c1245ef8dbdbcf09d7cc6b139f0184d5e0a46856c546666b494d7"
+checksum = "4a298a87658bf4420b179fb15ee45ed885d77b53dc9627b1e858c16e1705417f"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -7635,9 +7712,9 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "43.0.0"
+version = "46.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2059e3b338c0174e8dc9e144cc7e612165ca4c960c3a23c6c99c29ef34768f"
+checksum = "cc8f8415b05edacb24866790c540e29ff967250faffda9996709c2d48f0f6ca4"
 dependencies = [
  "bytes",
  "docify",
@@ -7662,9 +7739,9 @@ dependencies = [
 
 [[package]]
 name = "sp-keystore"
-version = "0.44.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5c0b829014afc22e992be2c198f2677592db43267fc218e9f3207dbbfb6fbb"
+checksum = "74fead48d67f4374903b78624bca25fbf15f95a79d8dbefdecd407bb01544c3d"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -7684,10 +7761,11 @@ dependencies = [
 
 [[package]]
 name = "sp-metadata-ir"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acb04cf79ea9c576c8cf3f493a9e6e432a81b181e64e9bdcc485b0004505fb5a"
+checksum = "fb285f8d35b3fbb553e31c66182c25985717526f21920a08d23fdca88e3bdd1e"
 dependencies = [
+ "derive-where",
  "frame-metadata",
  "parity-scale-codec",
  "scale-info",
@@ -7705,11 +7783,12 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "44.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee57bb77e94c26306501426ac82aca401bb80ee2279ecdba148f68e76cf58247"
+checksum = "00f3c9491215e9d640c05ea651723f6834699f1088aa53043dc9badeb6177935"
 dependencies = [
  "binary-merkle-tree",
+ "bytes",
  "docify",
  "either",
  "hash256-std-hasher",
@@ -7729,15 +7808,16 @@ dependencies = [
  "sp-std",
  "sp-trie",
  "sp-weights",
+ "strum",
  "tracing",
  "tuplex",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
-version = "32.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efdc2bc2adbfb9b4396ae07c7d94db20414d2351608e29e1f44e4f643b387c70"
+checksum = "1263162adb7ffe06c762467495dca536794667abe24567c7a00d5edd2b3e727c"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -7754,9 +7834,9 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04178084ae654b3924934a56943ee73e3562db4d277e948393561b08c3b5b5fe"
+checksum = "c7d9650b5186fd32bf5198adfe08d8fecc76f2ebe8a8927f28aaf2a537d75b2e"
 dependencies = [
  "Inflector",
  "expander",
@@ -7768,9 +7848,9 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.48.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "042677239cca40eb6a0d70e0b220f5693516f59853c2d678de471a79652cd16e"
+checksum = "3789d2895faa6e5d0a88c34c19b8ca7f3fdd9823729bde83743fd13668aaf08a"
 dependencies = [
  "hash-db",
  "log",
@@ -7795,9 +7875,9 @@ checksum = "12f8ee986414b0a9ad741776762f4083cd3a5128449b982a3919c4df36874834"
 
 [[package]]
 name = "sp-storage"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3b70ca340e41cde9d2e069d354508a6e37a6573d66f7cc38f11549002f64ec"
+checksum = "e5e5c9fb0016b49765f89d23e4869ee616e1317de8f75b59babb721ccc27d2af"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7821,9 +7901,9 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "41.1.1"
+version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e34c2336d82297f453340adb1188ec0592abcd862df1f7027994b8e1e5fc139"
+checksum = "1f4d4aa0fec3c80f98762cae84ad7dda64c16dcd37f1b97c34c9d3402023119f"
 dependencies = [
  "ahash",
  "foldhash 0.1.5",
@@ -7847,15 +7927,16 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "42.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633ea19da3ec057d449af667099072daa4e99900984f304b96f4c2ee15aeecc7"
+checksum = "45a409b2e4cf147fc24ef158b3c6659738e7dca70838350309a3dc0cd59a81bc"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
  "serde",
+ "sp-core",
  "sp-crypto-hashing-proc-macro",
  "sp-runtime",
  "sp-std",
@@ -7877,10 +7958,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-wasm-interface"
-version = "24.0.0"
+name = "sp-virtualization"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd177d0658f3df0492f28bd39d665133a7868db5aa66c8642c949b6265430719"
+checksum = "cbd5b06a4cc35605887e9681cda701554d159e1cb757ec97b12a4c496fc96ed2"
+dependencies = [
+ "log",
+ "num_enum",
+ "parity-scale-codec",
+ "polkavm",
+ "sp-runtime-interface",
+ "sp-std",
+ "sp-wasm-interface",
+ "strum",
+]
+
+[[package]]
+name = "sp-wasm-interface"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d29d5c802dbb12ce5efe240f1284842d285249b87530bb7729ddae2647c6b18"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -7891,9 +7988,9 @@ dependencies = [
 
 [[package]]
 name = "sp-weights"
-version = "33.2.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c34d353fdc6469da8fae9248ffc1f34faaf04bec8cabc43fd77681dcbc8517"
+checksum = "364f93051b3b243c6221e51965e2bef465605f1de169a2ebd126fba2576dc3d9"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -7960,10 +8057,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "substrate-bip39"
-version = "0.6.0"
+name = "strum"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca58ffd742f693dc13d69bdbb2e642ae239e0053f6aab3b104252892f856700a"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "substrate-bip39"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93affb0135879b1b67cbcf6370a256e1772f9eaaece3899ec20966d67ad0492"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -8785,9 +8904,9 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c0670ab45a6b7002c7df369fee950a27cf29ae0474343fd3a15aa15f691e7a6"
+checksum = "a7795f2df2ef744e4ffb2125f09325e60a21d305cc3ecece0adeef03f7a9e560"
 dependencies = [
  "hash-db",
  "log",
@@ -9082,9 +9201,9 @@ dependencies = [
 
 [[package]]
 name = "w3f-pcs"
-version = "0.0.2"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe7a8d5c914b69392ab3b267f679a2e546fe29afaddce47981772ac71bd02e1"
+checksum = "3ea1046a1deb6d26c34ba2d1f1bab4222d695d126502ee765f80b021753cb674"
 dependencies = [
  "ark-ec 0.5.0",
  "ark-ff 0.5.0",
@@ -9096,9 +9215,9 @@ dependencies = [
 
 [[package]]
 name = "w3f-plonk-common"
-version = "0.0.2"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aca389e494fe08c5c108b512e2328309036ee1c0bc7bdfdb743fef54d448c8c"
+checksum = "30408cda37b81bd7257319942584c794c5784d00d749757bc664656749a1472a"
 dependencies = [
  "ark-ec 0.5.0",
  "ark-ff 0.5.0",
@@ -9112,9 +9231,9 @@ dependencies = [
 
 [[package]]
 name = "w3f-ring-proof"
-version = "0.0.2"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a639379402ad51504575dbd258740383291ac8147d3b15859bdf1ea48c677de"
+checksum = "0cbfc4cb881a934e6f33c25927bf955d0cb18e52b94528bbc5fa28dddedb4cd1"
 dependencies = [
  "ark-ec 0.5.0",
  "ark-ff 0.5.0",
@@ -9230,12 +9349,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.235.0"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bc393c395cb621367ff02d854179882b9a351b4e0c93d1397e6090b53a5c2a"
+checksum = "724fccfd4f3c24b7e589d333fc0429c68042897a7e8a5f8694f31792471841e7"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
 ]
 
 [[package]]
@@ -9336,9 +9455,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.235.0"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
+checksum = "a9b1e81f3eb254cf7404a82cee6926a4a3ccc5aad80cc3d43608a070c67aa1d7"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
@@ -9361,35 +9480,37 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.235.0"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75aa8e9076de6b9544e6dab4badada518cca0bf4966d35b131bbd057aed8fa0a"
+checksum = "2df225df06a6df15b46e3f73ca066ff92c2e023670969f7d50ce7d5e695abbb1"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe976922a16af3b0d67172c473d1fd4f1aa5d0af9c8ba6538c741f3af686f4"
+checksum = "507d213104e83a7519d91af444a8b19c04281f2eef162d448ee7a894ac1c827d"
 dependencies = [
- "addr2line 0.24.2",
+ "addr2line",
  "anyhow",
  "bitflags 2.11.0",
  "bumpalo",
  "cc",
  "cfg-if",
- "gimli 0.31.1",
+ "fxprof-processed-profile",
+ "gimli",
  "hashbrown 0.15.5",
  "indexmap",
+ "ittapi",
  "libc",
  "log",
  "mach2",
  "memfd",
- "object 0.36.7",
+ "object",
  "once_cell",
  "postcard",
  "pulley-interpreter",
@@ -9397,62 +9518,64 @@ dependencies = [
  "rustix",
  "serde",
  "serde_derive",
+ "serde_json",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-asm-macros",
  "wasmtime-internal-cache",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
  "wasmtime-internal-jit-icache-coherence",
  "wasmtime-internal-math",
  "wasmtime-internal-slab",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
  "wasmtime-internal-winch",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b6264a78d806924abbc76bbc75eac24976bc83bdfb938e5074ae551242436f"
+checksum = "9784b325c3b85562ac6d7f81c8348c42af1f137d98dd4fc6631860e4e68bb655"
 dependencies = [
  "anyhow",
  "cpp_demangle",
  "cranelift-bitset",
  "cranelift-entity",
- "gimli 0.31.1",
+ "gimli",
  "indexmap",
  "log",
- "object 0.36.7",
+ "object",
  "postcard",
  "rustc-demangle",
  "serde",
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.235.0",
- "wasmparser 0.235.0",
+ "wasm-encoder 0.236.1",
+ "wasmparser 0.236.1",
  "wasmprinter",
 ]
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6775a9b516559716e5710e95a8014ca0adcc81e5bf4d3ad7899d89ae40094d1a"
+checksum = "bcaa9336cd5ba934ba734dfdfe35f5245c3c74b4e34f9af9e114fad892d81b3d"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e33ad4bd120f3b1c77d6d0dcdce0de8239555495befcda89393a40ba5e324"
+checksum = "e297746bc001fd919f8f9bb3d28ed1a01fb1ff10a5ccd9720e649b5807bf2b68"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9464,15 +9587,15 @@ dependencies = [
  "serde_derive",
  "sha2 0.10.9",
  "toml 0.8.23",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "zstd 0.13.3",
 ]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec9ad7565e6a8de7cb95484e230ff689db74a4a085219e0da0cbd637a29c01c"
+checksum = "e7d938ae501275f44e7e5532ae4bb720542b429357014d33842e128c46fb9b54"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -9481,15 +9604,15 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
- "gimli 0.31.1",
+ "gimli",
  "itertools 0.14.0",
  "log",
- "object 0.36.7",
+ "object",
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-math",
  "wasmtime-internal-versioned-export-macros",
@@ -9497,9 +9620,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b636ff8b220ebaf29dfe3b23770e4b2bad317b9683e3bf7345e162387385b39"
+checksum = "c1443b0914ff848ee7920e0f232368168e2819b739c54f3c352f0559b6164343"
 dependencies = [
  "anyhow",
  "cc",
@@ -9508,54 +9631,66 @@ dependencies = [
  "rustix",
  "wasmtime-internal-asm-macros",
  "wasmtime-internal-versioned-export-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "36.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "861d6f2a1652e95ca10b02552934b3bd460d7416b285fe10d7ca8c0a2b90dc3e"
+dependencies = [
+ "cc",
+ "object",
+ "rustix",
+ "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4417e06b7f80baff87d9770852c757a39b8d7f11d78b2620ca992b8725f16f50"
+checksum = "b1caeb3140c46319fecf09d93dc38a373eb535fd478e401a9fb2ac2da30fe5f6"
 dependencies = [
  "anyhow",
  "cfg-if",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7710d5c4ecdaa772927fd11e5dc30a9a62d1fc8fe933e11ad5576ad596ab6612"
+checksum = "7c631615929951a4076aae64da7d6cad88668d292f19672606392c24ae9c5a00"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ab22fabe1eed27ab01fd47cd89deacf43ad222ed7fd169ba6f4dd1fbddc53b"
+checksum = "7b28104d57b5bdb5d8facb3a8418463ec6c2cb40bb4adf9833b727ebf6a254eb"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307708f302f5dcf19c1bbbfb3d9f2cbc837dd18088a7988747b043a46ba38ecc"
+checksum = "0dd89f2db7377869aeaf66b71f56def8df54b9482e4f4e5533ccec2505f5c691"
 dependencies = [
  "anyhow",
  "cfg-if",
  "cranelift-codegen",
  "log",
- "object 0.36.7",
+ "object",
 ]
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342b0466f92b7217a4de9e114175fedee1907028567d2548bcd42f71a8b5b016"
+checksum = "a9cdb9c2e3965ee15629d067203cb800e9822664d04335dadc6fe1788d4fc335"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9564,16 +9699,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2012e7384c25b91aab2f1b6a1e1cbab9d0f199bbea06cc873597a3f047f05730"
+checksum = "53f693c8db710f20b927bcee025acd345acf599d055b63f122613d52f5553a5f"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
- "gimli 0.31.1",
- "object 0.36.7",
+ "gimli",
+ "object",
  "target-lexicon",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -9662,19 +9797,19 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "35.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839a334ef7c62d8368dbd427e767a6fbb1ba08cc12ecce19cbb666c10613b585"
+checksum = "4332c8656af179fb8fc3ae5114c738c29399ee97b638d431725201c17f99294e"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",
  "cranelift-codegen",
- "gimli 0.31.1",
+ "gimli",
  "regalloc2",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-math",
@@ -9821,6 +9956,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -9852,11 +9996,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -9881,6 +10042,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9891,6 +10058,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9905,10 +10078,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9923,6 +10108,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9933,6 +10124,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9947,6 +10144,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9957,6 +10160,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -10321,9 +10530,9 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zombienet-configuration"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5067eaad40f8c3b230a930911f58bb97a3163cc884fd4a5e0e771b29364f54"
+checksum = "b2c269216bae9a4628882f272d00d5e44be68091e7b468e75dc70fe7f3e838e4"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -10342,9 +10551,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-orchestrator"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a37c3e697c3261dc417ac952d508ddf431127684acd104d968d710d932847f"
+checksum = "dd5fc4ca778d2bf804f6ea1983f248957452f55fbf06bbb47f31a2bfbbac516b"
 dependencies = [
  "anyhow",
  "array-bytes",
@@ -10380,9 +10589,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-prom-metrics-parser"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b356bab187eda90677147bea9d10f888764aa8c3b8f5ed9d1cbb97a2a88884"
+checksum = "aa851f64b120ee4f5fc13f453f18bb3eb984225e21a91a480f713ecf23c409a0"
 dependencies = [
  "pest",
  "pest_derive",
@@ -10391,9 +10600,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-provider"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ab643816ac3e436ddbfad115680b8fbc205ad9a6a082d5d3e3048ea4466e91"
+checksum = "85a96858350524976ca391e88d637c51a1698de26a2a9de815b79ab99e53911f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10423,15 +10632,23 @@ dependencies = [
 
 [[package]]
 name = "zombienet-sdk"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e96f53151093a724f08622e1af75961e040da938333c34b4c8ace2465e50a4"
+checksum = "fac89f216adc651f1bc3c064b53b2a907efee05acb1a6b272dce3d1419a9d9bb"
 dependencies = [
+ "anyhow",
  "async-trait",
+ "chrono",
+ "flate2",
  "futures",
+ "hex",
  "lazy_static",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
  "subxt",
  "subxt-signer",
+ "tar",
  "tokio",
  "zombienet-configuration",
  "zombienet-orchestrator",
@@ -10441,9 +10658,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-support"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aee54081f7f967970c7c3829bad176fea8b40668c839f277fe79605572cb264a"
+checksum = "e00dc9084a78b16d2c3d0bd1c79a34998466ce7f522187ec1c7880b250af4011"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -18,4 +18,4 @@ smoldot = { path = "../lib", default-features = false }
 tar = "0.4"
 tempfile = "3.8.1"
 tokio = { version = "1.45", features = ["rt-multi-thread", "macros", "process", "time", "fs", "io-util"] }
-zombienet-sdk = "0.4"
+zombienet-sdk = "0.4.13"

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -40,6 +40,36 @@ What happens inside:
    `waitForMessage`.
 
 
+## chainHead against live networks
+
+[`run_chainhead_test.sh`](run_chainhead_test.sh) drives
+[`js/chainhead_v1_follow_test.js`](js/chainhead_v1_follow_test.js) against a
+live public network, attaching a smoldot light client to bundled chain specs
+from [`demo-chain-specs/`](../demo-chain-specs) and following `chainHead_v1`
+until it sees enough new and finalized blocks. Unlike the Zombienet tests
+above, it needs no local Polkadot binaries.
+
+```sh
+# Relay-only:
+./run_chainhead_test.sh paseo
+
+# Relay + asset-hub parachain:
+./run_chainhead_test.sh paseo-ah
+```
+
+The network argument selects the mode: a bare relay name (`paseo`, `polkadot`,
+`kusama`, `westend`) runs relay-only, while an `-ah`/`-ah-next` variant also
+adds the matching asset-hub parachain. When an RPC URL is configured for the
+network, the script first queries its finalized height so the validator's
+lag-regression check is meaningful.
+
+Useful overrides (see the script header for the full list):
+- `WITH_RUNTIME=true` — subscribe with runtime (default `false`).
+- `RELAY_CHAIN_SPEC` / `PARA_CHAIN_SPEC` — override the bundled specs.
+- `SMOLDOT_DB_DUMP_DIR` — dump smoldot DBs on success and warm-load them on
+  later runs from the same directory.
+
+
 ## Bulletin / bitswap snapshots
 
 The `bulletin_fetch` test drives smoldot's `bitswap_v1_get` JSON-RPC

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -47,7 +47,9 @@ What happens inside:
 live public network, attaching a smoldot light client to bundled chain specs
 from [`demo-chain-specs/`](../demo-chain-specs) and following `chainHead_v1`
 until it sees enough new and finalized blocks. Unlike the Zombienet tests
-above, it needs no local Polkadot binaries.
+above, it needs no local Polkadot binaries — only Node.js 22+ and npm. The
+script builds the smoldot JS bundle and installs `js/` dependencies on first
+run (set `SKIP_BUILD=true` to skip the rebuild on repeat runs).
 
 ```sh
 # Relay-only:

--- a/e2e-tests/browser/package-lock.json
+++ b/e2e-tests/browser/package-lock.json
@@ -11,7 +11,7 @@
     },
     "../../wasm-node/javascript": {
       "name": "smoldot",
-      "version": "3.1.3",
+      "version": "3.2.0",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/e2e-tests/docs/smoke-scenarios.md
+++ b/e2e-tests/docs/smoke-scenarios.md
@@ -12,9 +12,13 @@ Cold/warm both rely on smoldot's real warp sync (gap from `lightSyncState` to cu
 
 Chain: `westend-local` relay + `people-westend-local` parachain. Same as fresh, so all three scenarios are directly comparable.
 
-## Artifact bundle
+## Artifact layout
 
-Single GCS object per version:
+The bundle is built with the zombienet-sdk `BundleBuilder`, which packs only
+per-node DB tarballs plus a `manifest.json`. So the artifacts live in two
+places:
+
+**GCS bundle** — single object per version:
 
 ```
 gs://zombienet-db-snaps/zombienet/smoldot_smoke_db/{ARTIFACTS_VERSION}/bundle.tar.gz
@@ -22,14 +26,21 @@ gs://zombienet-db-snaps/zombienet/smoldot_smoke_db/{ARTIFACTS_VERSION}/bundle.ta
 
 Contains:
 
-- `relaychain-db.tgz`, `parachain-db.tgz` — node DB snapshots; keystore stripped
-- `relay-spec.json`, `para-spec.json` — full chain specs (substrate side)
-- `relay-spec-lightSyncState.json`, `para-spec-lightSyncState.json` — slim chain specs (smoldot side, `genesis.stateRootHash` instead of `genesis.raw`)
-- `smoldot-db/relay.json`, `smoldot-db/para.json` — `chainHead_unstable_finalizedDatabase` dumps for warm
+- `relaychain-db.tgz`, `parachain-db.tgz` — node DB snapshots produced by `NetworkNode::snapshot_db` (excludes `keystore/` + `network/`). The parachain tarball also carries the collator's embedded relay node DB (`relay-data/`).
+- `manifest.json` — `SnapshotManifest` with per-archive checksums and a `user_data` blob holding (all JSON, inlined):
+  - `relay_spec_light_sync_state`, `para_spec_light_sync_state` — slim smoldot specs (`genesis.stateRootHash` instead of `genesis.raw`)
+  - `smoldot_db_relay`, `smoldot_db_para` — `chainHead_unstable_finalizedDatabase` dumps for warm
+
+  The consumer (`snapshot::materialize`) writes these back out to disk by key on first use.
+
+**Repo** — full chain specs (with `genesis.raw`, needed by substrate) are committed, not bundled, because they pin the exact genesis the DB snapshot was built against:
+
+- `e2e-tests/chain-specs/smoke-relay-spec.json`
+- `e2e-tests/chain-specs/smoke-para-spec.json`
 
 `ARTIFACTS_VERSION` and `BUNDLE_SHA256` live in `e2e-tests/src/snapshot.rs`. On first use the bundle is downloaded into `~/.cache/smoldot-e2e/{ARTIFACTS_VERSION}/`, SHA-verified, and extracted in place.
 
-For local iteration: `ARTIFACTS_DIR_OVERRIDE=/path/to/dir` skips download/verify and uses files directly from that directory.
+For local iteration: `ARTIFACTS_DIR_OVERRIDE=/path/to/dir` skips download/verify and reads the bundled files directly from the generator output directory (loose `*.tgz` + the JSON artifacts the generator also writes there). Full specs still come from `chain-specs/`.
 
 ## Regenerating the artifact bundle
 
@@ -67,9 +78,16 @@ Steps (from `e2e-tests/`):
 
    Required: `ZOMBIE_PROVIDER=native`, polkadot/polkadot-parachain on `PATH`. The module-level docstring in `tests/smoke_generate_snapshots.rs` lists every env var.
 
-   It produces `bundle.tar.gz` under `SMOKE_SNAPSHOT_OUT` and prints the SHA256 in the manifest at the end.
+   It produces `bundle.tar.gz` under `SMOKE_SNAPSHOT_OUT`, prints the bundle SHA256, and prints the `cp` commands to copy the full specs into `chain-specs/`.
 
-3. **Verify locally** before publishing:
+3. **Commit the full specs** (printed by the generator):
+
+   ```bash
+   cp /tmp/smoldot-snap-v2/relay-spec.json e2e-tests/chain-specs/smoke-relay-spec.json
+   cp /tmp/smoldot-snap-v2/para-spec.json  e2e-tests/chain-specs/smoke-para-spec.json
+   ```
+
+4. **Verify locally** before publishing:
 
    ```bash
    ARTIFACTS_DIR_OVERRIDE=/tmp/smoldot-snap-v2 cargo test --test smoke_cold -- --nocapture
@@ -78,24 +96,25 @@ Steps (from `e2e-tests/`):
 
    Both must pass. If they don't, it's almost certainly the chain spec / runtime version or the `--spec-at-finalized` choice — fix and retry before uploading.
 
-4. **Publish**:
+5. **Publish**:
    ```bash
    gsutil cp /tmp/smoldot-snap-v2/bundle.tar.gz \
      gs://zombienet-db-snaps/zombienet/smoldot_smoke_db/v2/bundle.tar.gz
    ```
 
-5. **Pin the new SHA** in `src/snapshot.rs` (copy the value from the generator manifest):
+6. **Pin the new SHA** in `src/snapshot.rs` (copy the value from the generator manifest):
    ```rust
    const BUNDLE_SHA256: &str = "<hash>";
    ```
 
-6. **CI cache key** invalidates automatically — the workflow's cache step keys on `hashFiles('e2e-tests/src/snapshot.rs')`, so bumping the constant is enough.
+7. **CI cache key** invalidates automatically — the workflow's cache step keys on `hashFiles('e2e-tests/src/snapshot.rs')`, so bumping the constant is enough.
 
-7. Commit, open PR, run cold/warm tests in CI to confirm GCS download + extract path works end-to-end.
+8. Commit (bundle SHA, version, and the regenerated `chain-specs/smoke-*-spec.json`), open PR, run cold/warm tests in CI to confirm the GCS download + extract path works end-to-end.
 
 ## Notes on common pitfalls
 
-- **Sibling nodes with identical session keys equivocate.** The generator excludes `keystore/` when tarring; zombienet inserts per-node keys via `author_insertKey` after startup. Don't add keystore back into the snapshot.
+- **Sibling nodes with identical session keys equivocate.** `NetworkNode::snapshot_db` excludes `keystore/` (and `network/`); zombienet inserts per-node keys via `author_insertKey` after startup. Don't reintroduce keystore into the snapshot.
+- **Full specs must match the DB genesis.** The committed `chain-specs/smoke-*-spec.json` pin the genesis (including the elastic-scaling `scheduler_params` override) the DB snapshot was generated against. Regenerate and recommit them whenever genesis config or the runtime changes — a stale full spec yields a genesis-hash mismatch against the DB.
 - **Same tarball path passed to multiple zombienet nodes** triggers a TOCTOU race in zombienet-provider's `with_db_snapshot` cache. The generator and `network::stage_per_node_snapshots` work around this by copying the tarball once per consuming node.
 - **Spec-at-finalized too close to target-finalized**: gap ≤ 32 means smoldot uses follow-forward instead of warp sync, which can't traverse GRANDPA rotations. Default `M = N/2` keeps it safe.
 - **Bootnode multiaddrs are per-spawn** (zombienet picks free ports). The committed specs ship with empty `bootNodes`; `network::prepare_runtime_specs` injects current multiaddrs into a runtime copy before handing the spec to smoldot.

--- a/e2e-tests/docs/smoke-scenarios.md
+++ b/e2e-tests/docs/smoke-scenarios.md
@@ -22,7 +22,7 @@ gs://zombienet-db-snaps/zombienet/smoldot_smoke_db/{ARTIFACTS_VERSION}/bundle.ta
 
 Contains:
 
-- `relaychain-db.tgz`, `parachain-db.tgz` — node DB snapshots produced by `NetworkNode::snapshot_db` (excludes `keystore/` + `network/`). The parachain tarball also carries the collator's embedded relay node DB (`relay-data/`).
+- `relaychain-db-{i}.tgz` (one per relay validator), `parachain-db.tgz` — node DB snapshots produced by `NetworkNode::snapshot_db` (excludes `keystore/` + `network/`). Every relay validator is snapshotted (element `i` restored onto `validator-i`) so all erasure chunks and every backing group's full data survive the restore, letting availability recovery reconstruct candidates that were in flight at snapshot time. The parachain tarball also carries the collator's embedded relay node DB (`relay-data/`).
 - `manifest.json` — `SnapshotManifest` with per-archive checksums and a `user_data` blob holding every non-tarball artifact (all JSON, inlined). `BundleBuilder` only packs `NodeSnapshot` tarballs as files, so these ride in `user_data`:
   - `relay_full_spec`, `para_full_spec` — full chain specs (with `genesis.raw`, loaded by substrate)
   - `relay_spec_light_sync_state`, `para_spec_light_sync_state` — slim smoldot specs (`genesis.stateRootHash` instead of `genesis.raw`)

--- a/e2e-tests/docs/smoke-scenarios.md
+++ b/e2e-tests/docs/smoke-scenarios.md
@@ -14,11 +14,7 @@ Chain: `westend-local` relay + `people-westend-local` parachain. Same as fresh, 
 
 ## Artifact layout
 
-The bundle is built with the zombienet-sdk `BundleBuilder`, which packs only
-per-node DB tarballs plus a `manifest.json`. So the artifacts live in two
-places:
-
-**GCS bundle** — single object per version:
+Everything ships in a single self-contained `BundleBuilder` bundle on GCS:
 
 ```
 gs://zombienet-db-snaps/zombienet/smoldot_smoke_db/{ARTIFACTS_VERSION}/bundle.tar.gz
@@ -27,20 +23,16 @@ gs://zombienet-db-snaps/zombienet/smoldot_smoke_db/{ARTIFACTS_VERSION}/bundle.ta
 Contains:
 
 - `relaychain-db.tgz`, `parachain-db.tgz` — node DB snapshots produced by `NetworkNode::snapshot_db` (excludes `keystore/` + `network/`). The parachain tarball also carries the collator's embedded relay node DB (`relay-data/`).
-- `manifest.json` — `SnapshotManifest` with per-archive checksums and a `user_data` blob holding (all JSON, inlined):
+- `manifest.json` — `SnapshotManifest` with per-archive checksums and a `user_data` blob holding every non-tarball artifact (all JSON, inlined). `BundleBuilder` only packs `NodeSnapshot` tarballs as files, so these ride in `user_data`:
+  - `relay_full_spec`, `para_full_spec` — full chain specs (with `genesis.raw`, loaded by substrate)
   - `relay_spec_light_sync_state`, `para_spec_light_sync_state` — slim smoldot specs (`genesis.stateRootHash` instead of `genesis.raw`)
   - `smoldot_db_relay`, `smoldot_db_para` — `chainHead_unstable_finalizedDatabase` dumps for warm
 
-  The consumer (`snapshot::materialize`) writes these back out to disk by key on first use.
-
-**Repo** — full chain specs (with `genesis.raw`, needed by substrate) are committed, not bundled, because they pin the exact genesis the DB snapshot was built against:
-
-- `e2e-tests/chain-specs/smoke-relay-spec.json`
-- `e2e-tests/chain-specs/smoke-para-spec.json`
+  The consumer (`snapshot::materialize`) writes each back out to disk by key on first use. The bundle SHA pins the full specs to the exact genesis the DB snapshot was built against — nothing is committed to the repo.
 
 `ARTIFACTS_VERSION` and `BUNDLE_SHA256` live in `e2e-tests/src/snapshot.rs`. On first use the bundle is downloaded into `~/.cache/smoldot-e2e/{ARTIFACTS_VERSION}/`, SHA-verified, and extracted in place.
 
-For local iteration: `ARTIFACTS_DIR_OVERRIDE=/path/to/dir` skips download/verify and reads the bundled files directly from the generator output directory (loose `*.tgz` + the JSON artifacts the generator also writes there). Full specs still come from `chain-specs/`.
+For local iteration: `ARTIFACTS_DIR_OVERRIDE=/path/to/dir` skips download/verify and reads the loose files directly from the generator output directory.
 
 ## Regenerating the artifact bundle
 
@@ -78,16 +70,9 @@ Steps (from `e2e-tests/`):
 
    Required: `ZOMBIE_PROVIDER=native`, polkadot/polkadot-parachain on `PATH`. The module-level docstring in `tests/smoke_generate_snapshots.rs` lists every env var.
 
-   It produces `bundle.tar.gz` under `SMOKE_SNAPSHOT_OUT`, prints the bundle SHA256, and prints the `cp` commands to copy the full specs into `chain-specs/`.
+   It produces a self-contained `bundle.tar.gz` under `SMOKE_SNAPSHOT_OUT` and prints the bundle SHA256.
 
-3. **Commit the full specs** (printed by the generator):
-
-   ```bash
-   cp /tmp/smoldot-snap-v2/relay-spec.json e2e-tests/chain-specs/smoke-relay-spec.json
-   cp /tmp/smoldot-snap-v2/para-spec.json  e2e-tests/chain-specs/smoke-para-spec.json
-   ```
-
-4. **Verify locally** before publishing:
+3. **Verify locally** before publishing:
 
    ```bash
    ARTIFACTS_DIR_OVERRIDE=/tmp/smoldot-snap-v2 cargo test --test smoke_cold -- --nocapture
@@ -96,25 +81,25 @@ Steps (from `e2e-tests/`):
 
    Both must pass. If they don't, it's almost certainly the chain spec / runtime version or the `--spec-at-finalized` choice — fix and retry before uploading.
 
-5. **Publish**:
+4. **Publish**:
    ```bash
    gsutil cp /tmp/smoldot-snap-v2/bundle.tar.gz \
      gs://zombienet-db-snaps/zombienet/smoldot_smoke_db/v2/bundle.tar.gz
    ```
 
-6. **Pin the new SHA** in `src/snapshot.rs` (copy the value from the generator manifest):
+5. **Pin the new SHA** in `src/snapshot.rs` (copy the value from the generator manifest):
    ```rust
    const BUNDLE_SHA256: &str = "<hash>";
    ```
 
-7. **CI cache key** invalidates automatically — the workflow's cache step keys on `hashFiles('e2e-tests/src/snapshot.rs')`, so bumping the constant is enough.
+6. **CI cache key** invalidates automatically — the workflow's cache step keys on `hashFiles('e2e-tests/src/snapshot.rs')`, so bumping the constant is enough.
 
-8. Commit (bundle SHA, version, and the regenerated `chain-specs/smoke-*-spec.json`), open PR, run cold/warm tests in CI to confirm the GCS download + extract path works end-to-end.
+7. Commit the bumped version + SHA, open PR, run cold/warm tests in CI to confirm the GCS download + extract path works end-to-end.
 
 ## Notes on common pitfalls
 
 - **Sibling nodes with identical session keys equivocate.** `NetworkNode::snapshot_db` excludes `keystore/` (and `network/`); zombienet inserts per-node keys via `author_insertKey` after startup. Don't reintroduce keystore into the snapshot.
-- **Full specs must match the DB genesis.** The committed `chain-specs/smoke-*-spec.json` pin the genesis (including the elastic-scaling `scheduler_params` override) the DB snapshot was generated against. Regenerate and recommit them whenever genesis config or the runtime changes — a stale full spec yields a genesis-hash mismatch against the DB.
+- **Full specs must match the DB genesis.** The `*_full_spec` blobs in the bundle pin the genesis (including the elastic-scaling `scheduler_params` override) the DB snapshot was generated against. They're regenerated with the bundle, so a version bump keeps them in lockstep — no stale committed spec can drift from the DB.
 - **Same tarball path passed to multiple zombienet nodes** triggers a TOCTOU race in zombienet-provider's `with_db_snapshot` cache. The generator and `network::stage_per_node_snapshots` work around this by copying the tarball once per consuming node.
 - **Spec-at-finalized too close to target-finalized**: gap ≤ 32 means smoldot uses follow-forward instead of warp sync, which can't traverse GRANDPA rotations. Default `M = N/2` keeps it safe.
 - **Bootnode multiaddrs are per-spawn** (zombienet picks free ports). The committed specs ship with empty `bootNodes`; `network::prepare_runtime_specs` injects current multiaddrs into a runtime copy before handing the spec to smoldot.

--- a/e2e-tests/js/chainhead_v1_follow_test.js
+++ b/e2e-tests/js/chainhead_v1_follow_test.js
@@ -17,10 +17,10 @@
 
 // chainHead_v1_follow conformance + regression driver.
 //
-// Subscribes the para chain (withRuntime=true), validates the spec invariants
-// of every event, and on resubscribe (after `stop` or explicit unfollow)
-// reports a regression if the new initial finalized number is below the
-// previous subscription's last finalized number.
+// Subscribes the para chain (or the relay chain when no para spec is given),
+// validates the spec invariants of every event, and on resubscribe (after
+// `stop` or explicit unfollow) reports a regression if the new initial
+// finalized number is below the previous subscription's last finalized number.
 
 import * as fs from "node:fs";
 import {
@@ -47,9 +47,13 @@ const paraBestAtLaunch = Number.parseInt(process.env.PARA_BEST_AT_LAUNCH ?? "0",
 const paraFinalizedAtLaunch = Number.parseInt(process.env.PARA_FINALIZED_AT_LAUNCH ?? "0", 10);
 const initialLagTolerance = Number.parseInt(process.env.INITIAL_LAG_TOLERANCE ?? "50", 10);
 const dbDumpDir = process.env.SMOLDOT_DB_DUMP_DIR || null;
+// No para spec means relay-only: subscribe to the relay chain directly.
+const relayOnly = !paraSpecPath;
 
-if (!relaySpecPath || !paraSpecPath) {
-  console.error("Required env vars: RELAY_CHAIN_SPEC, PARA_CHAIN_SPEC");
+if (!relaySpecPath) {
+  console.error(
+    "Required env vars: RELAY_CHAIN_SPEC (PARA_CHAIN_SPEC optional; if unset, runs relay-only)",
+  );
   process.exit(1);
 }
 
@@ -533,13 +537,19 @@ try {
   relay = await addChainFromSpec(client, relaySpecPath, { databaseContent: relayDbContent });
   report("addChain relay", true);
 
-  para = await addChainFromSpec(client, paraSpecPath, {
-    databaseContent: paraDbContent,
-    potentialRelayChains: [relay],
-  });
-  report("addChain parachain", true);
+  let target;
+  if (relayOnly) {
+    target = relay;
+  } else {
+    para = await addChainFromSpec(client, paraSpecPath, {
+      databaseContent: paraDbContent,
+      potentialRelayChains: [relay],
+    });
+    report("addChain parachain", true);
+    target = para;
+  }
 
-  const mux = new JsonRpcMux(para);
+  const mux = new JsonRpcMux(target);
   const validator = new ChainHeadValidator({ withRuntime });
   const overallDeadline = Date.now() + overallTimeoutMs;
 
@@ -615,11 +625,17 @@ try {
   if (dbDumpDir && validator.violations.length === 0) {
     try {
       fs.mkdirSync(dbDumpDir, { recursive: true });
-      // Relay has no mux, so use sendRpcAndWait directly. Para is muxed.
-      const relayDb = await sendRpcAndWait(relay, "chainHead_unstable_finalizedDatabase", [], 30_000);
-      const paraDb = await mux.request("chainHead_unstable_finalizedDatabase", [], 30_000);
-      fs.writeFileSync(`${dbDumpDir}/relay.json`, relayDb);
-      fs.writeFileSync(`${dbDumpDir}/para.json`, paraDb);
+      if (relayOnly) {
+        // Relay is the muxed chain here; there is no parachain.
+        const relayDb = await mux.request("chainHead_unstable_finalizedDatabase", [], 30_000);
+        fs.writeFileSync(`${dbDumpDir}/relay.json`, relayDb);
+      } else {
+        // Relay has no mux, so use sendRpcAndWait directly. Para is muxed.
+        const relayDb = await sendRpcAndWait(relay, "chainHead_unstable_finalizedDatabase", [], 30_000);
+        const paraDb = await mux.request("chainHead_unstable_finalizedDatabase", [], 30_000);
+        fs.writeFileSync(`${dbDumpDir}/relay.json`, relayDb);
+        fs.writeFileSync(`${dbDumpDir}/para.json`, paraDb);
+      }
       report("dumped smoldot databaseContent", true, dbDumpDir);
     } catch (e) {
       report("dumped smoldot databaseContent", false, e.message);

--- a/e2e-tests/js/chainhead_v1_follow_test.js
+++ b/e2e-tests/js/chainhead_v1_follow_test.js
@@ -274,6 +274,9 @@ class ChainHeadValidator {
     if (this.withRuntime && !event.finalizedBlockRuntime) {
       this.violation("initialized.finalizedBlockRuntime missing with withRuntime=true");
     }
+    if (!this.withRuntime && event.finalizedBlockRuntime != null) {
+      this.violation("initialized.finalizedBlockRuntime present with withRuntime=false");
+    }
     for (const h of hashes) this.knownHashes.add(h);
     this.initialFinalizedHash = hashes[hashes.length - 1];
     this.lastFinalizedHash = this.initialFinalizedHash;
@@ -295,6 +298,9 @@ class ChainHeadValidator {
         `newBlock parent unknown: parent=${event.parentBlockHash} block=${event.blockHash}`,
       );
       return;
+    }
+    if (!this.withRuntime && event.newRuntime != null) {
+      this.violation(`newBlock.newRuntime present with withRuntime=false: ${event.blockHash}`);
     }
     this.knownHashes.add(event.blockHash);
     this.parents.set(event.blockHash, event.parentBlockHash);

--- a/e2e-tests/js/chainhead_v1_follow_test.js
+++ b/e2e-tests/js/chainhead_v1_follow_test.js
@@ -352,7 +352,9 @@ class ChainHeadValidator {
         this.violation(
           `finalized chain break: ${h} parent=${parent} expected=${prev}`,
         );
-        return;
+        // Record once; state still advances to the tip below so we don't
+        // re-flag the same gap on every later event.
+        break;
       }
       prev = h;
     }

--- a/e2e-tests/js/chainhead_v1_follow_test.js
+++ b/e2e-tests/js/chainhead_v1_follow_test.js
@@ -380,12 +380,14 @@ class ChainHeadValidator {
         `new initial finalized #${n} < previous last finalized #${this.previousSub.lastFinalizedNumber}`,
       );
     }
-    if (
-      paraFinalizedAtLaunch > 0 &&
-      n + initialLagTolerance < paraFinalizedAtLaunch
-    ) {
+    // Compare against the followed chain's own finalized-at-launch.
+    const chainLabel = relayOnly ? "relay" : "para";
+    const finalizedAtLaunch = relayOnly
+      ? relayFinalizedAtLaunch
+      : paraFinalizedAtLaunch;
+    if (finalizedAtLaunch > 0 && n + initialLagTolerance < finalizedAtLaunch) {
       this.regression(
-        `initial finalized #${n} lags more than ${initialLagTolerance} behind para finalized at launch #${paraFinalizedAtLaunch}`,
+        `initial finalized #${n} lags more than ${initialLagTolerance} behind ${chainLabel} finalized at launch #${finalizedAtLaunch}`,
       );
     }
   }

--- a/e2e-tests/run_chainhead_test.sh
+++ b/e2e-tests/run_chainhead_test.sh
@@ -163,6 +163,21 @@ if [[ -n "${SMOLDOT_DB_DUMP_DIR:-}" ]]; then
   fi
 fi
 
+# Mirror the Rust harness: build the smoldot JS bundle and install JS deps.
+# Set SKIP_BUILD=true to skip the (idempotent) rebuild on repeat runs.
+if [[ "${SKIP_BUILD:-false}" != "true" ]]; then
+  if [[ ! -d "${REPO_ROOT}/wasm-node/javascript/node_modules" ]]; then
+    echo "Installing smoldot JS deps..." >&2
+    (cd "${REPO_ROOT}/wasm-node/javascript" && npm ci)
+  fi
+  echo "Building smoldot JS bundle..." >&2
+  (cd "${REPO_ROOT}/wasm-node/javascript" && npm run build)
+fi
+if [[ ! -d "${SCRIPT_DIR}/js/node_modules" ]]; then
+  echo "Installing JS deps..." >&2
+  (cd "${SCRIPT_DIR}/js" && npm install)
+fi
+
 cd "${SCRIPT_DIR}"
 exec env \
   WITH_RUNTIME="${WITH_RUNTIME:-false}" \

--- a/e2e-tests/run_chainhead_test.sh
+++ b/e2e-tests/run_chainhead_test.sh
@@ -7,8 +7,12 @@
 # Usage:
 #   ./run_chainhead_test.sh <network>
 #
-# Supported networks (asset-hub para by default):
-#   paseo, polkadot, kusama, westend
+# A relay network name runs relay-only; an `-ah`/`-next` variant also adds the
+# corresponding asset-hub parachain (relay = the matching relay chain).
+#   relay-only: paseo, polkadot, kusama, westend
+#   with para:  paseo-ah, paseo-ah-next, polkadot-ah, kusama-ah, westend-ah
+#
+# Set WITH_RUNTIME=true to subscribe with runtime (default false).
 
 set -euo pipefail
 
@@ -17,14 +21,24 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 SPECS_DIR="${REPO_ROOT}/demo-chain-specs"
 
+# A network without a `para_spec` is treated as relay-only.
+relay_spec=""
+para_spec=""
+relay_rpc=""
+para_rpc=""
+
 case "${network}" in
   paseo)
+    relay_spec="${SPECS_DIR}/paseo.json"
+    relay_rpc="https://paseo-rpc.n.dwellir.com"
+    ;;
+  paseo-ah)
     relay_spec="${SPECS_DIR}/paseo.json"
     para_spec="${SPECS_DIR}/paseo_asset_hub.json"
     relay_rpc="https://paseo-rpc.n.dwellir.com"
     para_rpc="https://asset-hub-paseo-rpc.n.dwellir.com"
     ;;
-  paseo-next)
+  paseo-ah-next)
     relay_spec="${SPECS_DIR}/paseo.json"
     para_spec="${SPECS_DIR}/paseo_asset_hub_next.json"
     relay_rpc="https://paseo-rpc.n.dwellir.com"
@@ -32,11 +46,19 @@ case "${network}" in
     ;;
   polkadot)
     relay_spec="${SPECS_DIR}/polkadot.json"
+    relay_rpc=""  # TODO: set Polkadot relay RPC URL
+    ;;
+  polkadot-ah)
+    relay_spec="${SPECS_DIR}/polkadot.json"
     para_spec="${SPECS_DIR}/polkadot_asset_hub.json"
     relay_rpc=""  # TODO: set Polkadot relay RPC URL
     para_rpc=""  # TODO: set Polkadot Asset Hub RPC URL
     ;;
   kusama)
+    relay_spec="${SPECS_DIR}/ksmcc3.json"
+    relay_rpc=""  # TODO: set Kusama relay RPC URL
+    ;;
+  kusama-ah)
     relay_spec="${SPECS_DIR}/ksmcc3.json"
     para_spec="${SPECS_DIR}/ksmcc3_asset_hub.json"
     relay_rpc=""  # TODO: set Kusama relay RPC URL
@@ -44,13 +66,17 @@ case "${network}" in
     ;;
   westend)
     relay_spec="${SPECS_DIR}/westend2.json"
+    relay_rpc=""  # TODO: set Westend relay RPC URL
+    ;;
+  westend-ah)
+    relay_spec="${SPECS_DIR}/westend2.json"
     para_spec="${SPECS_DIR}/westend2_asset_hub.json"
     relay_rpc=""  # TODO: set Westend relay RPC URL
     para_rpc=""  # TODO: set Westend Asset Hub RPC URL
     ;;
   *)
     echo "Unknown network: ${network}" >&2
-    echo "Supported: paseo, polkadot, kusama, westend" >&2
+    echo "Supported: paseo[-ah[-next]], polkadot[-ah], kusama[-ah], westend[-ah]" >&2
     exit 1
     ;;
 esac
@@ -64,7 +90,7 @@ if [[ ! -f "${RELAY_CHAIN_SPEC}" ]]; then
   echo "Relay chain spec not found: ${RELAY_CHAIN_SPEC}" >&2
   exit 1
 fi
-if [[ ! -f "${PARA_CHAIN_SPEC}" ]]; then
+if [[ -n "${PARA_CHAIN_SPEC}" && ! -f "${PARA_CHAIN_SPEC}" ]]; then
   echo "Para chain spec not found: ${PARA_CHAIN_SPEC}" >&2
   exit 1
 fi
@@ -139,6 +165,7 @@ fi
 
 cd "${SCRIPT_DIR}"
 exec env \
+  WITH_RUNTIME="${WITH_RUNTIME:-false}" \
   RELAY_CHAIN_SPEC="${RELAY_CHAIN_SPEC}" \
   PARA_CHAIN_SPEC="${PARA_CHAIN_SPEC}" \
   RELAY_FINALIZED_AT_LAUNCH="${RELAY_FINALIZED_AT_LAUNCH}" \

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -76,9 +76,17 @@ fn project_root() -> PathBuf {
         .to_path_buf()
 }
 
-/// Ensures the smoldot JS bundle is built.
+/// Ensures the smoldot JS bundle is built, to make cargo test self-sufficient.
 pub fn ensure_smoldot_built() {
     let js_dir = project_root().join("wasm-node/javascript");
+    if !js_dir.join("node_modules").exists() {
+        let status = std::process::Command::new("npm")
+            .arg("ci")
+            .current_dir(&js_dir)
+            .status()
+            .expect("failed to run npm ci");
+        assert!(status.success(), "npm ci in wasm-node/javascript failed");
+    }
     let status = std::process::Command::new("npm")
         .arg("run")
         .arg("build")

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -24,8 +24,8 @@ pub mod statement;
 
 pub use network::{
     elastic_scaling_genesis_overrides, run_chainhead_v1_follow_js, run_smoke_js, spawn_scenario,
-    spawned_chain_spec_paths, LiveNetwork, Scenario, SmoldotDbPaths, SnapshotPaths, BEST_METRIC,
-    ELASTIC_MAX_VALIDATORS_PER_CORE, ELASTIC_SCALING_CORES, ELASTIC_VALIDATOR_COUNT,
+    spawned_chain_spec_paths, FollowChain, LiveNetwork, Scenario, SmoldotDbPaths, SnapshotPaths,
+    BEST_METRIC, ELASTIC_MAX_VALIDATORS_PER_CORE, ELASTIC_SCALING_CORES, ELASTIC_VALIDATOR_COUNT,
     FINALIZED_METRIC, PARA_ID,
 };
 

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -23,8 +23,10 @@ pub mod snapshot;
 pub mod statement;
 
 pub use network::{
-    run_chainhead_v1_follow_js, run_smoke_js, spawn_scenario, spawned_chain_spec_paths,
-    LiveNetwork, Scenario, SmoldotDbPaths, SnapshotPaths, BEST_METRIC, FINALIZED_METRIC, PARA_ID,
+    elastic_scaling_genesis_overrides, run_chainhead_v1_follow_js, run_smoke_js, spawn_scenario,
+    spawned_chain_spec_paths, LiveNetwork, Scenario, SmoldotDbPaths, SnapshotPaths, BEST_METRIC,
+    ELASTIC_MAX_VALIDATORS_PER_CORE, ELASTIC_SCALING_CORES, ELASTIC_VALIDATOR_COUNT,
+    FINALIZED_METRIC, PARA_ID,
 };
 
 /// A file-backed Rust → JS message channel. Rust appends newline-terminated

--- a/e2e-tests/src/network.rs
+++ b/e2e-tests/src/network.rs
@@ -45,6 +45,10 @@ pub const BEST_METRIC: &str = "block_height{status=\"best\"}";
 /// downstream smoldot timeout.
 const RELAY_FIRST_FINALIZED_TIMEOUT_SECS: u64 = 120;
 
+/// Core indices assigned to the parachain in the Fresh scenario so it can
+/// author multiple blocks per relay block (elastic scaling).
+const ELASTIC_SCALING_CORES: &[u32] = &[0, 1, 2];
+
 pub struct SnapshotPaths {
     /// Substrate-node DB tarballs.
     pub relay_db_tgz: PathBuf,
@@ -128,6 +132,7 @@ pub async fn spawn_scenario(
 
     if matches!(cfg, Scenario::Fresh) {
         wait_for_relay_first_finalized(&network).await?;
+        assign_elastic_cores(&network).await?;
     }
 
     let (relay_spec, para_spec) = match cfg.snapshot() {
@@ -182,22 +187,37 @@ fn build_network_config(
                 .with_default_command("polkadot")
                 .with_default_image(images.polkadot.as_str());
             let r = match relay_spec_path.as_deref() {
-                None => r,
+                // Fresh: declare the total core count so the para can later be
+                // assigned multiple cores at runtime (elastic scaling). Only
+                // valid for a generated genesis; snapshot specs bring their own.
+                None => r.with_genesis_overrides(serde_json::json!({
+                    "configuration": {
+                        "config": {
+                            "scheduler_params": {
+                                "num_cores": ELASTIC_SCALING_CORES.len(),
+                                "max_validators_per_core": 2
+                            }
+                        }
+                    }
+                })),
                 Some(p) => r.with_chain_spec_path(p),
-            };
-            r.with_validator(|n| {
+            }
+            .with_validator(|n| {
                 let n = n.with_name("validator-0").bootnode(true);
                 match relay_db.as_deref() {
                     Some(p) => n.with_db_snapshot(p),
                     None => n,
                 }
-            })
-            .with_validator(|n| {
-                let n = n.with_name("validator-1").bootnode(true);
-                match relay_db.as_deref() {
-                    Some(p) => n.with_db_snapshot(p),
-                    None => n,
-                }
+            });
+
+            (1..6).fold(r, |acc, i| {
+                acc.with_validator(|n| {
+                    let n = n.with_name(&format!("validator-{i}")).bootnode(true);
+                    match relay_db.as_deref() {
+                        Some(p) => n.with_db_snapshot(p),
+                        None => n,
+                    }
+                })
             })
         })
         .with_parachain(|p| {
@@ -258,6 +278,43 @@ async fn wait_for_relay_first_finalized(
         .await
         .map_err(|e| anyhow!("relay did not finalize any block: {e}"))?;
     log::info!("relay produced its first finalized block");
+    Ok(())
+}
+
+/// Assigns [`ELASTIC_SCALING_CORES`] to the parachain at runtime via
+/// `Sudo(Coretime::assign_core)`, mirroring polkadot-sdk's elastic-scaling
+/// zombienet tests. Runtime assignment (rather than the genesis
+/// `with_num_cores` path) is what people-westend's relay runtime actually
+/// honours, and it avoids mutating genesis.
+async fn assign_elastic_cores(network: &Network<LocalFileSystem>) -> Result<(), anyhow::Error> {
+    use zombienet_sdk::subxt::{ext::scale_value::value, OnlineClient, PolkadotConfig};
+
+    let relay = network.get_node("validator-0")?;
+    let client: OnlineClient<PolkadotConfig> = relay.wait_client().await?;
+
+    let assign_calls: Vec<_> = ELASTIC_SCALING_CORES
+        .iter()
+        .map(|core| {
+            value! {
+                Coretime(assign_core { core: *core, begin: 0, assignment: ((Task(PARA_ID), 57600)), end_hint: None() })
+            }
+        })
+        .collect();
+    let tx = zombienet_sdk::subxt::tx::dynamic(
+        "Sudo",
+        "sudo",
+        vec![value! { Utility(batch { calls: assign_calls }) }],
+    );
+
+    log::info!("assigning cores {ELASTIC_SCALING_CORES:?} to para {PARA_ID}");
+    let signer = zombienet_sdk::subxt_signer::sr25519::dev::alice();
+    client
+        .tx()
+        .sign_and_submit_then_watch_default(&tx, &signer)
+        .await?
+        .wait_for_finalized_success()
+        .await?;
+    log::info!("cores assigned to para {PARA_ID}");
     Ok(())
 }
 

--- a/e2e-tests/src/network.rs
+++ b/e2e-tests/src/network.rs
@@ -423,6 +423,13 @@ fn decode_header_number(hex_str: &str) -> Result<u64, anyhow::Error> {
     Ok(header.number)
 }
 
+/// Chain the JS driver subscribes `chainHead_v1_follow` to. Selected by whether
+/// `PARA_CHAIN_SPEC` is passed: omitting it makes the JS run relay-only.
+pub enum FollowChain {
+    Relay,
+    Para,
+}
+
 /// Runs `js/chainhead_v1_follow_test.js` against a live network. Snapshots the
 /// relay and para best/finalized heights from the validator/collator metrics
 /// immediately before launching JS, so the validator can flag an initialized
@@ -431,6 +438,7 @@ pub async fn run_chainhead_v1_follow_js(
     live: &LiveNetwork,
     cfg: &Scenario,
     with_runtime: bool,
+    follow: FollowChain,
 ) -> Result<(), anyhow::Error> {
     let relay_spec_str = live.relay_spec.to_str().expect("UTF-8 path");
     let para_spec_str = live.para_spec.to_str().expect("UTF-8 path");
@@ -456,20 +464,28 @@ pub async fn run_chainhead_v1_follow_js(
     let with_runtime_str = if with_runtime { "true" } else { "false" };
     let mut env_vars: Vec<(&str, &str)> = vec![
         ("RELAY_CHAIN_SPEC", relay_spec_str),
-        ("PARA_CHAIN_SPEC", para_spec_str),
         ("RELAY_BEST_AT_LAUNCH", relay_best_str.as_str()),
         ("RELAY_FINALIZED_AT_LAUNCH", relay_finalized_str.as_str()),
         ("PARA_BEST_AT_LAUNCH", para_best_str.as_str()),
         ("PARA_FINALIZED_AT_LAUNCH", para_finalized_str.as_str()),
         ("WITH_RUNTIME", with_runtime_str),
     ];
+    // The JS subscribes to the para chain iff PARA_CHAIN_SPEC is set; omitting
+    // it runs relay-only.
+    if matches!(follow, FollowChain::Para) {
+        env_vars.push(("PARA_CHAIN_SPEC", para_spec_str));
+    }
     if let Some((relay_db, para_db)) = smoldot_db_paths.as_ref() {
         env_vars.push(("SMOLDOT_DB_RELAY", relay_db.as_str()));
         env_vars.push(("SMOLDOT_DB_PARA", para_db.as_str()));
     }
 
+    let followed = match follow {
+        FollowChain::Relay => "relay",
+        FollowChain::Para => "para",
+    };
     log::info!(
-        "running chainHead_v1_follow JS driver (with_runtime={with_runtime}, relay_spec={relay_spec_str}, para_spec={para_spec_str}, relay best/finalized=#{relay_best}/#{relay_finalized}, para best/finalized=#{para_best}/#{para_finalized})"
+        "running chainHead_v1_follow JS driver (follow={followed}, with_runtime={with_runtime}, relay best/finalized=#{relay_best}/#{relay_finalized}, para best/finalized=#{para_best}/#{para_finalized})"
     );
     crate::run_js_test("js/chainhead_v1_follow_test.js", &env_vars)
         .await

--- a/e2e-tests/src/network.rs
+++ b/e2e-tests/src/network.rs
@@ -384,6 +384,7 @@ fn decode_header_number(hex_str: &str) -> Result<u64, anyhow::Error> {
 pub async fn run_chainhead_v1_follow_js(
     live: &LiveNetwork,
     cfg: &Scenario,
+    with_runtime: bool,
 ) -> Result<(), anyhow::Error> {
     let relay_spec_str = live.relay_spec.to_str().expect("UTF-8 path");
     let para_spec_str = live.para_spec.to_str().expect("UTF-8 path");
@@ -406,6 +407,7 @@ pub async fn run_chainhead_v1_follow_js(
     let para_best_str = para_best.to_string();
     let para_finalized_str = para_finalized.to_string();
 
+    let with_runtime_str = if with_runtime { "true" } else { "false" };
     let mut env_vars: Vec<(&str, &str)> = vec![
         ("RELAY_CHAIN_SPEC", relay_spec_str),
         ("PARA_CHAIN_SPEC", para_spec_str),
@@ -413,6 +415,7 @@ pub async fn run_chainhead_v1_follow_js(
         ("RELAY_FINALIZED_AT_LAUNCH", relay_finalized_str.as_str()),
         ("PARA_BEST_AT_LAUNCH", para_best_str.as_str()),
         ("PARA_FINALIZED_AT_LAUNCH", para_finalized_str.as_str()),
+        ("WITH_RUNTIME", with_runtime_str),
     ];
     if let Some((relay_db, para_db)) = smoldot_db_paths.as_ref() {
         env_vars.push(("SMOLDOT_DB_RELAY", relay_db.as_str()));
@@ -420,7 +423,7 @@ pub async fn run_chainhead_v1_follow_js(
     }
 
     log::info!(
-        "running chainHead_v1_follow JS driver (relay_spec={relay_spec_str}, para_spec={para_spec_str}, relay best/finalized=#{relay_best}/#{relay_finalized}, para best/finalized=#{para_best}/#{para_finalized})"
+        "running chainHead_v1_follow JS driver (with_runtime={with_runtime}, relay_spec={relay_spec_str}, para_spec={para_spec_str}, relay best/finalized=#{relay_best}/#{relay_finalized}, para best/finalized=#{para_best}/#{para_finalized})"
     );
     crate::run_js_test("js/chainhead_v1_follow_test.js", &env_vars)
         .await

--- a/e2e-tests/src/network.rs
+++ b/e2e-tests/src/network.rs
@@ -45,9 +45,31 @@ pub const BEST_METRIC: &str = "block_height{status=\"best\"}";
 /// downstream smoldot timeout.
 const RELAY_FIRST_FINALIZED_TIMEOUT_SECS: u64 = 120;
 
-/// Core indices assigned to the parachain in the Fresh scenario so it can
-/// author multiple blocks per relay block (elastic scaling).
-const ELASTIC_SCALING_CORES: &[u32] = &[0, 1, 2];
+/// Core indices assigned to the parachain for elastic scaling.
+pub const ELASTIC_SCALING_CORES: &[u32] = &[0, 1, 2];
+
+/// Validators per backing group; `cores × this` = validator-set size to back
+/// every core in one relay block.
+pub const ELASTIC_MAX_VALIDATORS_PER_CORE: u32 = 2;
+
+/// Relay validators to spawn for elastic scaling, all genesis authorities.
+pub const ELASTIC_VALIDATOR_COUNT: u32 =
+    ELASTIC_SCALING_CORES.len() as u32 * ELASTIC_MAX_VALIDATORS_PER_CORE;
+
+/// Genesis `scheduler_params` override declaring the cores. Only effective on a
+/// generated genesis; a raw spec / DB snapshot has its core count fixed already.
+pub fn elastic_scaling_genesis_overrides() -> serde_json::Value {
+    serde_json::json!({
+        "configuration": {
+            "config": {
+                "scheduler_params": {
+                    "num_cores": ELASTIC_SCALING_CORES.len(),
+                    "max_validators_per_core": ELASTIC_MAX_VALIDATORS_PER_CORE
+                }
+            }
+        }
+    })
+}
 
 pub struct SnapshotPaths {
     /// Substrate-node DB tarballs.
@@ -174,8 +196,8 @@ fn build_network_config(
     let images = zombienet_sdk::environment::get_images_from_env();
 
     let snap = cfg.snapshot();
-    let relay_db = snap.map(|s| s.relay_db_tgz.to_str().expect("UTF-8 path").to_owned());
-    let para_db = snap.map(|s| s.para_db_tgz.to_str().expect("UTF-8 path").to_owned());
+    let relay_db = snap.map(|s| s.relay_db_tgz.clone());
+    let para_db = snap.map(|s| s.para_db_tgz.clone());
     // Substrate gets the *full* spec — it needs `genesis.raw` to bootstrap.
     let relay_spec_path = snap.map(|s| s.relay_full_spec.to_str().expect("UTF-8 path").to_owned());
     let para_spec_path = snap.map(|s| s.para_full_spec.to_str().expect("UTF-8 path").to_owned());
@@ -185,39 +207,17 @@ fn build_network_config(
             let r = r
                 .with_chain("westend-local")
                 .with_default_command("polkadot")
-                .with_default_image(images.polkadot.as_str());
+                .with_default_image(images.polkadot.as_str())
+                .with_optional_default_db_snapshot(relay_db.clone());
             let r = match relay_spec_path.as_deref() {
-                // Fresh: declare the total core count so the para can later be
-                // assigned multiple cores at runtime (elastic scaling). Only
-                // valid for a generated genesis; snapshot specs bring their own.
-                None => r.with_genesis_overrides(serde_json::json!({
-                    "configuration": {
-                        "config": {
-                            "scheduler_params": {
-                                "num_cores": ELASTIC_SCALING_CORES.len(),
-                                "max_validators_per_core": 2
-                            }
-                        }
-                    }
-                })),
+                // Only effective on Fresh's generated genesis; snapshots bring their own.
+                None => r.with_genesis_overrides(elastic_scaling_genesis_overrides()),
                 Some(p) => r.with_chain_spec_path(p),
             }
-            .with_validator(|n| {
-                let n = n.with_name("validator-0").bootnode(true);
-                match relay_db.as_deref() {
-                    Some(p) => n.with_db_snapshot(p),
-                    None => n,
-                }
-            });
-
-            (1..6).fold(r, |acc, i| {
-                acc.with_validator(|n| {
-                    let n = n.with_name(&format!("validator-{i}")).bootnode(true);
-                    match relay_db.as_deref() {
-                        Some(p) => n.with_db_snapshot(p),
-                        None => n,
-                    }
-                })
+            // validator-0 outside the fold sets the typestate the fold builds on.
+            .with_validator(|n| n.with_name("validator-0").bootnode(true));
+            (1..ELASTIC_VALIDATOR_COUNT).fold(r, |acc, i| {
+                acc.with_validator(|n| n.with_name(&format!("validator-{i}")).bootnode(true))
             })
         })
         .with_parachain(|p| {
@@ -229,25 +229,14 @@ fn build_network_config(
                 .with_default_args(vec![
                     "--force-authoring".into(),
                     "--authoring=slot-based".into(),
-                ]);
+                ])
+                .with_optional_default_db_snapshot(para_db.clone());
             let p = match para_spec_path.as_deref() {
                 None => p,
                 Some(path) => p.with_chain_spec_path(path),
             };
-            p.with_collator(|n| {
-                let n = n.with_name("alice").bootnode(true);
-                match para_db.as_deref() {
-                    Some(p) => n.with_db_snapshot(p),
-                    None => n,
-                }
-            })
-            .with_collator(|n| {
-                let n = n.with_name("bob").bootnode(true);
-                match para_db.as_deref() {
-                    Some(p) => n.with_db_snapshot(p),
-                    None => n,
-                }
-            })
+            p.with_collator(|n| n.with_name("alice").bootnode(true))
+                .with_collator(|n| n.with_name("bob").bootnode(true))
         })
         .with_global_settings(|g| {
             g.with_base_dir(base_dir_str).with_spawn_concurrency(1) // https://github.com/paritytech/smoldot/pull/3249#issuecomment-4438807458

--- a/e2e-tests/src/network.rs
+++ b/e2e-tests/src/network.rs
@@ -31,9 +31,6 @@ use anyhow::anyhow;
 use serde_json::Value;
 use zombienet_sdk::{LocalFileSystem, Network, NetworkConfig, NetworkConfigBuilder};
 
-/// `BlockNumber` width on substrate-based chains used here (westend, people-westend).
-const BLOCK_NUMBER_BYTES: usize = 4;
-
 pub const PARA_ID: u32 = 1004;
 pub const PARA_CHAIN: &str = "people-westend-local";
 pub const FINALIZED_METRIC: &str = "block_height{status=\"finalized\"}";
@@ -44,6 +41,10 @@ pub const BEST_METRIC: &str = "block_height{status=\"best\"}";
 /// alive; failure here surfaces as a clear gate-failure rather than a
 /// downstream smoldot timeout.
 const RELAY_FIRST_FINALIZED_TIMEOUT_SECS: u64 = 120;
+
+/// smoldot's warp-sync engages only when its finalized-to-tip gap exceeds this;
+/// mirrors `warp_sync_minimum_gap` in `lib/src/sync/all.rs`.
+const WARP_SYNC_MINIMUM_GAP: u64 = 32;
 
 /// Core indices assigned to the parachain for elastic scaling.
 pub const ELASTIC_SCALING_CORES: &[u32] = &[0, 1, 2];
@@ -123,10 +124,8 @@ pub struct LiveNetwork {
     pub network: Network<LocalFileSystem>,
     pub relay_spec: PathBuf,
     pub para_spec: PathBuf,
-    /// Lower bound on the first finalized block smoldot reports after init.
-    /// Asserts smoldot honoured the artifact checkpoint (didn't fall back
-    /// to genesis). Fresh: 0. Cold: from `lightSyncState`. Warm:
-    /// max(cold, persisted DB).
+    /// Lower bound on the finalized block smoldot reports at `chainHead` init:
+    /// the live tip if it will warp-sync, else its start head. Fresh: 0.
     pub expected_initial_finalized: u64,
 }
 
@@ -153,7 +152,7 @@ pub async fn spawn_scenario(
     log::info!("network is up");
 
     if matches!(cfg, Scenario::Fresh) {
-        wait_for_relay_first_finalized(&network).await?;
+        wait_for_relay_finalized(&network).await?;
         assign_elastic_cores(&network).await?;
     }
 
@@ -170,16 +169,27 @@ pub async fn spawn_scenario(
         )?,
     };
 
-    let mut expected_initial_finalized = match cfg.snapshot() {
+    // Floor for the finalized block smoldot reports at `chainHead` init. It
+    // starts from its DB head (warm) or the spec's `lightSyncState` (cold), then
+    // either warp-syncs to ~tip (gap > WARP_SYNC_MINIMUM_GAP) or commits
+    // AllForksOnly and reports `start` (gap at-or-below it). Mirror that choice.
+    // Reading the tip here, its lowest point, keeps the floor safe under either
+    // outcome: smoldot warps to at-or-past it, and AllForksOnly reports `start`.
+    let expected_initial_finalized = match cfg.snapshot() {
         None => 0,
-        // lightSyncState is in both full and light-sync-state specs; use the
-        // smaller one.
-        Some(s) => parse_finalized_height_from_spec(&s.smoldot_relay_spec)?,
+        Some(snapshot) => {
+            let start = match cfg.smoldot_db() {
+                Some(db) => parse_finalized_height_from_db(&db.relay_db_json)?,
+                None => parse_finalized_height_from_spec(&snapshot.smoldot_relay_spec)?,
+            };
+            let tip = wait_for_relay_finalized(&network).await?;
+            if tip.saturating_sub(start) > WARP_SYNC_MINIMUM_GAP {
+                tip
+            } else {
+                start
+            }
+        }
     };
-    if let Some(db) = cfg.smoldot_db() {
-        let persisted = parse_finalized_height_from_db(&db.relay_db_json)?;
-        expected_initial_finalized = expected_initial_finalized.max(persisted);
-    }
 
     Ok(LiveNetwork {
         network,
@@ -253,11 +263,14 @@ fn build_network_config(
     })
 }
 
-async fn wait_for_relay_first_finalized(
+/// Waits until the relay validator reports a finalized block and returns its
+/// height. For snapshot scenarios this is the restored target head; for fresh
+/// it is the first block finalized after genesis.
+async fn wait_for_relay_finalized(
     network: &Network<LocalFileSystem>,
-) -> Result<(), anyhow::Error> {
+) -> Result<u64, anyhow::Error> {
     let validator = network.get_node("validator-0")?;
-    log::info!("waiting for relay to produce its first finalized block");
+    log::info!("waiting for relay to report a finalized block");
     validator
         .wait_metric_with_timeout(
             FINALIZED_METRIC,
@@ -266,8 +279,9 @@ async fn wait_for_relay_first_finalized(
         )
         .await
         .map_err(|e| anyhow!("relay did not finalize any block: {e}"))?;
-    log::info!("relay produced its first finalized block");
-    Ok(())
+    let finalized = validator.reports(FINALIZED_METRIC).await? as u64;
+    log::info!("relay finalized #{finalized}");
+    Ok(finalized)
 }
 
 /// Assigns [`ELASTIC_SCALING_CORES`] to the parachain at runtime via
@@ -388,6 +402,20 @@ pub fn spawned_chain_spec_paths(
     Ok((relay_spec, para_spec))
 }
 
+/// `BlockNumber` width on the substrate chains used here (westend, people-westend).
+const BLOCK_NUMBER_BYTES: usize = 4;
+
+/// Finalized head smoldot starts a warm resume from (its persisted DB head).
+fn parse_finalized_height_from_db(path: &Path) -> Result<u64, anyhow::Error> {
+    let db: Value = serde_json::from_slice(&std::fs::read(path)?)?;
+    let header_hex = db
+        .pointer("/chain/finalized_block_header")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("{}: missing chain.finalized_block_header", path.display()))?;
+    decode_header_number(header_hex).map_err(|e| anyhow!("{}: {e}", path.display()))
+}
+
+/// Finalized head smoldot starts a cold sync from (the spec's `lightSyncState`).
 fn parse_finalized_height_from_spec(path: &Path) -> Result<u64, anyhow::Error> {
     let spec: Value = serde_json::from_slice(&std::fs::read(path)?)?;
     let header_hex = spec
@@ -402,19 +430,9 @@ fn parse_finalized_height_from_spec(path: &Path) -> Result<u64, anyhow::Error> {
     decode_header_number(header_hex).map_err(|e| anyhow!("{}: {e}", path.display()))
 }
 
-fn parse_finalized_height_from_db(path: &Path) -> Result<u64, anyhow::Error> {
-    let db: Value = serde_json::from_slice(&std::fs::read(path)?)?;
-    let header_hex = db
-        .pointer("/chain/finalized_block_header")
-        .and_then(Value::as_str)
-        .ok_or_else(|| anyhow!("{}: missing chain.finalized_block_header", path.display()))?;
-    decode_header_number(header_hex).map_err(|e| anyhow!("{}: {e}", path.display()))
-}
-
 /// Decodes a hex SCALE-encoded substrate header and returns its block number.
 /// Accepts either a `0x`-prefixed string (chain spec lightSyncState format) or
-/// raw hex (smoldot databaseContent format). Uses smoldot's own header
-/// decoder.
+/// raw hex (smoldot databaseContent format). Uses smoldot's own header decoder.
 fn decode_header_number(hex_str: &str) -> Result<u64, anyhow::Error> {
     let stripped = hex_str.strip_prefix("0x").unwrap_or(hex_str);
     let bytes = hex::decode(stripped).map_err(|e| anyhow!("invalid hex: {e}"))?;

--- a/e2e-tests/src/network.rs
+++ b/e2e-tests/src/network.rs
@@ -73,8 +73,9 @@ pub fn elastic_scaling_genesis_overrides() -> serde_json::Value {
 }
 
 pub struct SnapshotPaths {
-    /// Substrate-node DB tarballs.
-    pub relay_db_tgz: PathBuf,
+    /// Relay-validator DB tarballs (all validators, element `i` -> `validator-i`),
+    /// so every erasure chunk survives restore.
+    pub relay_db_tgz: Vec<PathBuf>,
     pub para_db_tgz: PathBuf,
     /// Full chain spec with `genesis.raw`. Passed to substrate via
     /// `with_chain_spec_path` so node DB extraction matches.
@@ -206,7 +207,7 @@ fn build_network_config(
     let images = zombienet_sdk::environment::get_images_from_env();
 
     let snap = cfg.snapshot();
-    let relay_db = snap.map(|s| s.relay_db_tgz.clone());
+    let relay_dbs = snap.map(|s| s.relay_db_tgz.clone()).unwrap_or_default();
     let para_db = snap.map(|s| s.para_db_tgz.clone());
     // Substrate gets the *full* spec — it needs `genesis.raw` to bootstrap.
     let relay_spec_path = snap.map(|s| s.relay_full_spec.to_str().expect("UTF-8 path").to_owned());
@@ -217,17 +218,26 @@ fn build_network_config(
             let r = r
                 .with_chain("westend-local")
                 .with_default_command("polkadot")
-                .with_default_image(images.polkadot.as_str())
-                .with_optional_default_db_snapshot(relay_db.clone());
+                .with_default_image(images.polkadot.as_str());
             let r = match relay_spec_path.as_deref() {
                 // Only effective on Fresh's generated genesis; snapshots bring their own.
                 None => r.with_genesis_overrides(elastic_scaling_genesis_overrides()),
                 Some(p) => r.with_chain_spec_path(p),
             }
-            // validator-0 outside the fold sets the typestate the fold builds on.
-            .with_validator(|n| n.with_name("validator-0").bootnode(true));
+            // Per-node DB, element i onto validator-i; empty on Fresh.
+            // validator-0 outside the fold sets the typestate.
+            .with_validator(|n| {
+                n.with_name("validator-0")
+                    .bootnode(true)
+                    .with_optional_db_snapshot(relay_dbs.first().cloned())
+            });
             (1..ELASTIC_VALIDATOR_COUNT).fold(r, |acc, i| {
-                acc.with_validator(|n| n.with_name(&format!("validator-{i}")).bootnode(true))
+                let db = relay_dbs.get(i as usize).cloned();
+                acc.with_validator(|n| {
+                    n.with_name(&format!("validator-{i}"))
+                        .bootnode(true)
+                        .with_optional_db_snapshot(db)
+                })
             })
         })
         .with_parachain(|p| {

--- a/e2e-tests/src/snapshot.rs
+++ b/e2e-tests/src/snapshot.rs
@@ -16,10 +16,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Resolves the artifact set consumed by `smoke_cold` / `smoke_warm` from the
-//! single GCS bundle. `BundleBuilder` packs only the two DB tarballs as real
-//! files (`relay_db`, `para_db`); everything else (full specs, lightSyncState
-//! specs, smoldot-db dumps) is JSON carried in the manifest `user_data` and
-//! materialized to disk on first use.
+//! single GCS bundle. `BundleBuilder` packs only the DB tarballs as real files
+//! (one per relay validator + one collator); everything else (full specs,
+//! lightSyncState specs, smoldot-db dumps) is JSON carried in the manifest
+//! `user_data` and materialized to disk on first use.
 //!
 //! The bundle (`{GCS_BASE}/{ARTIFACTS_VERSION}/bundle.tar.gz`) is downloaded to
 //! `~/.cache/smoldot-e2e/{ARTIFACTS_VERSION}/`, SHA256-verified, and extracted on
@@ -44,10 +44,13 @@ const ARTIFACTS_DIR_OVERRIDE_ENV: &str = "ARTIFACTS_DIR_OVERRIDE";
 
 /// SHA256 of the published bundle for `ARTIFACTS_VERSION`. Empty means not
 /// yet pinned — in that case the resolver requires `ARTIFACTS_DIR_OVERRIDE`.
-const BUNDLE_SHA256: &str = "c01cfe6c9f6207c58444b996bfcfdc8074dda406b8ca8122cdfc7afc756c14b7";
+const BUNDLE_SHA256: &str = "661ba1065bac694cb802f30300662d24fdda9b60810dc56561b4540852e4607f";
 
-pub fn relay_db() -> Result<PathBuf, anyhow::Error> {
-    resolve("relaychain-db.tgz")
+/// One DB tarball per relay validator, element `i` restored onto `validator-i`.
+pub fn relay_dbs() -> Result<Vec<PathBuf>, anyhow::Error> {
+    (0..crate::network::ELASTIC_VALIDATOR_COUNT)
+        .map(|i| resolve(&format!("relaychain-db-{i}.tgz")))
+        .collect()
 }
 
 pub fn para_db() -> Result<PathBuf, anyhow::Error> {

--- a/e2e-tests/src/snapshot.rs
+++ b/e2e-tests/src/snapshot.rs
@@ -15,26 +15,24 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Resolves the artifact set consumed by `smoke_cold` / `smoke_warm`.
+//! Resolves the artifact set consumed by `smoke_cold` / `smoke_warm`, from
+//! three places:
+//!   - DB tarballs            → the GCS bundle (`relay_db`, `para_db`)
+//!   - full specs             → `chain-specs/smoke-*-spec.json` (`relay_spec`, …)
+//!   - lightSyncState + dumps → bundle manifest `user_data` (`*_light_sync_state`, …)
 //!
-//! Everything ships as a single bundle on GCS:
-//! `gs://zombienet-db-snaps/zombienet/smoldot_smoke_db/{ARTIFACTS_VERSION}/bundle.tar.gz`.
-//! On first use the bundle is downloaded into
-//! `~/.cache/smoldot-e2e/{ARTIFACTS_VERSION}/`, SHA256-verified, and
-//! extracted in place. A marker file (`.extracted-sha`) records which
-//! version is currently extracted; mismatch triggers re-download.
+//! The bundle (`{GCS_BASE}/{ARTIFACTS_VERSION}/bundle.tar.gz`) is downloaded to
+//! `~/.cache/smoldot-e2e/{ARTIFACTS_VERSION}/`, SHA256-verified, and extracted on
+//! first use; an `.extracted-sha` marker triggers re-download on mismatch.
+//! `ARTIFACTS_DIR_OVERRIDE` points the bundle resolvers at a generator output dir
+//! (no download); full specs still come from `chain-specs/`.
 //!
-//! For local iteration set `ARTIFACTS_DIR_OVERRIDE` to a directory laid out
-//! exactly like the generator output (`relaychain-db.tgz`, `relay-spec.json`,
-//! `smoldot-db/relay.json`, …). All resolvers point inside it; no download
-//! or verification.
-//!
-//! See `e2e-tests/docs/smoke-scenarios.md` for the full layout and the
-//! regeneration procedure.
+//! See `e2e-tests/docs/smoke-scenarios.md` for the layout and regeneration.
 
 use std::path::PathBuf;
 
 use anyhow::anyhow;
+use serde_json::Value;
 
 pub const ARTIFACTS_VERSION: &str = "v1";
 
@@ -57,27 +55,33 @@ pub fn para_db() -> Result<PathBuf, anyhow::Error> {
 }
 
 pub fn relay_spec() -> Result<PathBuf, anyhow::Error> {
-    resolve("relay-spec.json")
+    repo_spec("smoke-relay-spec.json")
 }
 
 pub fn para_spec() -> Result<PathBuf, anyhow::Error> {
-    resolve("para-spec.json")
+    repo_spec("smoke-para-spec.json")
 }
 
 pub fn relay_spec_light_sync_state() -> Result<PathBuf, anyhow::Error> {
-    resolve("relay-spec-lightSyncState.json")
+    materialize(
+        "relay-spec-lightSyncState.json",
+        "relay_spec_light_sync_state",
+    )
 }
 
 pub fn para_spec_light_sync_state() -> Result<PathBuf, anyhow::Error> {
-    resolve("para-spec-lightSyncState.json")
+    materialize(
+        "para-spec-lightSyncState.json",
+        "para_spec_light_sync_state",
+    )
 }
 
 pub fn smoldot_db_relay() -> Result<PathBuf, anyhow::Error> {
-    resolve("smoldot-db/relay.json")
+    materialize("smoldot-db/relay.json", "smoldot_db_relay")
 }
 
 pub fn smoldot_db_para() -> Result<PathBuf, anyhow::Error> {
-    resolve("smoldot-db/para.json")
+    materialize("smoldot-db/para.json", "smoldot_db_para")
 }
 
 fn resolve(rel: &str) -> Result<PathBuf, anyhow::Error> {
@@ -89,6 +93,42 @@ fn resolve(rel: &str) -> Result<PathBuf, anyhow::Error> {
             p.display()
         ));
     }
+    Ok(p)
+}
+
+fn repo_spec(name: &str) -> Result<PathBuf, anyhow::Error> {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("chain-specs")
+        .join(name);
+    if !p.is_file() {
+        return Err(anyhow!(
+            "committed full spec {} missing; regenerate via smoke_generate_snapshots and \
+             commit the emitted copy",
+            p.display()
+        ));
+    }
+    Ok(p)
+}
+
+/// Returns the loose `rel` file if present (override dir or prior call),
+/// otherwise writes it from `manifest.json` `user_data[key]` first.
+fn materialize(rel: &str, key: &str) -> Result<PathBuf, anyhow::Error> {
+    let dir = ensure_bundle_extracted()?;
+    let p = dir.join(rel);
+    if p.is_file() {
+        return Ok(p);
+    }
+    let manifest_path = dir.join("manifest.json");
+    let manifest: Value = serde_json::from_slice(
+        &std::fs::read(&manifest_path).map_err(|e| anyhow!("{}: {e}", manifest_path.display()))?,
+    )?;
+    let blob = manifest
+        .pointer(&format!("/user_data/{key}"))
+        .ok_or_else(|| anyhow!("{}: missing user_data.{key}", manifest_path.display()))?;
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&p, serde_json::to_string_pretty(blob)?)?;
     Ok(p)
 }
 

--- a/e2e-tests/src/snapshot.rs
+++ b/e2e-tests/src/snapshot.rs
@@ -34,7 +34,7 @@ use std::path::PathBuf;
 use anyhow::anyhow;
 use serde_json::Value;
 
-pub const ARTIFACTS_VERSION: &str = "v1";
+pub const ARTIFACTS_VERSION: &str = "v2";
 
 const GCS_BASE: &str =
     "https://storage.googleapis.com/zombienet-db-snaps/zombienet/smoldot_smoke_db";
@@ -44,7 +44,7 @@ const ARTIFACTS_DIR_OVERRIDE_ENV: &str = "ARTIFACTS_DIR_OVERRIDE";
 
 /// SHA256 of the published bundle for `ARTIFACTS_VERSION`. Empty means not
 /// yet pinned — in that case the resolver requires `ARTIFACTS_DIR_OVERRIDE`.
-const BUNDLE_SHA256: &str = "abea526d527c13aac54b4e1874602c04963046f7d3c3bc3e0adc217573bdc6da";
+const BUNDLE_SHA256: &str = "c01cfe6c9f6207c58444b996bfcfdc8074dda406b8ca8122cdfc7afc756c14b7";
 
 pub fn relay_db() -> Result<PathBuf, anyhow::Error> {
     resolve("relaychain-db.tgz")

--- a/e2e-tests/src/snapshot.rs
+++ b/e2e-tests/src/snapshot.rs
@@ -15,17 +15,17 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Resolves the artifact set consumed by `smoke_cold` / `smoke_warm`, from
-//! three places:
-//!   - DB tarballs            → the GCS bundle (`relay_db`, `para_db`)
-//!   - full specs             → `chain-specs/smoke-*-spec.json` (`relay_spec`, …)
-//!   - lightSyncState + dumps → bundle manifest `user_data` (`*_light_sync_state`, …)
+//! Resolves the artifact set consumed by `smoke_cold` / `smoke_warm` from the
+//! single GCS bundle. `BundleBuilder` packs only the two DB tarballs as real
+//! files (`relay_db`, `para_db`); everything else (full specs, lightSyncState
+//! specs, smoldot-db dumps) is JSON carried in the manifest `user_data` and
+//! materialized to disk on first use.
 //!
 //! The bundle (`{GCS_BASE}/{ARTIFACTS_VERSION}/bundle.tar.gz`) is downloaded to
 //! `~/.cache/smoldot-e2e/{ARTIFACTS_VERSION}/`, SHA256-verified, and extracted on
 //! first use; an `.extracted-sha` marker triggers re-download on mismatch.
-//! `ARTIFACTS_DIR_OVERRIDE` points the bundle resolvers at a generator output dir
-//! (no download); full specs still come from `chain-specs/`.
+//! `ARTIFACTS_DIR_OVERRIDE` points the resolvers at a generator output dir
+//! (no download), where the loose files already exist.
 //!
 //! See `e2e-tests/docs/smoke-scenarios.md` for the layout and regeneration.
 
@@ -55,11 +55,11 @@ pub fn para_db() -> Result<PathBuf, anyhow::Error> {
 }
 
 pub fn relay_spec() -> Result<PathBuf, anyhow::Error> {
-    repo_spec("smoke-relay-spec.json")
+    materialize("relay-spec.json", "relay_full_spec")
 }
 
 pub fn para_spec() -> Result<PathBuf, anyhow::Error> {
-    repo_spec("smoke-para-spec.json")
+    materialize("para-spec.json", "para_full_spec")
 }
 
 pub fn relay_spec_light_sync_state() -> Result<PathBuf, anyhow::Error> {
@@ -90,20 +90,6 @@ fn resolve(rel: &str) -> Result<PathBuf, anyhow::Error> {
     if !p.is_file() {
         return Err(anyhow!(
             "expected {} in artifact bundle, missing",
-            p.display()
-        ));
-    }
-    Ok(p)
-}
-
-fn repo_spec(name: &str) -> Result<PathBuf, anyhow::Error> {
-    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("chain-specs")
-        .join(name);
-    if !p.is_file() {
-        return Err(anyhow!(
-            "committed full spec {} missing; regenerate via smoke_generate_snapshots and \
-             commit the emitted copy",
             p.display()
         ));
     }

--- a/e2e-tests/tests/chainhead_v1_follow_cold.rs
+++ b/e2e-tests/tests/chainhead_v1_follow_cold.rs
@@ -58,6 +58,11 @@ async fn chainhead_v1_follow_cold() -> Result<(), anyhow::Error> {
         })?;
     log::info!("alice reached #{target} (>= baseline+{REQUIRED_BLOCKS})");
 
-    run_chainhead_v1_follow_js(&live, &cfg).await?;
+    // Step 1: follow with runtime
+    run_chainhead_v1_follow_js(&live, &cfg, true).await?;
+
+    // Step 2: follow without runtime
+    run_chainhead_v1_follow_js(&live, &cfg, false).await?;
+
     Ok(())
 }

--- a/e2e-tests/tests/chainhead_v1_follow_cold.rs
+++ b/e2e-tests/tests/chainhead_v1_follow_cold.rs
@@ -35,7 +35,7 @@ async fn chainhead_v1_follow_cold() -> Result<(), anyhow::Error> {
     let base_dir_str = base_dir.to_str().expect("UTF-8 path").to_owned();
 
     let cfg = Scenario::Cold(SnapshotPaths {
-        relay_db_tgz: snapshot::relay_db()?,
+        relay_db_tgz: snapshot::relay_dbs()?,
         para_db_tgz: snapshot::para_db()?,
         relay_full_spec: snapshot::relay_spec()?,
         para_full_spec: snapshot::para_spec()?,

--- a/e2e-tests/tests/chainhead_v1_follow_cold.rs
+++ b/e2e-tests/tests/chainhead_v1_follow_cold.rs
@@ -58,11 +58,14 @@ async fn chainhead_v1_follow_cold() -> Result<(), anyhow::Error> {
         })?;
     log::info!("alice reached #{target} (>= baseline+{REQUIRED_BLOCKS})");
 
-    // Step 1: follow with runtime
-    run_chainhead_v1_follow_js(&live, &cfg, true).await?;
+    // Follow the para chain, with and without runtime.
+    run_chainhead_v1_follow_js(&live, &cfg, true, FollowChain::Para).await?;
+    run_chainhead_v1_follow_js(&live, &cfg, false, FollowChain::Para).await?;
 
-    // Step 2: follow without runtime
-    run_chainhead_v1_follow_js(&live, &cfg, false).await?;
+    // Follow the relay chain directly (validates relay finality resuming from
+    // the snapshot), with and without runtime.
+    run_chainhead_v1_follow_js(&live, &cfg, true, FollowChain::Relay).await?;
+    run_chainhead_v1_follow_js(&live, &cfg, false, FollowChain::Relay).await?;
 
     Ok(())
 }

--- a/e2e-tests/tests/chainhead_v1_follow_fresh.rs
+++ b/e2e-tests/tests/chainhead_v1_follow_fresh.rs
@@ -43,6 +43,11 @@ async fn chainhead_v1_follow_fresh() -> Result<(), anyhow::Error> {
         .map_err(|e| anyhow!("alice did not produce parachain blocks: {e}"))?;
     log::info!("alice has \u{2265}{REQUIRED_BLOCKS} parachain blocks");
 
-    run_chainhead_v1_follow_js(&live, &cfg).await?;
+    // Step 1: follow with runtime
+    run_chainhead_v1_follow_js(&live, &cfg, true).await?;
+
+    // Step 2: follow without runtime
+    run_chainhead_v1_follow_js(&live, &cfg, false).await?;
+
     Ok(())
 }

--- a/e2e-tests/tests/chainhead_v1_follow_fresh.rs
+++ b/e2e-tests/tests/chainhead_v1_follow_fresh.rs
@@ -43,11 +43,13 @@ async fn chainhead_v1_follow_fresh() -> Result<(), anyhow::Error> {
         .map_err(|e| anyhow!("alice did not produce parachain blocks: {e}"))?;
     log::info!("alice has \u{2265}{REQUIRED_BLOCKS} parachain blocks");
 
-    // Step 1: follow with runtime
-    run_chainhead_v1_follow_js(&live, &cfg, true).await?;
+    // Follow the para chain, with and without runtime.
+    run_chainhead_v1_follow_js(&live, &cfg, true, FollowChain::Para).await?;
+    run_chainhead_v1_follow_js(&live, &cfg, false, FollowChain::Para).await?;
 
-    // Step 2: follow without runtime
-    run_chainhead_v1_follow_js(&live, &cfg, false).await?;
+    // Follow the relay chain directly, with and without runtime.
+    run_chainhead_v1_follow_js(&live, &cfg, true, FollowChain::Relay).await?;
+    run_chainhead_v1_follow_js(&live, &cfg, false, FollowChain::Relay).await?;
 
     Ok(())
 }

--- a/e2e-tests/tests/chainhead_v1_follow_warm.rs
+++ b/e2e-tests/tests/chainhead_v1_follow_warm.rs
@@ -63,6 +63,11 @@ async fn chainhead_v1_follow_warm() -> Result<(), anyhow::Error> {
         })?;
     log::info!("alice reached #{target} (>= baseline+{REQUIRED_BLOCKS})");
 
-    run_chainhead_v1_follow_js(&live, &cfg).await?;
+    // Step 1: follow with runtime
+    run_chainhead_v1_follow_js(&live, &cfg, true).await?;
+
+    // Step 2: follow without runtime
+    run_chainhead_v1_follow_js(&live, &cfg, false).await?;
+
     Ok(())
 }

--- a/e2e-tests/tests/chainhead_v1_follow_warm.rs
+++ b/e2e-tests/tests/chainhead_v1_follow_warm.rs
@@ -35,7 +35,7 @@ async fn chainhead_v1_follow_warm() -> Result<(), anyhow::Error> {
 
     let cfg = Scenario::Warm {
         snapshot: SnapshotPaths {
-            relay_db_tgz: snapshot::relay_db()?,
+            relay_db_tgz: snapshot::relay_dbs()?,
             para_db_tgz: snapshot::para_db()?,
             relay_full_spec: snapshot::relay_spec()?,
             para_full_spec: snapshot::para_spec()?,

--- a/e2e-tests/tests/chainhead_v1_follow_warm.rs
+++ b/e2e-tests/tests/chainhead_v1_follow_warm.rs
@@ -63,11 +63,14 @@ async fn chainhead_v1_follow_warm() -> Result<(), anyhow::Error> {
         })?;
     log::info!("alice reached #{target} (>= baseline+{REQUIRED_BLOCKS})");
 
-    // Step 1: follow with runtime
-    run_chainhead_v1_follow_js(&live, &cfg, true).await?;
+    // Follow the para chain, with and without runtime.
+    run_chainhead_v1_follow_js(&live, &cfg, true, FollowChain::Para).await?;
+    run_chainhead_v1_follow_js(&live, &cfg, false, FollowChain::Para).await?;
 
-    // Step 2: follow without runtime
-    run_chainhead_v1_follow_js(&live, &cfg, false).await?;
+    // Follow the relay chain directly (validates relay finality resuming from
+    // the snapshot), with and without runtime.
+    run_chainhead_v1_follow_js(&live, &cfg, true, FollowChain::Relay).await?;
+    run_chainhead_v1_follow_js(&live, &cfg, false, FollowChain::Relay).await?;
 
     Ok(())
 }

--- a/e2e-tests/tests/smoke_cold.rs
+++ b/e2e-tests/tests/smoke_cold.rs
@@ -34,7 +34,7 @@ async fn smoke_cold() -> Result<(), anyhow::Error> {
     let base_dir_str = base_dir.to_str().expect("UTF-8 path").to_owned();
 
     let cfg = Scenario::Cold(SnapshotPaths {
-        relay_db_tgz: snapshot::relay_db()?,
+        relay_db_tgz: snapshot::relay_dbs()?,
         para_db_tgz: snapshot::para_db()?,
         relay_full_spec: snapshot::relay_spec()?,
         para_full_spec: snapshot::para_spec()?,

--- a/e2e-tests/tests/smoke_generate_snapshots.rs
+++ b/e2e-tests/tests/smoke_generate_snapshots.rs
@@ -37,12 +37,12 @@ use std::path::{Path, PathBuf};
 use anyhow::anyhow;
 use serde_json::Value;
 use smoldot_e2e_tests::{
-    ensure_js_deps_installed, ensure_smoldot_built, resolve_base_dir, run_js_test,
-    FINALIZED_METRIC, PARA_ID,
+    elastic_scaling_genesis_overrides, ensure_js_deps_installed, ensure_smoldot_built,
+    resolve_base_dir, run_js_test, ELASTIC_VALIDATOR_COUNT, FINALIZED_METRIC, PARA_ID,
 };
 use zombienet_sdk::{
-    subxt::ext::subxt_rpcs::rpc_params, LocalFileSystem, Network, NetworkConfig,
-    NetworkConfigBuilder, NetworkNode,
+    snapshot::BundleBuilder, subxt::ext::subxt_rpcs::rpc_params, Bundle, LocalFileSystem, Network,
+    NetworkConfig, NetworkConfigBuilder, NetworkNode,
 };
 
 const DEFAULT_TARGET_FINALIZED: u32 = 2500;
@@ -142,61 +142,51 @@ async fn smoke_generate_snapshots() -> Result<(), anyhow::Error> {
 
     dump_smoldot_db(&args.out, &network).await?;
 
-    // Step 3: snapshot validator-0 + alice DBs *after* the dump. Tarring
-    // before would freeze the network DBs at an earlier point than smoldot's
-    // persisted finalized — when the test later spawns from the snapshot,
-    // smoldot's persisted block wouldn't yet exist in the validator's DB and
-    // smoldot would hang on `storage-proof-request-error`.
-    pause_and_tar(
-        &network,
-        "validator-0",
-        &network_base,
-        &args.out.join("relaychain-db.tgz"),
-    )
-    .await?;
-    pause_and_tar(
-        &network,
-        "alice",
-        &network_base,
-        &args.out.join("parachain-db.tgz"),
-    )
-    .await?;
+    // Step 3: snapshot the DBs *after* the dump, so they are not frozen behind
+    // smoldot's persisted finalized (else the consumer hangs on
+    // `storage-proof-request-error`). `snapshot_db` tars `data/` (minus
+    // `keystore/`/`network/`); `BundleBuilder` packs both tarballs + a manifest
+    // carrying the lightSyncState specs and smoldot-db dumps in `user_data`.
+    log::info!("pausing network for DB snapshots");
+    network.pause().await?;
+    let relay_snap = network
+        .get_node("validator-0")?
+        .snapshot_db(args.out.join("relaychain-db.tgz"))
+        .await?;
+    let para_snap = network
+        .get_node("alice")?
+        .snapshot_db(args.out.join("parachain-db.tgz"))
+        .await?;
+    network.resume().await?;
+    log::info!("network resumed");
 
-    create_bundle(&args.out)?;
-    print_manifest(&args.out)?;
+    let bundle = BundleBuilder::new()
+        .add(relay_snap)
+        .add(para_snap)
+        .user_data(build_user_data(&args.out)?)
+        .build(args.out.join("bundle.tar.gz"))?;
+
+    print_manifest(&args.out, &bundle)?;
     log::info!("done");
     Ok(())
 }
 
-/// Bundles every artifact in `out` (DB tarballs + full specs +
-/// light-sync-state specs + smoldot-db dumps) into a single
-/// `bundle.tar.gz`, consumed by `snapshot::ensure_bundle_extracted` at
-/// test time.
-fn create_bundle(out: &Path) -> Result<(), anyhow::Error> {
-    let bundle = out.join("bundle.tar.gz");
-    log::info!("bundling artifacts -> {}", bundle.display());
-    let status = std::process::Command::new("tar")
-        .arg("-czf")
-        .arg(&bundle)
-        .arg("-C")
-        .arg(out)
-        .arg("relaychain-db.tgz")
-        .arg("parachain-db.tgz")
-        .arg("relay-spec.json")
-        .arg("para-spec.json")
-        .arg("relay-spec-lightSyncState.json")
-        .arg("para-spec-lightSyncState.json")
-        .arg("smoldot-db")
-        .status()?;
-    if !status.success() {
-        return Err(anyhow!("tar bundle failed (exit {status})"));
-    }
-    log::info!(
-        "wrote {} ({} bytes)",
-        bundle.display(),
-        std::fs::metadata(&bundle)?.len()
-    );
-    Ok(())
+/// Embeds the JSON artifacts not packed as bundle archives (lightSyncState
+/// specs + smoldot-db dumps) into the manifest `user_data`, keyed for
+/// `snapshot::materialize`.
+fn build_user_data(out: &Path) -> Result<serde_json::Value, anyhow::Error> {
+    let read_json = |rel: &str| -> Result<Value, anyhow::Error> {
+        let p = out.join(rel);
+        serde_json::from_slice(&std::fs::read(&p).map_err(|e| anyhow!("{}: {e}", p.display()))?)
+            .map_err(|e| anyhow!("{}: {e}", p.display()))
+    };
+    Ok(serde_json::json!({
+        "artifacts_version": smoldot_e2e_tests::snapshot::ARTIFACTS_VERSION,
+        "relay_spec_light_sync_state": read_json("relay-spec-lightSyncState.json")?,
+        "para_spec_light_sync_state": read_json("para-spec-lightSyncState.json")?,
+        "smoldot_db_relay": read_json("smoldot-db/relay.json")?,
+        "smoldot_db_para": read_json("smoldot-db/para.json")?,
+    }))
 }
 
 /// Writes a light-sync-state copy of `full_spec_path` to `lss_spec_path`:
@@ -364,40 +354,30 @@ async fn dump_smoldot_db(
     Ok(())
 }
 
-/// Computes a manifest of the artifact files (sha256 + size) and prints
-/// suggested constant lines for `e2e-tests/src/snapshot.rs`. Uses
-/// `sha256sum` from coreutils.
-fn print_manifest(out: &Path) -> Result<(), anyhow::Error> {
-    let bundle = out.join("bundle.tar.gz");
-    if !bundle.is_file() {
-        return Err(anyhow!("manifest: bundle.tar.gz missing"));
-    }
-    let size = std::fs::metadata(&bundle)?.len();
-    let hash = sha256_of(&bundle)?;
-
+/// Prints the bundle sha256/size (from the `BundleBuilder` result), the
+/// `snapshot.rs` constant lines to pin, and the commands to commit the full
+/// specs into `chain-specs/`.
+fn print_manifest(out: &Path, bundle: &Bundle) -> Result<(), anyhow::Error> {
     println!("\n=== artifact manifest ===");
-    println!("  bundle.tar.gz  {size:>10} bytes  {hash}");
+    println!(
+        "  {}  {:>10} bytes  {}",
+        bundle.path.display(),
+        bundle.size,
+        bundle.sha256
+    );
     println!("\n=== snapshot.rs constants ===");
     println!("pub const ARTIFACTS_VERSION: &str = \"v1\";");
-    println!("const BUNDLE_SHA256: &str = \"{hash}\";");
+    println!("const BUNDLE_SHA256: &str = \"{}\";", bundle.sha256);
+    println!("\n=== commit the full specs ===");
+    println!(
+        "cp {} e2e-tests/chain-specs/smoke-relay-spec.json",
+        out.join("relay-spec.json").display()
+    );
+    println!(
+        "cp {} e2e-tests/chain-specs/smoke-para-spec.json",
+        out.join("para-spec.json").display()
+    );
     Ok(())
-}
-
-fn sha256_of(path: &Path) -> Result<String, anyhow::Error> {
-    let output = std::process::Command::new("sha256sum").arg(path).output()?;
-    if !output.status.success() {
-        return Err(anyhow!(
-            "sha256sum failed for {}: {}",
-            path.display(),
-            String::from_utf8_lossy(&output.stderr)
-        ));
-    }
-    let stdout = String::from_utf8(output.stdout)?;
-    let hex = stdout
-        .split_whitespace()
-        .next()
-        .ok_or_else(|| anyhow!("empty sha256sum output for {}", path.display()))?;
-    Ok(hex.to_string())
 }
 
 async fn wait_for_finalized(node: &NetworkNode, height: u32) -> Result<(), anyhow::Error> {
@@ -436,55 +416,6 @@ async fn gen_sync_spec(node: &NetworkNode, out_path: &Path) -> Result<(), anyhow
     std::fs::write(out_path, serde_json::to_string_pretty(&spec)?)?;
     let size = std::fs::metadata(out_path)?.len();
     log::info!("wrote {} ({} bytes)", out_path.display(), size);
-    Ok(())
-}
-
-/// Pauses `node_name`, tars its `data/` dir into `out_tgz`, and resumes it.
-/// `network_base` is the zombienet namespace base dir.
-async fn pause_and_tar(
-    network: &Network<LocalFileSystem>,
-    node_name: &str,
-    network_base: &Path,
-    out_tgz: &Path,
-) -> Result<(), anyhow::Error> {
-    let node = network.get_node(node_name)?;
-    log::info!("pausing {node_name} for snapshot");
-    node.pause().await?;
-
-    let node_base = network_base.join(node_name);
-    let data_dir = node_base.join("data");
-    if !data_dir.is_dir() {
-        return Err(anyhow!(
-            "{node_name} data dir missing at {}",
-            data_dir.display()
-        ));
-    }
-    log::info!(
-        "tarring {} -> {} (excluding keystore/)",
-        data_dir.display(),
-        out_tgz.display()
-    );
-    // Exclude `keystore/` so a sibling node consuming this snapshot doesn't end
-    // up with the source node's session keys on top of its own (zombienet
-    // inserts per-node keys via author_insertKey at startup). Otherwise BOTH
-    // nodes can author for the same slot and the chain stalls under
-    // equivocation.
-    let status = std::process::Command::new("tar")
-        .arg("-czf")
-        .arg(out_tgz)
-        .arg("--exclude=keystore")
-        .arg("-C")
-        .arg(&node_base)
-        .arg("data")
-        .status()?;
-    if !status.success() {
-        return Err(anyhow!("tar failed for {node_name} (exit {status})"));
-    }
-    let size = std::fs::metadata(out_tgz)?.len();
-    log::info!("wrote {} ({} bytes)", out_tgz.display(), size);
-
-    log::info!("resuming {node_name}");
-    node.resume().await?;
     Ok(())
 }
 
@@ -554,53 +485,37 @@ fn build_config(
     para_db: Option<&Path>,
 ) -> Result<NetworkConfig, anyhow::Error> {
     let images = zombienet_sdk::environment::get_images_from_env();
-    let relay_db = relay_db.map(|p| p.to_str().expect("UTF-8 path").to_owned());
-    let para_db = para_db.map(|p| p.to_str().expect("UTF-8 path").to_owned());
+    let relay_db = relay_db.map(Path::to_path_buf);
+    let para_db = para_db.map(Path::to_path_buf);
     NetworkConfigBuilder::new()
         .with_relaychain(|r| {
+            // Bake elastic-scaling cores + validator set into genesis so the
+            // snapshot can back multiple cores. Regenerate from genesis only:
+            // changing genesis config changes the hash, mismatching an old DB.
             let r = r
                 .with_chain("westend-local")
                 .with_default_command("polkadot")
-                .with_default_image(images.polkadot.as_str());
-            r.with_validator(|n| {
-                let n = n.with_name("validator-0").bootnode(true);
-                match relay_db.as_deref() {
-                    Some(p) => n.with_db_snapshot(p),
-                    None => n,
-                }
-            })
-            .with_validator(|n| {
-                let n = n.with_name("validator-1").bootnode(true);
-                match relay_db.as_deref() {
-                    Some(p) => n.with_db_snapshot(p),
-                    None => n,
-                }
+                .with_default_image(images.polkadot.as_str())
+                .with_genesis_overrides(elastic_scaling_genesis_overrides())
+                .with_optional_default_db_snapshot(relay_db.clone())
+                // validator-0 outside the fold sets the typestate the fold builds on.
+                .with_validator(|n| n.with_name("validator-0").bootnode(true));
+            (1..ELASTIC_VALIDATOR_COUNT).fold(r, |acc, i| {
+                acc.with_validator(|n| n.with_name(&format!("validator-{i}")).bootnode(true))
             })
         })
         .with_parachain(|p| {
-            let p = p
-                .with_id(PARA_ID)
+            p.with_id(PARA_ID)
                 .with_default_command("polkadot-parachain")
                 .with_default_image(images.cumulus.as_str())
                 .with_chain("people-westend-local")
                 .with_default_args(vec![
                     "--force-authoring".into(),
                     "--authoring=slot-based".into(),
-                ]);
-            p.with_collator(|n| {
-                let n = n.with_name("alice").bootnode(true);
-                match para_db.as_deref() {
-                    Some(p) => n.with_db_snapshot(p),
-                    None => n,
-                }
-            })
-            .with_collator(|n| {
-                let n = n.with_name("bob").bootnode(true);
-                match para_db.as_deref() {
-                    Some(p) => n.with_db_snapshot(p),
-                    None => n,
-                }
-            })
+                ])
+                .with_optional_default_db_snapshot(para_db.clone())
+                .with_collator(|n| n.with_name("alice").bootnode(true))
+                .with_collator(|n| n.with_name("bob").bootnode(true))
         })
         .with_global_settings(|g| {
             g.with_base_dir(base_dir_str).with_spawn_concurrency(1) // https://github.com/paritytech/smoldot/pull/3249#issuecomment-4438807458

--- a/e2e-tests/tests/smoke_generate_snapshots.rs
+++ b/e2e-tests/tests/smoke_generate_snapshots.rs
@@ -404,7 +404,10 @@ fn print_manifest(bundle: &Bundle) {
         bundle.sha256
     );
     println!("\n=== snapshot.rs constants ===");
-    println!("pub const ARTIFACTS_VERSION: &str = \"v1\";");
+    println!(
+        "pub const ARTIFACTS_VERSION: &str = \"{}\";",
+        smoldot_e2e_tests::snapshot::ARTIFACTS_VERSION
+    );
     println!("const BUNDLE_SHA256: &str = \"{}\";", bundle.sha256);
 }
 

--- a/e2e-tests/tests/smoke_generate_snapshots.rs
+++ b/e2e-tests/tests/smoke_generate_snapshots.rs
@@ -170,7 +170,7 @@ async fn smoke_generate_snapshots() -> Result<(), anyhow::Error> {
         .user_data(build_user_data(&args.out)?)
         .build(args.out.join("bundle.tar.gz"))?;
 
-    print_manifest(&args.out, &bundle)?;
+    print_manifest(&bundle);
     log::info!("done");
     Ok(())
 }
@@ -208,8 +208,8 @@ async fn drain_parachain_pipeline(network: &Network<LocalFileSystem>) -> Result<
     Ok(())
 }
 
-/// Embeds the JSON artifacts not packed as bundle archives (lightSyncState
-/// specs + smoldot-db dumps) into the manifest `user_data`, keyed for
+/// Embeds every non-tarball artifact (full specs, lightSyncState specs,
+/// smoldot-db dumps — all JSON) into the manifest `user_data`, keyed for
 /// `snapshot::materialize`.
 fn build_user_data(out: &Path) -> Result<serde_json::Value, anyhow::Error> {
     let read_json = |rel: &str| -> Result<Value, anyhow::Error> {
@@ -219,6 +219,8 @@ fn build_user_data(out: &Path) -> Result<serde_json::Value, anyhow::Error> {
     };
     Ok(serde_json::json!({
         "artifacts_version": smoldot_e2e_tests::snapshot::ARTIFACTS_VERSION,
+        "relay_full_spec": read_json("relay-spec.json")?,
+        "para_full_spec": read_json("para-spec.json")?,
         "relay_spec_light_sync_state": read_json("relay-spec-lightSyncState.json")?,
         "para_spec_light_sync_state": read_json("para-spec-lightSyncState.json")?,
         "smoldot_db_relay": read_json("smoldot-db/relay.json")?,
@@ -391,10 +393,9 @@ async fn dump_smoldot_db(
     Ok(())
 }
 
-/// Prints the bundle sha256/size (from the `BundleBuilder` result), the
-/// `snapshot.rs` constant lines to pin, and the commands to commit the full
-/// specs into `chain-specs/`.
-fn print_manifest(out: &Path, bundle: &Bundle) -> Result<(), anyhow::Error> {
+/// Prints the bundle sha256/size and the `snapshot.rs` constant lines to pin.
+/// The bundle is fully self-contained — nothing else to commit.
+fn print_manifest(bundle: &Bundle) {
     println!("\n=== artifact manifest ===");
     println!(
         "  {}  {:>10} bytes  {}",
@@ -405,16 +406,6 @@ fn print_manifest(out: &Path, bundle: &Bundle) -> Result<(), anyhow::Error> {
     println!("\n=== snapshot.rs constants ===");
     println!("pub const ARTIFACTS_VERSION: &str = \"v1\";");
     println!("const BUNDLE_SHA256: &str = \"{}\";", bundle.sha256);
-    println!("\n=== commit the full specs ===");
-    println!(
-        "cp {} e2e-tests/chain-specs/smoke-relay-spec.json",
-        out.join("relay-spec.json").display()
-    );
-    println!(
-        "cp {} e2e-tests/chain-specs/smoke-para-spec.json",
-        out.join("para-spec.json").display()
-    );
-    Ok(())
 }
 
 async fn wait_for_finalized(node: &NetworkNode, height: u32) -> Result<(), anyhow::Error> {

--- a/e2e-tests/tests/smoke_generate_snapshots.rs
+++ b/e2e-tests/tests/smoke_generate_snapshots.rs
@@ -38,7 +38,7 @@ use anyhow::anyhow;
 use serde_json::Value;
 use smoldot_e2e_tests::{
     elastic_scaling_genesis_overrides, ensure_js_deps_installed, ensure_smoldot_built,
-    resolve_base_dir, run_js_test, BEST_METRIC, ELASTIC_VALIDATOR_COUNT, FINALIZED_METRIC, PARA_ID,
+    resolve_base_dir, run_js_test, ELASTIC_VALIDATOR_COUNT, FINALIZED_METRIC, PARA_ID,
 };
 use zombienet_sdk::{
     snapshot::BundleBuilder, subxt::ext::subxt_rpcs::rpc_params, Bundle, LocalFileSystem, Network,
@@ -142,21 +142,25 @@ async fn smoke_generate_snapshots() -> Result<(), anyhow::Error> {
 
     dump_smoldot_db(&args.out, &network).await?;
 
-    // Step 3: drain in-flight parachain candidates so the unfinalized relay
-    // suffix is candidate-free at snapshot time (see `drain_parachain_pipeline`).
-    drain_parachain_pipeline(&network).await?;
-
-    // Step 4: snapshot the DBs *after* the dump, so they are not frozen behind
+    // Step 3: snapshot the DBs *after* the dump, so they are not frozen behind
     // smoldot's persisted finalized (else the consumer hangs on
     // `storage-proof-request-error`). `snapshot_db` tars `data/` (minus
-    // `keystore/`/`network/`); `BundleBuilder` packs both tarballs + a manifest
+    // `keystore/`/`network/`); `BundleBuilder` packs the tarballs + a manifest
     // carrying the lightSyncState specs and smoldot-db dumps in `user_data`.
+    //
+    // Snapshot every validator so all erasure chunks survive restore; recovery
+    // can then reconstruct in-flight candidates, so no draining is needed.
     log::info!("pausing network for DB snapshots");
     network.pause().await?;
-    let relay_snap = network
-        .get_node("validator-0")?
-        .snapshot_db(args.out.join("relaychain-db.tgz"))
-        .await?;
+    let mut relay_snaps = Vec::new();
+    for i in 0..ELASTIC_VALIDATOR_COUNT {
+        let name = format!("validator-{i}");
+        let snap = network
+            .get_node(&name)?
+            .snapshot_db(args.out.join(format!("relaychain-db-{i}.tgz")))
+            .await?;
+        relay_snaps.push(snap);
+    }
     let para_snap = network
         .get_node("alice")?
         .snapshot_db(args.out.join("parachain-db.tgz"))
@@ -164,47 +168,21 @@ async fn smoke_generate_snapshots() -> Result<(), anyhow::Error> {
     network.resume().await?;
     log::info!("network resumed");
 
-    let bundle = BundleBuilder::new()
-        .add(relay_snap)
+    let mut relay_snaps = relay_snaps.into_iter();
+    let first_relay = relay_snaps
+        .next()
+        .ok_or_else(|| anyhow!("no relay validators to snapshot"))?;
+    let mut builder = BundleBuilder::new().add(first_relay);
+    for snap in relay_snaps {
+        builder = builder.add(snap);
+    }
+    let bundle = builder
         .add(para_snap)
         .user_data(build_user_data(&args.out)?)
         .build(args.out.join("bundle.tar.gz"))?;
 
     print_manifest(&bundle);
     log::info!("done");
-    Ok(())
-}
-
-/// Pauses the collators and waits for the relay to finalize past any in-flight
-/// candidate, so the snapshot has no backed-but-unapproved candidate in its
-/// unfinalized suffix.
-///
-/// Why: the single-node snapshot is restored to every consumer validator, so
-/// network-wide there is only one validator's erasure chunk per candidate. A
-/// candidate still pending approval at snapshot time can't be recovered after
-/// resume (n=6 needs 2 distinct chunks), so its relay block never gets approved
-/// and finality freezes. Post-resume candidates get full chunk distribution and
-/// are fine — only the boundary ones are a problem, and draining removes them.
-async fn drain_parachain_pipeline(network: &Network<LocalFileSystem>) -> Result<(), anyhow::Error> {
-    /// Margin past best-at-pause, covering a collation already in flight.
-    const DRAIN_MARGIN: u64 = 4;
-
-    let relay = network.get_node("validator-0")?;
-    let best_at_pause = relay.reports(BEST_METRIC).await? as u64;
-    log::info!("draining parachain pipeline: pausing collators (relay best #{best_at_pause})");
-    for collator in ["alice", "bob"] {
-        network.get_node(collator)?.pause().await?;
-    }
-
-    let drain_target = best_at_pause + DRAIN_MARGIN;
-    let timeout_secs = (DRAIN_MARGIN * 12).max(180);
-    relay
-        .wait_metric_with_timeout(FINALIZED_METRIC, |h| h >= drain_target as f64, timeout_secs)
-        .await
-        .map_err(|e| {
-            anyhow!("relay did not finalize through #{drain_target} while draining: {e}")
-        })?;
-    log::info!("parachain pipeline drained: relay finalized >= #{drain_target}");
     Ok(())
 }
 

--- a/e2e-tests/tests/smoke_generate_snapshots.rs
+++ b/e2e-tests/tests/smoke_generate_snapshots.rs
@@ -38,7 +38,7 @@ use anyhow::anyhow;
 use serde_json::Value;
 use smoldot_e2e_tests::{
     elastic_scaling_genesis_overrides, ensure_js_deps_installed, ensure_smoldot_built,
-    resolve_base_dir, run_js_test, ELASTIC_VALIDATOR_COUNT, FINALIZED_METRIC, PARA_ID,
+    resolve_base_dir, run_js_test, BEST_METRIC, ELASTIC_VALIDATOR_COUNT, FINALIZED_METRIC, PARA_ID,
 };
 use zombienet_sdk::{
     snapshot::BundleBuilder, subxt::ext::subxt_rpcs::rpc_params, Bundle, LocalFileSystem, Network,
@@ -142,7 +142,11 @@ async fn smoke_generate_snapshots() -> Result<(), anyhow::Error> {
 
     dump_smoldot_db(&args.out, &network).await?;
 
-    // Step 3: snapshot the DBs *after* the dump, so they are not frozen behind
+    // Step 3: drain in-flight parachain candidates so the unfinalized relay
+    // suffix is candidate-free at snapshot time (see `drain_parachain_pipeline`).
+    drain_parachain_pipeline(&network).await?;
+
+    // Step 4: snapshot the DBs *after* the dump, so they are not frozen behind
     // smoldot's persisted finalized (else the consumer hangs on
     // `storage-proof-request-error`). `snapshot_db` tars `data/` (minus
     // `keystore/`/`network/`); `BundleBuilder` packs both tarballs + a manifest
@@ -168,6 +172,39 @@ async fn smoke_generate_snapshots() -> Result<(), anyhow::Error> {
 
     print_manifest(&args.out, &bundle)?;
     log::info!("done");
+    Ok(())
+}
+
+/// Pauses the collators and waits for the relay to finalize past any in-flight
+/// candidate, so the snapshot has no backed-but-unapproved candidate in its
+/// unfinalized suffix.
+///
+/// Why: the single-node snapshot is restored to every consumer validator, so
+/// network-wide there is only one validator's erasure chunk per candidate. A
+/// candidate still pending approval at snapshot time can't be recovered after
+/// resume (n=6 needs 2 distinct chunks), so its relay block never gets approved
+/// and finality freezes. Post-resume candidates get full chunk distribution and
+/// are fine — only the boundary ones are a problem, and draining removes them.
+async fn drain_parachain_pipeline(network: &Network<LocalFileSystem>) -> Result<(), anyhow::Error> {
+    /// Margin past best-at-pause, covering a collation already in flight.
+    const DRAIN_MARGIN: u64 = 4;
+
+    let relay = network.get_node("validator-0")?;
+    let best_at_pause = relay.reports(BEST_METRIC).await? as u64;
+    log::info!("draining parachain pipeline: pausing collators (relay best #{best_at_pause})");
+    for collator in ["alice", "bob"] {
+        network.get_node(collator)?.pause().await?;
+    }
+
+    let drain_target = best_at_pause + DRAIN_MARGIN;
+    let timeout_secs = (DRAIN_MARGIN * 12).max(180);
+    relay
+        .wait_metric_with_timeout(FINALIZED_METRIC, |h| h >= drain_target as f64, timeout_secs)
+        .await
+        .map_err(|e| {
+            anyhow!("relay did not finalize through #{drain_target} while draining: {e}")
+        })?;
+    log::info!("parachain pipeline drained: relay finalized >= #{drain_target}");
     Ok(())
 }
 

--- a/e2e-tests/tests/smoke_warm.rs
+++ b/e2e-tests/tests/smoke_warm.rs
@@ -36,7 +36,7 @@ async fn smoke_warm() -> Result<(), anyhow::Error> {
 
     let cfg = Scenario::Warm {
         snapshot: SnapshotPaths {
-            relay_db_tgz: snapshot::relay_db()?,
+            relay_db_tgz: snapshot::relay_dbs()?,
             para_db_tgz: snapshot::para_db()?,
             relay_full_spec: snapshot::relay_spec()?,
             para_full_spec: snapshot::para_spec()?,

--- a/lib/src/chain/blocks_tree/finality.rs
+++ b/lib/src/chain/blocks_tree/finality.rs
@@ -38,8 +38,9 @@ impl<T> NonFinalizedTree<T> {
                 || !matches!(self.finality, Finality::Outsourced)
         );
 
-        // All entries are yielded, including the first pending set-change blocks (key `None`
-        // or `<=` finalized), which must be finalized before any of their descendants.
+        // Yield every pending set-change block. The first tuple field holds the previous set-change
+        // block that must finalize first; `None` means there is none, so this block is
+        // first in line.
         self.blocks_trigger_gp_change.iter().map(
             |(_prev_auth_change_trigger_number, block_index)| {
                 let block = self

--- a/lib/src/chain/blocks_tree/finality.rs
+++ b/lib/src/chain/blocks_tree/finality.rs
@@ -38,25 +38,17 @@ impl<T> NonFinalizedTree<T> {
                 || !matches!(self.finality, Finality::Outsourced)
         );
 
-        self.blocks_trigger_gp_change
-            .range((
-                ops::Bound::Excluded((
-                    Some(self.finalized_block_number),
-                    fork_tree::NodeIndex::MAX,
-                )),
-                ops::Bound::Unbounded,
-            ))
-            .map(|(_prev_auth_change_trigger_number, block_index)| {
-                debug_assert!(
-                    _prev_auth_change_trigger_number
-                        .map_or(false, |n| n > self.finalized_block_number)
-                );
+        // All entries are yielded, including the first pending set-change blocks (key `None`
+        // or `<=` finalized), which must be finalized before any of their descendants.
+        self.blocks_trigger_gp_change.iter().map(
+            |(_prev_auth_change_trigger_number, block_index)| {
                 let block = self
                     .blocks
                     .get(*block_index)
                     .unwrap_or_else(|| unreachable!());
                 (block.number, &block.hash)
-            })
+            },
+        )
     }
 
     /// Verifies the given justification.

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -242,6 +242,11 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         self.ready_to_transition = None;
     }
 
+    /// Returns `true` if a warp sync completed while suppressed and its result is being held.
+    pub fn has_pending_warp_completion(&self) -> bool {
+        self.ready_to_transition.is_some()
+    }
+
     /// Returns the value that was initially passed in [`Config::block_number_bytes`].
     pub fn block_number_bytes(&self) -> usize {
         self.shared.block_number_bytes

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -4446,7 +4446,8 @@ pub(super) async fn run<TPlat: PlatformRef>(
 
                 match notification {
                     sync_service::Notification::Finalized {
-                        hash,
+                        finalized_blocks_hashes,
+                        hash: _,
                         best_block_hash_if_changed,
                         pruned_blocks,
                     } => {
@@ -4473,7 +4474,10 @@ pub(super) async fn run<TPlat: PlatformRef>(
                                 methods::ServerToClient::chainHead_v1_followEvent {
                                     subscription: Cow::Borrowed(&subscription_id),
                                     result: methods::FollowEvent::Finalized {
-                                        finalized_blocks_hashes: vec![methods::HashHexString(hash)],
+                                        finalized_blocks_hashes: finalized_blocks_hashes
+                                            .into_iter()
+                                            .map(methods::HashHexString)
+                                            .collect(),
                                         pruned_blocks_hashes: pruned_blocks
                                             .into_iter()
                                             .map(methods::HashHexString)

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -4447,7 +4447,6 @@ pub(super) async fn run<TPlat: PlatformRef>(
                 match notification {
                     sync_service::Notification::Finalized {
                         finalized_blocks_hashes,
-                        hash: _,
                         best_block_hash_if_changed,
                         pruned_blocks,
                     } => {

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -2564,11 +2564,12 @@ async fn run_background<TPlat: PlatformRef>(
             }
 
             WakeUpReason::Notification(sync_service::Notification::Finalized {
-                hash,
+                finalized_blocks_hashes,
                 best_block_hash_if_changed,
                 ..
             }) => {
                 // Sync service has reported a finalized block.
+                let hash = *finalized_blocks_hashes.last().unwrap();
 
                 log!(
                     &background.platform,

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -1336,12 +1336,9 @@ pub enum Notification {
     /// A non-finalized block has been finalized.
     Finalized {
         /// Newly-finalized blocks in ascending order (each the child of the previous). Never
-        /// empty; chains onto the previously-finalized block. All were previously reported as
-        /// blocks.
+        /// empty; chains onto the previously-finalized block. The last element is the highest
+        /// finalized block. All were previously reported as blocks.
         finalized_blocks_hashes: Vec<[u8; 32]>,
-
-        /// Highest finalized block. Equal to the last element of `finalized_blocks_hashes`.
-        hash: [u8; 32],
 
         /// If the current best block is pruned by the finalization, contains the updated hash
         /// of the best block after the finalization.

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -1335,15 +1335,12 @@ pub struct FinalizedBlockRuntime {
 pub enum Notification {
     /// A non-finalized block has been finalized.
     Finalized {
-        /// BLAKE2 hash of the block that has been finalized.
-        ///
-        /// A block with this hash is guaranteed to have earlier been reported in a
-        /// [`BlockNotification`], either in [`SubscribeAll::non_finalized_blocks_ancestry_order`]
-        /// or in a [`Notification::Block`].
-        ///
-        /// It is, however, not guaranteed that this block is a child of the previously-finalized
-        /// block. In other words, if multiple blocks are finalized at the same time, only one
-        /// [`Notification::Finalized`] is generated and contains the highest finalized block.
+        /// Newly-finalized blocks in ascending order (each the child of the previous). Never
+        /// empty; chains onto the previously-finalized block. All were previously reported as
+        /// blocks.
+        finalized_blocks_hashes: Vec<[u8; 32]>,
+
+        /// Highest finalized block. Equal to the last element of `finalized_blocks_hashes`.
         hash: [u8; 32],
 
         /// If the current best block is pruned by the finalization, contains the updated hash

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -1160,13 +1160,14 @@ fn drain_pending_subscriptions<TPlat: PlatformRef>(task: &mut Task<TPlat>) {
 }
 
 impl<TPlat: PlatformRef> Task<TPlat> {
+    /// Sends a notification to all the notification receivers.
+    ///
+    /// A subscriber whose buffer is full is dropped, per the `subscribe_all` contract;
+    /// skipping the notification instead would leave a gap in its stream.
     fn dispatch_all_subscribers(&mut self, notification: Notification) {
         for index in (0..self.all_notifications.len()).rev() {
             let subscription = self.all_notifications.swap_remove(index);
             if subscription.try_send(notification.clone()).is_err() {
-                if !subscription.is_closed() {
-                    self.all_notifications.push(subscription);
-                }
                 continue;
             }
 

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -1161,12 +1161,14 @@ fn drain_pending_subscriptions<TPlat: PlatformRef>(task: &mut Task<TPlat>) {
 
 impl<TPlat: PlatformRef> Task<TPlat> {
     /// Sends a notification to all the notification receivers.
-    ///
-    /// A subscriber whose buffer is full is dropped, per the `subscribe_all` contract;
-    /// skipping the notification instead would leave a gap in its stream.
     fn dispatch_all_subscribers(&mut self, notification: Notification) {
+        // Elements in `all_notifications` are removed one by one and inserted back if the
+        // channel is still open and not full.
         for index in (0..self.all_notifications.len()).rev() {
             let subscription = self.all_notifications.swap_remove(index);
+            // try_send can fail for two reasons: the receiver was dropped (closed), or its buffer is full.
+            // Drop the subscriber in both cases: a closed one is already dead, and
+            // keeping a full one would skip this notification, causing a gap in the stream.
             if subscription.try_send(notification.clone()).is_err() {
                 continue;
             }

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -350,6 +350,12 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
                                     task.known_finalized_runtime = None;
                                 }
                                 task.dispatch_all_subscribers(Notification::Finalized {
+                                    finalized_blocks_hashes: result
+                                        .finalized_blocks
+                                        .iter()
+                                        .rev()
+                                        .map(|b| b.block_hash)
+                                        .collect(),
                                     hash: pending_hash,
                                     best_block_hash_if_changed: if result.updates_best_block {
                                         Some(*task.sync.as_ref().unwrap().best_block_hash())
@@ -913,6 +919,12 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
                             task.known_finalized_runtime = None;
                         }
                         task.dispatch_all_subscribers(Notification::Finalized {
+                            finalized_blocks_hashes: result
+                                .finalized_blocks
+                                .iter()
+                                .rev()
+                                .map(|b| b.block_hash)
+                                .collect(),
                             hash: finalized_hash,
                             best_block_hash_if_changed: if result.updates_best_block {
                                 Some(*task.sync.as_ref().unwrap().best_block_hash())
@@ -937,6 +949,7 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
             }
 
             WakeUpReason::ParaheadNotification(Notification::Finalized {
+                finalized_blocks_hashes: _,
                 hash,
                 best_block_hash_if_changed: _,
                 pruned_blocks: _,
@@ -964,6 +977,12 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
                             task.known_finalized_runtime = None;
                         }
                         task.dispatch_all_subscribers(Notification::Finalized {
+                            finalized_blocks_hashes: result
+                                .finalized_blocks
+                                .iter()
+                                .rev()
+                                .map(|b| b.block_hash)
+                                .collect(),
                             hash,
                             best_block_hash_if_changed: if result.updates_best_block {
                                 Some(*task.sync.as_ref().unwrap().best_block_hash())

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -356,7 +356,6 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
                                         .rev()
                                         .map(|b| b.block_hash)
                                         .collect(),
-                                    hash: pending_hash,
                                     best_block_hash_if_changed: if result.updates_best_block {
                                         Some(*task.sync.as_ref().unwrap().best_block_hash())
                                     } else {
@@ -925,7 +924,6 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
                                 .rev()
                                 .map(|b| b.block_hash)
                                 .collect(),
-                            hash: finalized_hash,
                             best_block_hash_if_changed: if result.updates_best_block {
                                 Some(*task.sync.as_ref().unwrap().best_block_hash())
                             } else {
@@ -949,11 +947,11 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
             }
 
             WakeUpReason::ParaheadNotification(Notification::Finalized {
-                finalized_blocks_hashes: _,
-                hash,
+                finalized_blocks_hashes,
                 best_block_hash_if_changed: _,
                 pruned_blocks: _,
             }) => {
+                let hash = *finalized_blocks_hashes.last().unwrap();
                 log!(
                     &task.platform,
                     Debug,
@@ -983,7 +981,6 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
                                 .rev()
                                 .map(|b| b.block_hash)
                                 .collect(),
-                            hash,
                             best_block_hash_if_changed: if result.updates_best_block {
                                 Some(*task.sync.as_ref().unwrap().best_block_hash())
                             } else {

--- a/light-base/src/sync_service/paraheads.rs
+++ b/light-base/src/sync_service/paraheads.rs
@@ -415,6 +415,7 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                                     let sender =
                                         runtime_subscription.all_subscriptions.swap_remove(index);
                                     let notif = super::Notification::Finalized {
+                                        finalized_blocks_hashes: Vec::from([hash]),
                                         hash,
                                         best_block_hash_if_changed: if best_output_block_updated {
                                             Some(best_block_hash)

--- a/light-base/src/sync_service/paraheads.rs
+++ b/light-base/src/sync_service/paraheads.rs
@@ -416,7 +416,6 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                                         runtime_subscription.all_subscriptions.swap_remove(index);
                                     let notif = super::Notification::Finalized {
                                         finalized_blocks_hashes: Vec::from([hash]),
-                                        hash,
                                         best_block_hash_if_changed: if best_output_block_updated {
                                             Some(best_block_hash)
                                         } else {

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -1869,7 +1869,7 @@ mod tests {
     //   (see https://github.com/paritytech/smoldot/pull/3268#discussion_r3311390876)
     //   needs a test-only AllSync setter or crypto-correct warp fragments
     // - same limitation for the pending-completion and storage/call-proof arms of
-    //   `warp_sync_can_proceed` (docs/SYNC_MODE_DECISION_RACE.md)
+    //   `warp_sync_can_proceed`
     use super::*;
     use smoldot::{
         chain::chain_information,

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -1698,9 +1698,12 @@ impl<TPlat: PlatformRef> Task<TPlat> {
     /// Sends a notification to all the notification receivers.
     fn dispatch_all_subscribers(&mut self, notification: Notification) {
         // Elements in `all_notifications` are removed one by one and inserted back if the
-        // channel is still open.
+        // channel is still open and not full.
         for index in (0..self.all_notifications.len()).rev() {
             let subscription = self.all_notifications.swap_remove(index);
+            // try_send can fail for two reasons: the receiver was dropped (closed), or its buffer is full.
+            // Drop the subscriber in both cases: a closed one is already dead, and
+            // keeping a full one would skip this notification, causing a gap in the stream.
             if subscription.try_send(notification.clone()).is_err() {
                 continue;
             }

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -610,7 +610,6 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                                 .rev()
                                 .map(|b| b.block_hash)
                                 .collect(),
-                            hash: *sync.finalized_block_hash(),
                             best_block_hash_if_changed: if updates_best_block {
                                 Some(*sync.best_block_hash())
                             } else {

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -1776,10 +1776,15 @@ fn neighbor_packet_outcome(
     }
 }
 
-/// Warp is downloading/building, or a qualifying source is available for the next request.
+/// Warp is downloading/building, holds a completed-but-suppressed result, or a qualifying
+/// source is available for the next request.
 fn warp_sync_can_proceed(
     sync: &all::AllSync<future::AbortHandle, (libp2p::PeerId, codec::Role), ()>,
 ) -> bool {
+    // A result completed while suppressed is fresh; it must be applied, not discarded.
+    if sync.has_pending_warp_completion() {
+        return true;
+    }
     match sync.status() {
         all::Status::WarpSyncFragments {
             source: Some(_), ..
@@ -1788,9 +1793,17 @@ fn warp_sync_can_proceed(
         // At the mode-decision point no warp request is dispatched yet, so this arm decides.
         // The caller already fed the source's finalized height (update_source_finality_state),
         // so desired_requests() is expected to already include a warp request when the gap > 32.
-        _ => sync
-            .desired_requests()
-            .any(|(_, _, rq)| matches!(rq, all::DesiredRequest::WarpSync { .. })),
+        // The storage/call-proof requests are emitted only by the warp machine; they cover the
+        // window between the last fragment verification and the runtime-download dispatch,
+        // where the status still reports `WarpSyncFragments { source: None }`.
+        _ => sync.desired_requests().any(|(_, _, rq)| {
+            matches!(
+                rq,
+                all::DesiredRequest::WarpSync { .. }
+                    | all::DesiredRequest::StorageGetMerkleProof { .. }
+                    | all::DesiredRequest::RuntimeCallMerkleProof { .. }
+            )
+        }),
     }
 }
 
@@ -1853,6 +1866,8 @@ mod tests {
     // - add a `Status::WarpSyncChainInformation` case
     //   (see https://github.com/paritytech/smoldot/pull/3268#discussion_r3311390876)
     //   needs a test-only AllSync setter or crypto-correct warp fragments
+    // - same limitation for the pending-completion and storage/call-proof arms of
+    //   `warp_sync_can_proceed` (docs/SYNC_MODE_DECISION_RACE.md)
     use super::*;
     use smoldot::{
         chain::chain_information,

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -605,6 +605,11 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                             task.known_finalized_runtime = None;
                         }
                         task.dispatch_all_subscribers(Notification::Finalized {
+                            finalized_blocks_hashes: finalized_blocks_newest_to_oldest
+                                .iter()
+                                .rev()
+                                .map(|b| b.block_hash)
+                                .collect(),
                             hash: *sync.finalized_block_hash(),
                             best_block_hash_if_changed: if updates_best_block {
                                 Some(*sync.best_block_hash())


### PR DESCRIPTION
### Motivation

The `sync_service` `Finalized` notification carried only the highest finalized block hash, so when several blocks finalize at once `chainHead_v1_follow` emitted events that skipped the intermediate ones.

This wasn't strictly a spec violation (the spec only pins the last element + the `newBlock`-first rule), but the stream was lossy - consumers tracking every finalized block missed the skipped ones. This PR makes it complete and contiguous. While testing against the relay chain, a few related bugs surfaced and were fixed here too.

### Changes

1. Full finalized ancestry (original fix): `Notification::Finalized` now carries `finalized_blocks_hashes` - all newly-finalized blocks in ascending order, never empty - forwarded whole by the JSON-RPC layer. All were already reported via `newBlock`, so it stays spec-compliant.
2. Don't discard a finished warp sync: a warp result finishing while the sync mode was still being decided got parked, then thrown away when all-forks was picked. It's now kept.
3. Yield the first pending set-change block in `finality_checkpoints`: it was excluded, so all-forks requested a justification it couldn't verify yet (TooFarAhead), banned the peer, and finality starved across the set change.
4. Drop a full-buffer subscriber instead of silently skipping its notification (which gapped the stream); its channel is now closed per the `subscribe_all` contract.

### Testing
- New `chainHead_v1_follow` e2e coverage against the relay chain (relay-only and `with_runtime=false`); the relay-only test reproduces the stall and now passes.
- Multi-block finalization needed elastic scaling, hence new snapshots. Every relay validator is snapshotted so availability recovery can reconstruct in-flight candidates after restore.