### PR TITLE
npm smoldot v3.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light-wasm"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "async-lock",
  "async-task",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -7356,7 +7356,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -7432,7 +7432,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smoldot 2.0.0",
+ "smoldot 2.1.0",
  "tempfile",
  "tokio",
  "zombienet-sdk",

--- a/benchmarks/js/package-lock.json
+++ b/benchmarks/js/package-lock.json
@@ -11,7 +11,7 @@
     },
     "../../wasm-node/javascript": {
       "name": "smoldot",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -7316,7 +7316,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -7377,7 +7377,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smoldot 2.0.0",
+ "smoldot 2.1.0",
  "tempfile",
  "tokio",
  "zombienet-sdk",

--- a/e2e-tests/browser/package-lock.json
+++ b/e2e-tests/browser/package-lock.json
@@ -11,7 +11,7 @@
     },
     "../../wasm-node/javascript": {
       "name": "smoldot",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/e2e-tests/js/package-lock.json
+++ b/e2e-tests/js/package-lock.json
@@ -10,7 +10,7 @@
     },
     "../../wasm-node/javascript": {
       "name": "smoldot",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot"
-version = "2.0.0"
+version = "2.1.0"
 description = "Primitives to build a client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot"
 keywords = ["blockchain", "peer-to-peer"]

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light"
-version = "1.3.0"
+version = "1.3.1"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot-light"
 authors.workspace = true

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,9 +2,21 @@
 
 ## Unreleased
 
+## 3.3.1 - 2026-07-02
+
 ### Added
 
-- Add support for the `ext_statement_store_remove_by_version_1` host function as a no-op. Fixes wasm-VM traps on runtimes that import this symbol during runtime execution.
+- Add support for the `ext_statement_store_remove_by_version_1` host function as a no-op. Fixes wasm-VM traps on runtimes that import this symbol during runtime execution. ([#3295](https://github.com/paritytech/smoldot/pull/3295))
+
+### Changed
+
+- `chainHead_v1_follow` now reports every finalized block: the `finalized` event lists all newly-finalized blocks in ascending order instead of only the highest, so consumers tracking each finalized block no longer skip intermediate ones when several blocks finalize at once. ([#3282](https://github.com/paritytech/smoldot/pull/3282))
+
+### Fixed
+
+- Fix finality stalling across an authority-set change, and no longer discard a warp sync that completes while the sync mode is still being decided. ([#3282](https://github.com/paritytech/smoldot/pull/3282))
+- Fix a panic in peer discovery when a Kademlia-capable peer had no usable connection (its capability flag was learned on a since-closed connection). ([#3293](https://github.com/paritytech/smoldot/pull/3293))
+- Fix parachain bootstrap looping forever when the first connected peer couldn't serve the runtime; smoldot now rotates through the other connected peers before erroring. ([#3294](https://github.com/paritytech/smoldot/pull/3294))
 
 ## 3.3.0 - 2026-06-26
 

--- a/wasm-node/javascript/package-lock.json
+++ b/wasm-node/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smoldot",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smoldot",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/wasm-node/javascript/package.json
+++ b/wasm-node/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoldot",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Light client that connects to Polkadot and Substrate-based blockchains",
   "contributors": [
     "Parity Technologies <admin@parity.io>",

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light-wasm"
-version = "3.3.0"
+version = "3.3.1"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
This is to:
- publish `smoldot-v3.3.1` npm.
- publish crates `smoldot-light v1.3.1`, `smoldot v2.1.0`

## Changes

### Added

- Add support for the `ext_statement_store_remove_by_version_1` host function as a no-op. Fixes wasm-VM traps on runtimes that import this symbol during runtime execution. ([#3295](https://github.com/paritytech/smoldot/pull/3295))

### Changed

- `chainHead_v1_follow` now reports every finalized block: the `finalized` event lists all newly-finalized blocks in ascending order instead of only the highest, so consumers tracking each finalized block no longer skip intermediate ones when several blocks finalize at once. ([#3282](https://github.com/paritytech/smoldot/pull/3282))

### Fixed

- Fix finality stalling across an authority-set change, and no longer discard a warp sync that completes while the sync mode is still being decided. ([#3282](https://github.com/paritytech/smoldot/pull/3282))
- Fix a panic in peer discovery when a Kademlia-capable peer had no usable connection (its capability flag was learned on a since-closed connection). ([#3293](https://github.com/paritytech/smoldot/pull/3293))
- Fix parachain bootstrap looping forever when the first connected peer could not serve the runtime; smoldot now rotates through the other connected peers before erroring. ([#3294](https://github.com/paritytech/smoldot/pull/3294))