### PR TITLE
fix: rotate peers when bootstrapping parachain consensus

### DIFF
--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -1330,6 +1330,16 @@ async fn bootstrap_parachain_consensus<TPlat: PlatformRef>(
 
     let peers = connected_peers_or_wait(network_service).await;
 
+    log!(
+        platform,
+        Trace,
+        log_target,
+        format!(
+            "Attempting parachain runtime download from {} connected peer(s)",
+            peers.len()
+        )
+    );
+
     first_successful_peer(peers, |peer_id| {
         attempt_bootstrap_with_peer(
             log_target,

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -1311,25 +1311,15 @@ async fn bootstrap_parachain_consensus<TPlat: PlatformRef>(
 
     let peers = connected_peers_or_wait(network_service).await;
 
-    first_successful_peer(peers, |peer_id| async move {
-        let result = attempt_bootstrap_with_peer(
+    first_successful_peer(peers, |peer_id| {
+        attempt_bootstrap_with_peer(
             log_target,
             platform,
             network_service,
             chain_info,
             block_number_bytes,
-            peer_id.clone(),
+            peer_id,
         )
-        .await;
-        if let Err(err) = &result {
-            log!(
-                platform,
-                Debug,
-                log_target,
-                format!("Bootstrap via peer {peer_id} failed: {err}; trying next peer")
-            );
-        }
-        result
     })
     .await
 }
@@ -1368,19 +1358,14 @@ where
     F: FnMut(libp2p::PeerId) -> Fut,
     Fut: Future<Output = Result<T, String>>,
 {
-    let mut attempts = 0usize;
     let mut last_err = None;
     for peer in peers {
-        attempts += 1;
         match attempt(peer).await {
             Ok(value) => return Ok(value),
             Err(err) => last_err = Some(err),
         }
     }
-    Err(match last_err {
-        Some(err) => format!("all {attempts} connected peer(s) failed; last error: {err}"),
-        None => String::from("no peers connected"),
-    })
+    Err(last_err.unwrap_or_else(|| String::from("no peers connected")))
 }
 
 /// Downloads the parachain runtime from a single peer and determines Aura consensus parameters.

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -1286,12 +1286,8 @@ struct BootstrappedParachain {
     finalized_runtime: FinalizedBlockRuntime,
 }
 
-/// Downloads the parachain runtime from a P2P peer and determines Aura consensus parameters.
-///
-/// Tries each currently-connected peer in turn, rotating past any peer that fails to answer
-/// (for instance with `RemoteCouldntAnswer`). Returns an error only once every connected peer
-/// has been tried, so the caller can retry against a possibly-changed peer set instead of
-/// spinning forever on a single peer that cannot serve the requested block. See issue #3290.
+/// Downloads the parachain runtime and determines Aura consensus parameters, trying each
+/// connected peer in turn and rotating past any that fails. See issue #3290.
 async fn bootstrap_parachain_consensus<TPlat: PlatformRef>(
     log_target: &str,
     platform: &TPlat,
@@ -1338,13 +1334,11 @@ async fn bootstrap_parachain_consensus<TPlat: PlatformRef>(
     .await
 }
 
-/// Returns the list of currently-connected peers, waiting for at least one to connect if none
-/// are yet. The result is a snapshot: the caller tries each peer and, if all fail, calls this
-/// again later, by which point discovery may have added new peers.
+/// Returns a snapshot of the currently-connected peers, waiting for at least one if none yet.
 async fn connected_peers_or_wait<TPlat: PlatformRef>(
     network_service: &Arc<network_service::NetworkServiceChain<TPlat>>,
 ) -> Vec<libp2p::PeerId> {
-    // Subscribe before reading the peer list so a peer connecting in between is not missed.
+    // Subscribe before listing so a peer connecting in between isn't missed.
     let mut from_network = Box::pin(network_service.subscribe().await);
 
     let current = network_service.peers_list().await.collect::<Vec<_>>();
@@ -1365,8 +1359,7 @@ async fn connected_peers_or_wait<TPlat: PlatformRef>(
     }
 }
 
-/// Calls `attempt` against each peer in turn, returning the first `Ok`. Rotates to the next peer
-/// on any `Err`, and returns an error only once all peers have been tried.
+/// Tries `attempt` on each peer in turn, returning the first `Ok`; errors only once all fail.
 async fn first_successful_peer<T, F, Fut>(
     peers: impl IntoIterator<Item = libp2p::PeerId>,
     mut attempt: F,
@@ -1667,9 +1660,7 @@ fn run_single_runtime_call(
 
 #[cfg(test)]
 mod tests {
-    //! Tests for the peer-rotation driver behind the parachain bootstrap, covering the
-    //! regression described in issue #3290 (bootstrap stuck retrying a single peer that
-    //! responds with `RemoteCouldntAnswer`).
+    //! Peer-rotation driver tests for the #3290 regression.
 
     use super::first_successful_peer;
     use alloc::{string::String, vec, vec::Vec};
@@ -1677,7 +1668,7 @@ mod tests {
     use futures_lite::future::block_on;
     use smoldot::libp2p::peer_id::PeerId;
 
-    // Two distinct, valid PeerIds, reused from the network_service tests.
+    // Two distinct, valid PeerIds.
     const PEER_A: &str = "12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN";
     const PEER_B: &str = "12D3KooWQk1yQtG1YugyKjiQf6KNk8VjGGAT5xy1FWcnRKN4yXYJ";
 
@@ -1685,9 +1676,7 @@ mod tests {
         PeerId::from_bytes(bs58::decode(s).into_vec().unwrap()).unwrap()
     }
 
-    // Reproduces #3290: the first peer fails (as a peer returning `RemoteCouldntAnswer`
-    // would), so the driver must rotate to the next peer and succeed there instead of
-    // giving up or spinning on the first peer.
+    // Reproduces #3290: first peer fails, driver must rotate to the next and succeed.
     #[test]
     fn rotates_past_peer_that_cannot_answer() {
         let a = peer(PEER_A);
@@ -1711,13 +1700,10 @@ mod tests {
         }));
 
         assert_eq!(result, Ok(b.clone()));
-        // Both peers were tried, in order, before succeeding on the second.
         assert_eq!(*tried.borrow(), vec![a, b]);
     }
 
-    // When every connected peer fails, the driver returns an error (so the caller can sleep
-    // and retry against a refreshed peer set) rather than looping forever. It must try each
-    // peer exactly once.
+    // Every peer fails: driver errors (letting the caller retry later) after trying each once.
     #[test]
     fn errors_after_trying_every_peer() {
         let a = peer(PEER_A);
@@ -1736,7 +1722,7 @@ mod tests {
         assert_eq!(tried.borrow().len(), 2);
     }
 
-    // With no connected peers the driver errors immediately without invoking the attempt.
+    // No peers: driver errors without invoking the attempt.
     #[test]
     fn errors_when_no_peers() {
         let result: Result<PeerId, String> = block_on(first_successful_peer(
@@ -1746,8 +1732,7 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // The common path: the first peer answers, so no rotation happens and only one attempt
-    // is made.
+    // Happy path: first peer answers, so only one attempt is made.
     #[test]
     fn uses_first_peer_when_it_succeeds() {
         let a = peer(PEER_A);

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -1664,3 +1664,105 @@ fn run_single_runtime_call(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Tests for the peer-rotation driver behind the parachain bootstrap, covering the
+    //! regression described in issue #3290 (bootstrap stuck retrying a single peer that
+    //! responds with `RemoteCouldntAnswer`).
+
+    use super::first_successful_peer;
+    use alloc::{string::String, vec, vec::Vec};
+    use core::cell::RefCell;
+    use futures_lite::future::block_on;
+    use smoldot::libp2p::peer_id::PeerId;
+
+    // Two distinct, valid PeerIds, reused from the network_service tests.
+    const PEER_A: &str = "12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN";
+    const PEER_B: &str = "12D3KooWQk1yQtG1YugyKjiQf6KNk8VjGGAT5xy1FWcnRKN4yXYJ";
+
+    fn peer(s: &str) -> PeerId {
+        PeerId::from_bytes(bs58::decode(s).into_vec().unwrap()).unwrap()
+    }
+
+    // Reproduces #3290: the first peer fails (as a peer returning `RemoteCouldntAnswer`
+    // would), so the driver must rotate to the next peer and succeed there instead of
+    // giving up or spinning on the first peer.
+    #[test]
+    fn rotates_past_peer_that_cannot_answer() {
+        let a = peer(PEER_A);
+        let b = peer(PEER_B);
+        let failing = a.clone();
+        let tried = RefCell::new(Vec::new());
+
+        let result = block_on(first_successful_peer([a.clone(), b.clone()], |peer_id| {
+            let tried = &tried;
+            let failing = &failing;
+            async move {
+                tried.borrow_mut().push(peer_id.clone());
+                if peer_id == *failing {
+                    Err(String::from(
+                        "Storage proof request failed: RemoteCouldntAnswer",
+                    ))
+                } else {
+                    Ok(peer_id)
+                }
+            }
+        }));
+
+        assert_eq!(result, Ok(b.clone()));
+        // Both peers were tried, in order, before succeeding on the second.
+        assert_eq!(*tried.borrow(), vec![a, b]);
+    }
+
+    // When every connected peer fails, the driver returns an error (so the caller can sleep
+    // and retry against a refreshed peer set) rather than looping forever. It must try each
+    // peer exactly once.
+    #[test]
+    fn errors_after_trying_every_peer() {
+        let a = peer(PEER_A);
+        let b = peer(PEER_B);
+        let tried = RefCell::new(Vec::new());
+
+        let result: Result<PeerId, String> = block_on(first_successful_peer([a, b], |peer_id| {
+            let tried = &tried;
+            async move {
+                tried.borrow_mut().push(peer_id);
+                Err(String::from("RemoteCouldntAnswer"))
+            }
+        }));
+
+        assert!(result.is_err());
+        assert_eq!(tried.borrow().len(), 2);
+    }
+
+    // With no connected peers the driver errors immediately without invoking the attempt.
+    #[test]
+    fn errors_when_no_peers() {
+        let result: Result<PeerId, String> = block_on(first_successful_peer(
+            core::iter::empty(),
+            |peer_id| async move { Ok(peer_id) },
+        ));
+        assert!(result.is_err());
+    }
+
+    // The common path: the first peer answers, so no rotation happens and only one attempt
+    // is made.
+    #[test]
+    fn uses_first_peer_when_it_succeeds() {
+        let a = peer(PEER_A);
+        let b = peer(PEER_B);
+        let attempts = RefCell::new(0usize);
+
+        let result = block_on(first_successful_peer([a.clone(), b], |peer_id| {
+            let attempts = &attempts;
+            async move {
+                *attempts.borrow_mut() += 1;
+                Ok(peer_id)
+            }
+        }));
+
+        assert_eq!(result, Ok(a));
+        assert_eq!(*attempts.borrow(), 1);
+    }
+}

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -1287,6 +1287,11 @@ struct BootstrappedParachain {
 }
 
 /// Downloads the parachain runtime from a P2P peer and determines Aura consensus parameters.
+///
+/// Tries each currently-connected peer in turn, rotating past any peer that fails to answer
+/// (for instance with `RemoteCouldntAnswer`). Returns an error only once every connected peer
+/// has been tried, so the caller can retry against a possibly-changed peer set instead of
+/// spinning forever on a single peer that cannot serve the requested block. See issue #3290.
 async fn bootstrap_parachain_consensus<TPlat: PlatformRef>(
     log_target: &str,
     platform: &TPlat,
@@ -1295,7 +1300,6 @@ async fn bootstrap_parachain_consensus<TPlat: PlatformRef>(
     block_number_bytes: usize,
 ) -> Result<BootstrappedParachain, String> {
     let ci_ref = chain_info.as_ref();
-    let state_root = *ci_ref.finalized_block_header.state_root;
     let block_hash = ci_ref.finalized_block_header.hash(block_number_bytes);
 
     log!(
@@ -1309,24 +1313,95 @@ async fn bootstrap_parachain_consensus<TPlat: PlatformRef>(
         )
     );
 
-    // Wait for a peer to connect.
-    let peer_id = {
-        let mut from_network = Box::pin(network_service.subscribe().await);
+    let peers = connected_peers_or_wait(network_service).await;
 
-        if let Some(peer) = network_service.peers_list().await.next() {
-            peer
-        } else {
-            loop {
-                match from_network.next().await {
-                    Some(network_service::Event::Connected { peer_id, .. }) => break peer_id,
-                    Some(_) => continue,
-                    None => {
-                        from_network = Box::pin(network_service.subscribe().await);
-                    }
-                }
+    first_successful_peer(peers, |peer_id| async move {
+        let result = attempt_bootstrap_with_peer(
+            log_target,
+            platform,
+            network_service,
+            chain_info,
+            block_number_bytes,
+            peer_id.clone(),
+        )
+        .await;
+        if let Err(err) = &result {
+            log!(
+                platform,
+                Debug,
+                log_target,
+                format!("Bootstrap via peer {peer_id} failed: {err}; trying next peer")
+            );
+        }
+        result
+    })
+    .await
+}
+
+/// Returns the list of currently-connected peers, waiting for at least one to connect if none
+/// are yet. The result is a snapshot: the caller tries each peer and, if all fail, calls this
+/// again later, by which point discovery may have added new peers.
+async fn connected_peers_or_wait<TPlat: PlatformRef>(
+    network_service: &Arc<network_service::NetworkServiceChain<TPlat>>,
+) -> Vec<libp2p::PeerId> {
+    // Subscribe before reading the peer list so a peer connecting in between is not missed.
+    let mut from_network = Box::pin(network_service.subscribe().await);
+
+    let current = network_service.peers_list().await.collect::<Vec<_>>();
+    if !current.is_empty() {
+        return current;
+    }
+
+    loop {
+        match from_network.next().await {
+            Some(network_service::Event::Connected { .. }) => {
+                return network_service.peers_list().await.collect();
+            }
+            Some(_) => continue,
+            None => {
+                from_network = Box::pin(network_service.subscribe().await);
             }
         }
-    };
+    }
+}
+
+/// Calls `attempt` against each peer in turn, returning the first `Ok`. Rotates to the next peer
+/// on any `Err`, and returns an error only once all peers have been tried.
+async fn first_successful_peer<T, F, Fut>(
+    peers: impl IntoIterator<Item = libp2p::PeerId>,
+    mut attempt: F,
+) -> Result<T, String>
+where
+    F: FnMut(libp2p::PeerId) -> Fut,
+    Fut: Future<Output = Result<T, String>>,
+{
+    let mut attempts = 0usize;
+    let mut last_err = None;
+    for peer in peers {
+        attempts += 1;
+        match attempt(peer).await {
+            Ok(value) => return Ok(value),
+            Err(err) => last_err = Some(err),
+        }
+    }
+    Err(match last_err {
+        Some(err) => format!("all {attempts} connected peer(s) failed; last error: {err}"),
+        None => String::from("no peers connected"),
+    })
+}
+
+/// Downloads the parachain runtime from a single peer and determines Aura consensus parameters.
+async fn attempt_bootstrap_with_peer<TPlat: PlatformRef>(
+    log_target: &str,
+    platform: &TPlat,
+    network_service: &Arc<network_service::NetworkServiceChain<TPlat>>,
+    chain_info: &chain::chain_information::ValidChainInformation,
+    block_number_bytes: usize,
+    peer_id: libp2p::PeerId,
+) -> Result<BootstrappedParachain, String> {
+    let ci_ref = chain_info.as_ref();
+    let state_root = *ci_ref.finalized_block_header.state_root;
+    let block_hash = ci_ref.finalized_block_header.hash(block_number_bytes);
 
     log!(
         platform,


### PR DESCRIPTION
## Problem
Parachain bootstrap always used the first connected peer to download the runtime. If that peer replied `RemoteCouldntAnswer` (it can't serve theblock), the request failed, and the 5s retry loop re-picked the same peer
and same block - so bootstrap could retry forever without recovering.

Reported in  #3290.

## Fix
Try each connected peer in turn, rotating past any that fails. Only return an error once all peers have been tried, so the caller retries against a possibly-changed peer set instead of spinning on one peer.

## Tests
Unit tests for the rotation driver: rotate past a failing peer, error (not loop) once all peers fail, empty-peer handling, single-attempt on success.

Also verified end-to-end against live Kusama Asset Hub: warp sync + parachain follow pass with no regression.