### PR TITLE
light-base: queue pending events instead of overwriting on ban

### DIFF
--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -48,7 +48,7 @@ use crate::{
 use alloc::{
     borrow::ToOwned as _,
     boxed::Box,
-    collections::BTreeMap,
+    collections::{BTreeMap, VecDeque},
     format,
     string::{String, ToString as _},
     sync::Arc,
@@ -257,7 +257,7 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
             chains_ever_gossip_connected: HashSet::with_capacity_and_hasher(4, Default::default()),
             v2_statement_peers: HashMap::with_capacity_and_hasher(4, Default::default()),
             current_affinity_filter: HashMap::with_capacity_and_hasher(4, Default::default()),
-            event_pending_send: None,
+            events_pending_send: VecDeque::with_capacity(4),
             event_senders: either::Left(Vec::new()),
             pending_new_subscriptions: Vec::new(),
             bitswap_event_pending_send: None,
@@ -1077,8 +1077,12 @@ struct BackgroundTask<TPlat: PlatformRef> {
     // TODO: should also detect whenever we fail to open a block announces substream with any of these peers
     important_nodes: HashMap<ChainId, HashSet<PeerId, fnv::FnvBuildHasher>, fnv::FnvBuildHasher>,
 
-    /// Event about to be sent on the senders of [`BackgroundTask::event_senders`].
-    event_pending_send: Option<(ChainId, Event)>,
+    /// Events about to be sent on the senders of [`BackgroundTask::event_senders`].
+    ///
+    /// Network events are only pulled when this queue is empty, keeping it small. A queue is
+    /// nonetheless necessary, as processing a [`ToBackgroundChain::DisconnectAndBan`] message can
+    /// generate an event while another event is already waiting to be dispatched.
+    events_pending_send: VecDeque<(ChainId, Event)>,
 
     /// Bitswap event about to be sent on the senders of [`BackgroundTask::bitswap_event_senders`].
     bitswap_event_pending_send: Option<BitswapEvent>,
@@ -1245,7 +1249,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                 }
             };
             let service_event = async {
-                if let Some(event) = (task.event_pending_send.is_none()
+                if let Some(event) = (task.events_pending_send.is_empty()
                     && task.bitswap_event_pending_send.is_none()
                     && task.pending_new_subscriptions.is_empty()
                     && task.pending_new_bitswap_subscriptions.is_empty())
@@ -1391,7 +1395,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     let event_senders = event_sending_future.await;
                     task.event_senders = either::Left(event_senders);
                     WakeUpReason::EventSendersReady
-                } else if task.event_pending_send.is_some()
+                } else if !task.events_pending_send.is_empty()
                     || !task.pending_new_subscriptions.is_empty()
                 {
                     WakeUpReason::EventSendersReady
@@ -1490,7 +1494,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                 };
 
                 if let Some((event_to_dispatch_chain_id, event_to_dispatch)) =
-                    task.event_pending_send.take()
+                    task.events_pending_send.pop_front()
                 {
                     let mut event_senders = mem::take(event_senders);
                     task.event_senders = either::Right(Box::pin(async move {
@@ -1701,8 +1705,10 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                         peers.remove(&peer_id);
                     }
 
-                    debug_assert!(task.event_pending_send.is_none());
-                    task.event_pending_send = Some((chain_id, Event::Disconnected { peer_id }));
+                    // Unlike the network-event handlers below, this message handler can run
+                    // while another event is already queued, hence the push to a queue.
+                    task.events_pending_send
+                        .push_back((chain_id, Event::Disconnected { peer_id }));
                 }
             }
             WakeUpReason::MessageForChain(
@@ -2505,9 +2511,9 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     }
                 }
 
-                debug_assert!(task.event_pending_send.is_none());
-                task.event_pending_send =
-                    Some((chain_id, Event::BlockAnnounce { peer_id, announce }));
+                debug_assert!(task.events_pending_send.is_empty());
+                task.events_pending_send
+                    .push_back((chain_id, Event::BlockAnnounce { peer_id, announce }));
             }
             WakeUpReason::NetworkEvent(service::Event::GossipConnected {
                 peer_id,
@@ -2541,8 +2547,8 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
 
                 task.chains_ever_gossip_connected.insert(chain_id);
 
-                debug_assert!(task.event_pending_send.is_none());
-                task.event_pending_send = Some((
+                debug_assert!(task.events_pending_send.is_empty());
+                task.events_pending_send.push_back((
                     chain_id,
                     Event::Connected {
                         peer_id,
@@ -2658,8 +2664,9 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     peers.remove(&peer_id);
                 }
 
-                debug_assert!(task.event_pending_send.is_none());
-                task.event_pending_send = Some((chain_id, Event::Disconnected { peer_id }));
+                debug_assert!(task.events_pending_send.is_empty());
+                task.events_pending_send
+                    .push_back((chain_id, Event::Disconnected { peer_id }));
             }
             WakeUpReason::NetworkEvent(service::Event::BitswapConnected { peer_id }) => {
                 task.bitswap_connected_peers = task.bitswap_connected_peers.saturating_add(1);
@@ -3209,8 +3216,8 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     .unwrap()
                     .finalized_block_height = Some(state.commit_finalized_height);
 
-                debug_assert!(task.event_pending_send.is_none());
-                task.event_pending_send = Some((
+                debug_assert!(task.events_pending_send.is_empty());
+                task.events_pending_send.push_back((
                     chain_id,
                     Event::GrandpaNeighborPacket {
                         peer_id,
@@ -3233,22 +3240,22 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     target_block_hash = HashDisplay(message.decode().target_hash),
                 );
 
-                debug_assert!(task.event_pending_send.is_none());
-                task.event_pending_send =
-                    Some((chain_id, Event::GrandpaCommitMessage { peer_id, message }));
+                debug_assert!(task.events_pending_send.is_empty());
+                task.events_pending_send
+                    .push_back((chain_id, Event::GrandpaCommitMessage { peer_id, message }));
             }
             WakeUpReason::NetworkEvent(service::Event::StatementsNotification {
                 chain_id,
                 peer_id,
                 statements,
             }) => {
-                debug_assert!(task.event_pending_send.is_none());
+                debug_assert!(task.events_pending_send.is_empty());
 
                 if statements.is_empty() {
                     continue;
                 }
 
-                task.event_pending_send = Some((
+                task.events_pending_send.push_back((
                     chain_id,
                     Event::StatementsNotification {
                         peer_id,


### PR DESCRIPTION
Fixes #3312

The `DisconnectAndBan` handler could overwrite an undispatched event in `events_pending_send` while an event send to subscribers was in flight. 
Only a `debug_assert!` guarded the slot:

- debug builds: panic `assertion failed: task.event_pending_send.is_none()`
- release builds: the pending event was silently overwritten; a lost `Connected` later panics the sync service on an unmatched `Disconnected`(`substrate_compat.rs:741`, seen under load)

Replace the single-slot `Option` with a `VecDeque`. The queue stays bounded: network events are still only pulled when it is empty, so it can only accumulate ban-synthesized `Disconnected` events - at most one per open gossip link, since repeat bans on a closed link are no-ops.