### PR TITLE
wasm-node: don't swallow JS exceptions thrown inside Wasm

### DIFF
--- a/wasm-node/javascript/src/internals/local-instance.ts
+++ b/wasm-node/javascript/src/internals/local-instance.ts
@@ -448,7 +448,30 @@ export async function startLocalInstance(config: Config, wasmModule: WebAssembly
                 break;
             try {
                 state.instance.exports.advance_execution();
-            } catch (_error) {
+            } catch (error) {
+                // Two kinds of exceptions can reach this point:
+                //
+                // - A Rust panic. The `panic` binding has already emitted the `wasm-panic`
+                //   event, notified the shutdown callback, and set `state.instance` to `null`.
+                //
+                // - An exception thrown by JavaScript code called from within the Wasm (for
+                //   example a platform binding, see
+                //   <https://github.com/paritytech/smoldot/issues/3302>). The exception has
+                //   unwound through the Wasm frames without the Rust code being aware of it,
+                //   leaving the instance in an unusable state (locks still held, etc.).
+                //   Swallowing it would leave a zombie instance that panics at every
+                //   subsequent entry point. Instead, report it as a crash, the same way as
+                //   a panic.
+                if (state.instance) {
+                    state.instance = null;
+                    eventCallback({
+                        ty: "wasm-panic",
+                        message: error instanceof Error ? (error.stack ?? error.toString()) : String(error),
+                        currentTask: state.currentTask
+                    });
+                    state.onShutdownExecutorOrWasmPanic();
+                    state.onShutdownExecutorOrWasmPanic = () => { };
+                }
                 return;
             }
 

--- a/wasm-node/javascript/test/test.mjs
+++ b/wasm-node/javascript/test/test.mjs
@@ -47,3 +47,37 @@ test('system_name works', async t => {
     })
     .then(() => client.terminate());
 });
+
+// An exception thrown by JavaScript code called from within the Wasm (such as a platform
+// binding, or, here, the `logCallback`) unwinds through the Wasm frames without the Rust code
+// being aware of it, leaving the instance unusable. This test verifies that the client detects
+// this situation and turns it into a proper crash, instead of silently leaving a broken client
+// behind. See <https://github.com/paritytech/smoldot/issues/3302>.
+test('exception thrown from a callback crashes the client cleanly', async t => {
+  // `logCallback` is called synchronously from within the Wasm, making it a stand-in for
+  // any JavaScript binding that throws (like the platform `connect()` in #3302).
+  let throwRequested = false;
+  const client = start({
+    maxLogLevel: 4,  // Debug logs, so that background tasks emit log lines frequently.
+    logCallback: () => {
+      if (throwRequested)
+        throw new Error("boom from logCallback");
+    }
+  });
+
+  // Arm the throw only after `addChain`, so that it fires from within the background
+  // execution of tasks rather than from `addChain` itself, which handles errors on its own.
+  const chain = await client.addChain({ chainSpec: westendSpec });
+  const pendingResponse = chain.nextJsonRpcResponse();
+  throwRequested = true;
+
+  // No request was sent, so this promise settles only if the crash releases it.
+  // If the exception were swallowed, the test would fail by timing out.
+  await t.throwsAsync(pendingResponse);
+
+  // A crashed client reports the original exception as the cause, not a generic error.
+  await t.throwsAsync(
+    client.addChain({ chainSpec: westendSpec }),
+    { message: /boom from logCallback/ }
+  );
+});


### PR DESCRIPTION
## Problem

A JS exception thrown by code called from within the Wasm (e.g. a platform binding, see #3302) unwinds through the Wasm frames without Rust noticing, leaving the instance unusable (`STATE` mutex permanently locked).

The `catch` around `advance_execution()` swallowed such exceptions silently. The result was a smoldot zombie instance:
- the primary failure produced no error, no log, no Sentry event;
- every later call into the Wasm panicked with a misleading generic message - likely the actual story behind #3306 and #3307.

## Fix

In the `catch`, tell the two cases apart via `state.instance`:

- `null` - a Rust panic, already reported by the `panic` binding. Return as before.
- still set - a JS exception escaped the Wasm. Report it the same way as a panic: emit `wasm-panic` with the original error's message and stack, and shut down.

The existing crash machinery then takes over: connections are reset, pending calls fail with `CrashError`, and the console shows one clear error with the true cause.

## Why it matters

#3303 removes one trigger, but any future bug that throws synchronously from a JS binding would recreate the same failure mode. With this change such a bug shows up as a single, immediate crash report pointing at the real cause, and the client fails fast instead of hanging its users on a half-dead instance. Diagnosing #3302 from production data took hours precisely because this information was missing.

## Testing

New test: a throwing `logCallback` (same calling shape as a throwing platform binding) must crash the client cleanly.

- without the fix: the test hangs and fails by timeout (the zombie behavior);
- with the fix: it passes in <1s, and the full suite (23 tests) passes.