### PR TITLE
housekeeping: CI download hardening, repo-URL updates, action version bumps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -261,7 +261,7 @@ jobs:
         working-directory: ./wasm-node/javascript
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: npm-package-${{ github.sha }}
           path: ./wasm-node/javascript/*.tgz

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,8 +59,8 @@ jobs:
         context: .
         file: ./full-node/Dockerfile
         load: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        tags: ghcr.io/smol-dot/full-node:main
-    - run: docker push ghcr.io/smol-dot/full-node:main
+        tags: ghcr.io/paritytech/full-node:main
+    - run: docker push ghcr.io/paritytech/full-node:main
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
   build-js-doc:

--- a/.github/workflows/zombienet.yml
+++ b/.github/workflows/zombienet.yml
@@ -192,7 +192,7 @@ jobs:
 
       - name: Upload zombienet logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: zombienet-logs-${{ matrix.test.job-name }}-${{ github.sha }}
           path: |

--- a/.github/workflows/zombienet.yml
+++ b/.github/workflows/zombienet.yml
@@ -171,7 +171,10 @@ jobs:
           mkdir -p "$GITHUB_WORKSPACE/bin"
           base="https://github.com/paritytech/polkadot-sdk/releases/download/${RELEASE_TAG}"
           for bin in polkadot polkadot-execute-worker polkadot-prepare-worker polkadot-parachain; do
-            curl -fL --retry 3 -o "$GITHUB_WORKSPACE/bin/${bin}" "${base}/${bin}"
+            # These large binaries occasionally hit a mid-download connection reset from the
+            # GitHub release CDN (curl exit 56). Plain --retry does not retry a reset, so
+            # --retry-all-errors is required to make curl retry and re-fetch the binary.
+            curl -fL --retry 5 --retry-all-errors --retry-delay 5 -o "$GITHUB_WORKSPACE/bin/${bin}" "${base}/${bin}"
             chmod +x "$GITHUB_WORKSPACE/bin/${bin}"
           done
           "$GITHUB_WORKSPACE/bin/polkadot" --version

--- a/.github/workflows/zombienet.yml
+++ b/.github/workflows/zombienet.yml
@@ -23,7 +23,7 @@ jobs:
       ZOMBIENET_SDK_LARGE_RUNNER: ${{ steps.vars.outputs.ZOMBIENET_SDK_LARGE_RUNNER }}
       POLKADOT_RELEASE_TAG: ${{ steps.vars.outputs.POLKADOT_RELEASE_TAG }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6
 
       - name: Source zombienet-env
         id: vars
@@ -97,7 +97,7 @@ jobs:
             runner-type: "default"
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6.1.0
         with:

--- a/README.md
+++ b/README.md
@@ -7,33 +7,33 @@ This repository contains the following components:
 - `smoldot-light-js` (`/wasm-node`): A JavaScript package that can connect to a Substrate-based chains as a light client. Works both in the browser and in NodeJS/Deno. **This is the main component of this repository. The development mostly focuses around it, and the name `smoldot` generally refers to this component in particular.**
   - 📦 NPM: <https://www.npmjs.com/package/smoldot>. Only versions of NodeJS that [are still maintained](https://nodejs.dev/en/about/releases/) are guaranteed to be supported.
   - 📦 Deno.land/x: <https://deno.land/x/smoldot2> (URL to import: `https://deno.land/x/smoldot2/index-deno.js`)
-  - 📄 CHANGELOG: <https://github.com/smol-dot/smoldot/blob/main/wasm-node/CHANGELOG.md>
-  - 📚 <https://smol-dot.github.io/smoldot/doc-javascript/> (latest commit)
+  - 📄 CHANGELOG: <https://github.com/paritytech/smoldot/blob/main/wasm-node/CHANGELOG.md>
+  - 📚 <https://paritytech.github.io/smoldot/doc-javascript/> (latest commit)
   - Has a stable API that rarely changes.
 
 - `smoldot` (`/lib`): An unopinionated Rust library of general-purpose primitives that relate to Substrate and Polkadot. Serves as a base for the other components.
   - 📦 <https://crates.io/crates/smoldot>
   - 📚 <https://docs.rs/smoldot> (latest published version)
-  - 📚 <https://smol-dot.github.io/smoldot/doc-rust/smoldot/index.html> (latest commit)
-  - Tests coverage: <https://smol-dot.github.io/smoldot/tests-coverage/index.html> (latest commit)
+  - 📚 <https://paritytech.github.io/smoldot/doc-rust/smoldot/index.html> (latest commit)
+  - Tests coverage: <https://paritytech.github.io/smoldot/tests-coverage/index.html> (latest commit)
   - Has an unstable API.
 
 - `smoldot-light` (`/light-base`): A platform-agnostic Rust library that can connect to a Substrate-based chain as a light client. Serves as the base for the `smoldot-light-js` component explained above.
   - 📦 <https://crates.io/crates/smoldot-light>
   - 📚 <https://docs.rs/smoldot-light> (latest published version)
-  - 📚 <https://smol-dot.github.io/smoldot/doc-rust/smoldot_light/index.html> (latest commit)
+  - 📚 <https://paritytech.github.io/smoldot/doc-rust/smoldot_light/index.html> (latest commit)
   - Has a semi-stable API that might change occasionally in minor ways.
 
 - `smoldot-full-node` (`/full-node`): A work-in-progress prototype of a full node binary that can connect to Substrate-base chains. Doesn't yet support many features that the official client supports.
-  - 🐳 <https://github.com/smol-dot/smoldot/pkgs/container/full-node>
+  - 🐳 <https://github.com/paritytech/smoldot/pkgs/container/full-node>
   - 📦 `cargo install --locked smoldot-full-node`
   - Has semi-stable CLI commands that might change occasionally in minor ways.
   - Can also be used as a library to be embedded in other programs:
     - 📦 <https://crates.io/crates/smoldot-full-node>
     - 📚 <https://docs.rs/smoldot-full-node> (latest published version)
-    - 📚 <https://smol-dot.github.io/smoldot/doc-rust/smoldot_full_node/index.html> (latest commit)
+    - 📚 <https://paritytech.github.io/smoldot/doc-rust/smoldot_full_node/index.html> (latest commit)
 
-[![dependency status](https://deps.rs/repo/github/smol-dot/smoldot/status.svg)](https://deps.rs/repo/github/smol-dot/smoldot)
+[![dependency status](https://deps.rs/repo/github/paritytech/smoldot/status.svg)](https://deps.rs/repo/github/paritytech/smoldot)
 
 # Frequently asked questions
 
@@ -105,7 +105,7 @@ Anyone contributing to this project pledges to propose a welcoming, constructive
 
 While the light client is fully maintained, please be aware that at the moment the full node is completely experimental. While none of the source code in this repository comes with any guarantee, it is even more true for the full node. You are at the moment strongly encouraged to not run a validator using the smoldot full node in a production environment, as it could result in a loss of money.
 
-**The following are considered critical security issues**. If you find such an issue, please use the GitHub private disclosure feature found at <https://github.com/smol-dot/smoldot/security/advisories>:
+**The following are considered critical security issues**. If you find such an issue, please use the GitHub private disclosure feature found at <https://github.com/paritytech/smoldot/security/advisories>:
 
 - Smoldot believes that a certain block has been finalized, when it is not actually the case on the blockchain it is connected to.
 - Remote arbitrary memory accesses.

--- a/full-node/bin/main.rs
+++ b/full-node/bin/main.rs
@@ -355,7 +355,7 @@ async fn run(cli_options: cli::CliOptionsRun) {
         smoldot_full_node::LogLevel::Warn,
         "Please note that this full node is experimental. It is not feature complete and is \
         known to panic often. Please report any panic you might encounter to \
-        <https://github.com/smol-dot/smoldot/issues>."
+        <https://github.com/paritytech/smoldot/issues>."
             .to_string(),
     );
 

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -3137,7 +3137,7 @@ fn compile_runtime<TPlat: PlatformRef>(
                         format!(
                             "Unresolved host function in runtime: `{}`:`{}`. Smoldot might \
                             encounter errors later on. Please report this issue in \
-                            https://github.com/smol-dot/smoldot",
+                            https://github.com/paritytech/smoldot",
                             module_name, function
                         )
                     );

--- a/wasm-node/javascript/src/internals/client.ts
+++ b/wasm-node/javascript/src/internals/client.ts
@@ -276,7 +276,7 @@ export function start(options: ClientOptions, wasmModule: SmoldotBytecode | Prom
                     "Smoldot has panicked" +
                     (event.currentTask ? (" while executing task `" + event.currentTask + "`") : "") +
                     ". This is a bug in smoldot. Please open an issue at " +
-                    "https://github.com/smol-dot/smoldot/issues with the following message:\n" +
+                    "https://github.com/paritytech/smoldot/issues with the following message:\n" +
                     event.message
                 );
 


### PR DESCRIPTION
- **zombienet CI:** harden the polkadot binary download against mid-transfer connection resets
- **Repo URLs:** repoint remaining `smol-dot/smoldot` references to `paritytech/smoldot`
- **Actions:** `upload-artifact@v4 → @v6` 
- **Actions:** unpin `checkout` in zombienet.yml to `@v6` to match the rest.