### PR TITLE
Add `ext_statement_store_remove_by_version_1` as no-op HF

### DIFF
--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -2340,9 +2340,8 @@ impl ReadyToRun {
             }
             HostFunction::ext_statement_store_remove_by_version_1 => {
                 // Statement store is an off-chain, gossiped side-store; a light client cannot
-                // maintain it. On-chain code paths (e.g. `Core_execute_block`) may still call
-                // this function, so we accept and discard the request. Consuming the 32-byte
-                // account pointer keeps the wasm VM's argument stack balanced.
+                // maintain it. On-chain code paths may still call
+                // this function, so we accept and discard the request.
                 let _who = expect_pointer_constant_size!(0, 32);
                 HostVm::ReadyToRun(ReadyToRun {
                     inner: self.inner,

--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -2338,6 +2338,17 @@ impl ReadyToRun {
                     resume_value: None,
                 })
             }
+            HostFunction::ext_statement_store_remove_by_version_1 => {
+                // Statement store is an off-chain, gossiped side-store; a light client cannot
+                // maintain it. On-chain code paths (e.g. `Core_execute_block`) may still call
+                // this function, so we accept and discard the request. Consuming the 32-byte
+                // account pointer keeps the wasm VM's argument stack balanced.
+                let _who = expect_pointer_constant_size!(0, 32);
+                HostVm::ReadyToRun(ReadyToRun {
+                    inner: self.inner,
+                    resume_value: None,
+                })
+            }
         }
     }
 }

--- a/lib/src/executor/host/functions.rs
+++ b/lib/src/executor/host/functions.rs
@@ -158,6 +158,7 @@ host_functions! {
     ext_panic_handler_abort_on_panic_version_1,
     ext_transaction_index_index_version_1,
     ext_transaction_index_renew_version_1,
+    ext_statement_store_remove_by_version_1,
 }
 
 impl HostFunction {
@@ -463,6 +464,9 @@ impl HostFunction {
             }
             HostFunction::ext_transaction_index_renew_version_1 => {
                 crate::signature!((vm::ValueType::I32, vm::ValueType::I32) => ())
+            }
+            HostFunction::ext_statement_store_remove_by_version_1 => {
+                crate::signature!((vm::ValueType::I32) => ())
             }
         }
     }

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add support for the `ext_statement_store_remove_by_version_1` host function as a no-op. Fixes wasm-VM traps on runtimes such as `next-people-paseo` that import this symbol during on-chain block execution. ([paritytech/misc-issues#164](https://github.com/paritytech/misc-issues/issues/164))
+- Add support for the `ext_statement_store_remove_by_version_1` host function as a no-op. Fixes wasm-VM traps on runtimes that import this symbol during runtime execution.
 
 ## 3.3.0 - 2026-06-26
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add support for the `ext_statement_store_remove_by_version_1` host function as a no-op. Fixes wasm-VM traps on runtimes such as `next-people-paseo` that import this symbol during on-chain block execution. ([paritytech/misc-issues#164](https://github.com/paritytech/misc-issues/issues/164))
+
 ## 3.3.0 - 2026-06-26
 
 ### Added


### PR DESCRIPTION
Adds `ext_statement_store_remove_by_version_1`. Since it has unit return type and we don't have anything to remove, its a no-op. Should resolve https://github.com/paritytech/misc-issues/issues/164