### PR TITLE
npm smoldot v3.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light-wasm"
-version = "3.3.1"
+version = "3.3.2"
 dependencies = [
  "async-lock",
  "async-task",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -7356,7 +7356,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -7432,7 +7432,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smoldot 2.1.0",
+ "smoldot 2.1.1",
  "tempfile",
  "tokio",
  "zombienet-sdk",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -1477,9 +1477,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/benchmarks/js/package-lock.json
+++ b/benchmarks/js/package-lock.json
@@ -11,7 +11,7 @@
     },
     "../../wasm-node/javascript": {
       "name": "smoldot",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -151,7 +151,9 @@ Then commit whichever locks actually changed (`git diff --name-only`).
 Insert a new section **below** the `## Unreleased` heading (leave `Unreleased`
 in place). Use the current date in `YYYY-MM-DD`. Group entries under
 `### Added` / `### Changed` / `### Fixed` / `### Removed`. Each bullet must
-link to its PR.
+link to its PR, and — when the PR fixes or relates to a GitHub issue
+(check the PR/commit body for `Fixes #N` / `Closes #N` / issue mentions) —
+also link the issue(s).
 
 Template:
 
@@ -160,8 +162,11 @@ Template:
 
 ### Fixed
 
-- <user-facing description>. ([#<PR>](https://github.com/paritytech/smoldot/pull/<PR>))
+- <user-facing description>. ([#<PR>](https://github.com/paritytech/smoldot/pull/<PR>); fixes [#<issue>](https://github.com/paritytech/smoldot/issues/<issue>))
 ```
+
+Use `fixes [#N]` when the PR closes the issue, `related to [#N]` when it
+only touches it. Omit the clause when there is no linked issue.
 
 Rules of thumb:
 

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -1437,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -7316,7 +7316,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -7377,7 +7377,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smoldot 2.1.0",
+ "smoldot 2.1.1",
  "tempfile",
  "tokio",
  "zombienet-sdk",

--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -11,7 +11,7 @@
     },
     "../wasm-node/javascript": {
       "name": "smoldot",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot"
-version = "2.1.0"
+version = "2.1.1"
 description = "Primitives to build a client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot"
 keywords = ["blockchain", "peer-to-peer"]

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light"
-version = "1.3.1"
+version = "1.3.2"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot-light"
 authors.workspace = true

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## 3.3.2 - 2026-07-24
+
+### Changed
+
+- Match incoming statements against statement-store subscriptions through a topic index instead of scanning every subscription, making statement matching efficient when many subscriptions are active. Filter semantics are unchanged. ([#3281](https://github.com/paritytech/smoldot/pull/3281); fixes [#3144](https://github.com/paritytech/smoldot/issues/3144), [#3147](https://github.com/paritytech/smoldot/issues/3147))
+
+### Fixed
+
+- Fix a panic (`called Result::unwrap() on an Err value` in `runtime_service`) during parachain sync, caused by a relay chain block being unpinned twice when its parahead fetch finished but the block was pruned before being reported. ([#3287](https://github.com/paritytech/smoldot/pull/3287); fixes [#3286](https://github.com/paritytech/smoldot/issues/3286))
+- No longer crash the entire client when WebRTC is unavailable in the environment (e.g. inside a worker thread, where `RTCPeerConnection` doesn't exist); WebRTC connections are now forbidden instead. ([#3303](https://github.com/paritytech/smoldot/pull/3303); fixes [#3302](https://github.com/paritytech/smoldot/issues/3302))
+- JS exceptions thrown by code called from within the Wasm are no longer silently swallowed (which left an unusable instance and misleading errors on later calls); they now trigger the regular crash handling with a `wasm-panic` event carrying the original message and stack. ([#3308](https://github.com/paritytech/smoldot/pull/3308); related to [#3302](https://github.com/paritytech/smoldot/issues/3302), [#3306](https://github.com/paritytech/smoldot/issues/3306), [#3307](https://github.com/paritytech/smoldot/issues/3307))
+- Fix a panic (`same stream_id used multiple times in connection_stream_opened`) when a browser delivers the `open` event of an `RTCDataChannel` more than once. ([#3309](https://github.com/paritytech/smoldot/pull/3309); fixes [#3305](https://github.com/paritytech/smoldot/issues/3305))
+
 ## 3.3.1 - 2026-07-02
 
 ### Added

--- a/wasm-node/javascript/package-lock.json
+++ b/wasm-node/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smoldot",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smoldot",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/wasm-node/javascript/package.json
+++ b/wasm-node/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoldot",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Light client that connects to Polkadot and Substrate-based blockchains",
   "contributors": [
     "Parity Technologies <admin@parity.io>",

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light-wasm"
-version = "3.3.1"
+version = "3.3.2"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
This is to:
- publish `smoldot-v3.3.2` npm.
- publish crates `smoldot-light v1.3.2`, `smoldot v2.1.1`

## Changes

### Changed

- Match incoming statements against statement-store subscriptions through a topic index instead of scanning every subscription, making statement matching efficient when many subscriptions are active. Filter semantics are unchanged. ([#3281](https://github.com/paritytech/smoldot/pull/3281); fixes [#3144](https://github.com/paritytech/smoldot/issues/3144), [#3147](https://github.com/paritytech/smoldot/issues/3147))

### Fixed

- Fix a panic (`called Result::unwrap() on an Err value` in `runtime_service`) during parachain sync, caused by a relay chain block being unpinned twice when its parahead fetch finished but the block was pruned before being reported. ([#3287](https://github.com/paritytech/smoldot/pull/3287); fixes [#3286](https://github.com/paritytech/smoldot/issues/3286))
- No longer crash the entire client when WebRTC is unavailable in the environment (e.g. inside a worker thread, where `RTCPeerConnection` doesn't exist); WebRTC connections are now forbidden instead. ([#3303](https://github.com/paritytech/smoldot/pull/3303); fixes [#3302](https://github.com/paritytech/smoldot/issues/3302))
- JS exceptions thrown by code called from within the Wasm are no longer silently swallowed (which left an unusable instance and misleading errors on later calls); they now trigger the regular crash handling with a `wasm-panic` event carrying the original message and stack. ([#3308](https://github.com/paritytech/smoldot/pull/3308); related to [#3302](https://github.com/paritytech/smoldot/issues/3302), [#3306](https://github.com/paritytech/smoldot/issues/3306), [#3307](https://github.com/paritytech/smoldot/issues/3307))
- Fix a panic (`same stream_id used multiple times in connection_stream_opened`) when a browser delivers the `open` event of an `RTCDataChannel` more than once. ([#3309](https://github.com/paritytech/smoldot/pull/3309); fixes [#3305](https://github.com/paritytech/smoldot/issues/3305))

Also updates `docs/RELEASING.md` step 5: changelog entries now link related GitHub issues.