### PR TITLE
libp2p/yamux: include substream id in Index/IndexMut panic message

### DIFF
--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -1722,7 +1722,7 @@ impl<TNow, TSub> ops::Index<SubstreamId> for Yamux<TNow, TSub> {
             .inner
             .substreams
             .get(&substream_id.0)
-            .unwrap()
+            .unwrap_or_else(|| panic!("no substream with id {} in yamux state", substream_id.0))
             .user_data
     }
 }
@@ -1733,7 +1733,7 @@ impl<TNow, TSub> ops::IndexMut<SubstreamId> for Yamux<TNow, TSub> {
             .inner
             .substreams
             .get_mut(&substream_id.0)
-            .unwrap_or_else(|| panic!())
+            .unwrap_or_else(|| panic!("no substream with id {} in yamux state", substream_id.0))
             .user_data
     }
 }


### PR DESCRIPTION
The `Index`/`IndexMut` impls for `Yamux` panic with a bare "explicit panic" when a `SubstreamId` is missing from the map. Since these accessors are inlined, crash reports (e.g. #3304) show only `Yamux::index_mut` with no clue which substream. Add the id to the message:
```
    no substream with id <N> in yamux state
```

Refs #3304