### PR TITLE
Move StatementProtocolConfig out of network_service into json_rpc_service

### DIFF
--- a/light-base/examples/statement_test.rs
+++ b/light-base/examples/statement_test.rs
@@ -63,14 +63,12 @@ fn main() {
                 potential_relay_chains: iter::empty(),
                 database_content: "",
                 user_data: (),
-                statement_protocol_config: Some(
-                    smoldot_light::network_service::StatementProtocolConfig::new(
-                        core::num::NonZeroUsize::new(65536).unwrap(),
-                        0.01,
-                        rand::random(),
-                        core::time::Duration::from_secs(1),
-                    ),
-                ),
+                statement_protocol_config: Some(smoldot_light::StatementProtocolConfig::new(
+                    core::num::NonZeroUsize::new(65536).unwrap(),
+                    0.01,
+                    rand::random(),
+                    core::time::Duration::from_secs(1),
+                )),
             })
             .unwrap();
 
@@ -91,14 +89,12 @@ fn main() {
                     potential_relay_chains: [relay_chain_id].into_iter(),
                     database_content: "",
                     user_data: (),
-                    statement_protocol_config: Some(
-                        smoldot_light::network_service::StatementProtocolConfig::new(
-                            core::num::NonZeroUsize::new(65536).unwrap(),
-                            0.01,
-                            rand::random(),
-                            core::time::Duration::from_secs(1),
-                        ),
-                    ),
+                    statement_protocol_config: Some(smoldot_light::StatementProtocolConfig::new(
+                        core::num::NonZeroUsize::new(65536).unwrap(),
+                        0.01,
+                        rand::random(),
+                        core::time::Duration::from_secs(1),
+                    )),
                 })
                 .unwrap();
 

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -55,6 +55,8 @@ use alloc::{
 use core::{num::NonZero, pin::Pin};
 use futures_lite::StreamExt as _;
 
+pub use statement::StatementProtocolConfig;
+
 /// Configuration for [`service()`].
 pub struct Config<TPlat: PlatformRef> {
     /// Access to the platform's capabilities.
@@ -121,11 +123,7 @@ pub struct Config<TPlat: PlatformRef> {
     pub genesis_block_hash: [u8; 32],
 
     /// Statement protocol configuration. `None` if the statement protocol is disabled.
-    pub statement_protocol_config: Option<network_service::StatementProtocolConfig>,
-
-    /// Maximum number of seen statement hashes tracked per subscription for dedup.
-    /// `None` if the statement protocol is disabled.
-    pub max_seen_statements: Option<NonZero<usize>>,
+    pub statement_protocol_config: Option<StatementProtocolConfig>,
 }
 
 /// Creates a new JSON-RPC service with the given configuration.
@@ -166,7 +164,6 @@ pub fn service<TPlat: PlatformRef>(config: Config<TPlat>) -> Frontend<TPlat> {
                 system_version: config.system_version,
                 genesis_block_hash: config.genesis_block_hash,
                 statement_protocol_config: config.statement_protocol_config,
-                max_seen_statements: config.max_seen_statements,
             },
             requests_rx,
             responses_tx,

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -16,7 +16,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-    bitswap_service, log, network_service,
+    bitswap_service,
+    json_rpc_service::StatementProtocolConfig,
+    log, network_service,
     platform::PlatformRef,
     runtime_service, sync_service, transactions_service,
     util::{self, SipHasherBuild},
@@ -91,11 +93,7 @@ pub(super) struct Config<TPlat: PlatformRef> {
     pub genesis_block_hash: [u8; 32],
 
     /// Statement protocol configuration. `None` if the statement protocol is disabled.
-    pub statement_protocol_config: Option<network_service::StatementProtocolConfig>,
-
-    /// Maximum number of seen statement hashes tracked per subscription for dedup.
-    /// `None` if the statement protocol is disabled.
-    pub max_seen_statements: Option<NonZero<usize>>,
+    pub statement_protocol_config: Option<StatementProtocolConfig>,
 }
 
 /// Fields used to process JSON-RPC requests in the background.
@@ -126,7 +124,7 @@ struct Background<TPlat: PlatformRef> {
     /// Randomness used for various purposes, such as generating subscription IDs.
     randomness: ChaCha20Rng,
 
-    statement_protocol_config: Option<network_service::StatementProtocolConfig>,
+    statement_protocol_config: Option<StatementProtocolConfig>,
 
     /// See [`Config::network_service`].
     network_service: Arc<network_service::NetworkServiceChain<TPlat>>,
@@ -239,10 +237,6 @@ struct Background<TPlat: PlatformRef> {
     /// The values are list of keys.
     state_get_keys_paged_cache:
         lru::LruCache<GetKeysPagedCacheKey, Vec<Vec<u8>>, util::SipHasherBuild>,
-
-    /// Maximum number of seen statement hashes tracked per subscription for dedup.
-    /// `None` if the statement protocol is disabled.
-    max_seen_statements: Option<NonZero<usize>>,
 
     /// Active statement subscriptions, indexed by topic for efficient matching.
     statement_subscriptions: super::statement::StatementSubscriptions,
@@ -651,7 +645,6 @@ pub(super) async fn run<TPlat: PlatformRef>(
         ),
         genesis_block_hash: config.genesis_block_hash,
         printed_legacy_json_rpc_warning: false,
-        max_seen_statements: config.max_seen_statements,
         statement_subscriptions: super::statement::StatementSubscriptions::with_capacity(16),
         statement_affinity_stale: false,
         next_statement_affinity_update: None,
@@ -3037,7 +3030,9 @@ pub(super) async fn run<TPlat: PlatformRef>(
                         me.statement_subscriptions.insert(
                             subscription_id.clone(),
                             filter,
-                            me.max_seen_statements,
+                            me.statement_protocol_config
+                                .as_ref()
+                                .map(|c| c.max_seen_statements()),
                         );
 
                         me.schedule_statement_affinity_update();

--- a/light-base/src/json_rpc_service/statement.rs
+++ b/light-base/src/json_rpc_service/statement.rs
@@ -17,11 +17,59 @@
 
 use crate::network_service::{self, BroadcastStatementResult};
 use alloc::{string::String, vec::Vec};
-use core::num::NonZero;
+use core::{num::NonZero, time::Duration};
 use smoldot::json_rpc::methods::{
     HexString, InternalError, InvalidReason, StatementSubmitResult, TopicFilter,
 };
 use smoldot::network::codec;
+
+/// Configuration for the Statement Store protocol.
+#[derive(Debug, Clone)]
+pub struct StatementProtocolConfig {
+    /// Per-subscription LRU cache size used for deduplicating delivered statements.
+    max_seen_statements: NonZero<usize>,
+    false_positive_rate: f64,
+    bloom_seed: u128,
+    affinity_update_interval: Duration,
+}
+
+impl StatementProtocolConfig {
+    pub fn new(
+        max_seen_statements: NonZero<usize>,
+        false_positive_rate: f64,
+        bloom_seed: u128,
+        affinity_update_interval: Duration,
+    ) -> Self {
+        assert!(
+            false_positive_rate.is_finite()
+                && false_positive_rate > 0.0
+                && false_positive_rate < 1.0
+        );
+        assert!(!affinity_update_interval.is_zero());
+        StatementProtocolConfig {
+            max_seen_statements,
+            false_positive_rate,
+            bloom_seed,
+            affinity_update_interval,
+        }
+    }
+
+    pub fn max_seen_statements(&self) -> NonZero<usize> {
+        self.max_seen_statements
+    }
+
+    pub fn false_positive_rate(&self) -> f64 {
+        self.false_positive_rate
+    }
+
+    pub fn bloom_seed(&self) -> u128 {
+        self.bloom_seed
+    }
+
+    pub fn affinity_update_interval(&self) -> Duration {
+        self.affinity_update_interval
+    }
+}
 
 /// Validates a SCALE-encoded statement and broadcasts it to the network.
 ///
@@ -240,7 +288,7 @@ impl StatementSubscriptions {
 
     pub(super) fn build_combined_affinity_filter(
         &self,
-        config: &network_service::StatementProtocolConfig,
+        config: &StatementProtocolConfig,
     ) -> network_service::AffinityFilter {
         let mut all_topics: Vec<&[u8; 32]> = Vec::new();
 
@@ -273,8 +321,8 @@ mod tests {
     const SEED: u128 = 0x5EED_5EED_5EED_5EED_5EED_5EED_5EED_5EED;
     const FPR: f64 = 0.01;
 
-    fn test_config() -> network_service::StatementProtocolConfig {
-        network_service::StatementProtocolConfig::new(
+    fn test_config() -> StatementProtocolConfig {
+        StatementProtocolConfig::new(
             NonZero::new(128).unwrap(),
             FPR,
             SEED,

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -107,7 +107,7 @@ mod util;
 pub mod network_service;
 pub mod platform;
 
-pub use json_rpc_service::HandleRpcError;
+pub use json_rpc_service::{HandleRpcError, StatementProtocolConfig};
 
 /// See [`Client::add_chain`].
 #[derive(Debug, Clone)]
@@ -145,7 +145,7 @@ pub struct AddChainConfig<'a, TChain, TRelays> {
     pub json_rpc: AddChainConfigJsonRpc,
 
     /// If `Some`, enables the statement store networking protocol.
-    pub statement_protocol_config: Option<network_service::StatementProtocolConfig>,
+    pub statement_protocol_config: Option<StatementProtocolConfig>,
 }
 
 /// See [`AddChainConfig::json_rpc`].
@@ -677,10 +677,6 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
 
         let statement_protocol_config = config.statement_protocol_config;
 
-        let max_seen_statements = statement_protocol_config
-            .as_ref()
-            .map(|c| c.max_seen_statements());
-
         // Start the services of the chain to add, or grab the services if they already exist.
         let (services, log_name) = match chains_by_key.entry(new_chain_key.clone()) {
             Entry::Occupied(mut entry) => {
@@ -729,7 +725,7 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                         chain_spec.fork_id().map(|f| f.to_owned()),
                         config,
                         network_identify_agent_version,
-                        statement_protocol_config.clone(),
+                        statement_protocol_config.is_some(),
                     )
                 };
 
@@ -945,7 +941,6 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                 system_version: self.platform.client_version().into_owned(),
                 genesis_block_hash,
                 statement_protocol_config,
-                max_seen_statements,
             });
 
             Some(frontend)
@@ -1134,7 +1129,7 @@ fn start_services<TPlat: platform::PlatformRef>(
     fork_id: Option<String>,
     config: StartServicesChainTy<'_, TPlat>,
     network_identify_agent_version: String,
-    statement_protocol_config: Option<network_service::StatementProtocolConfig>,
+    enable_statement_protocol: bool,
 ) -> ChainServices<TPlat> {
     let network_service = network_service.get_or_insert_with(|| {
         network_service::NetworkService::new(network_service::Config {
@@ -1178,7 +1173,7 @@ fn start_services<TPlat: platform::PlatformRef>(
         },
         fork_id,
         block_number_bytes,
-        statement_protocol_config,
+        enable_statement_protocol,
     });
 
     let (sync_service, runtime_service) = match config {

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -54,7 +54,7 @@ use alloc::{
     sync::Arc,
     vec::{self, Vec},
 };
-use core::{cmp, mem, num::NonZero, num::NonZeroUsize, pin::Pin, time::Duration};
+use core::{cmp, mem, num::NonZero, pin::Pin, time::Duration};
 use futures_channel::oneshot;
 use futures_lite::FutureExt as _;
 use futures_util::{StreamExt as _, future, stream};
@@ -77,54 +77,6 @@ use service::SendTopicAffinityError;
 pub use service::{
     ChainId, EncodedMerkleProof, PeerId, QueueNotificationError, SendBitswapMessageError,
 };
-
-/// Configuration for the Statement Store protocol.
-#[derive(Debug, Clone)]
-pub struct StatementProtocolConfig {
-    /// Per-subscription LRU cache size used for deduplicating delivered statements.
-    max_seen_statements: NonZeroUsize,
-    false_positive_rate: f64,
-    bloom_seed: u128,
-    affinity_update_interval: Duration,
-}
-
-impl StatementProtocolConfig {
-    pub fn new(
-        max_seen_statements: NonZeroUsize,
-        false_positive_rate: f64,
-        bloom_seed: u128,
-        affinity_update_interval: Duration,
-    ) -> Self {
-        assert!(
-            false_positive_rate.is_finite()
-                && false_positive_rate > 0.0
-                && false_positive_rate < 1.0
-        );
-        assert!(!affinity_update_interval.is_zero());
-        StatementProtocolConfig {
-            max_seen_statements,
-            false_positive_rate,
-            bloom_seed,
-            affinity_update_interval,
-        }
-    }
-
-    pub fn max_seen_statements(&self) -> NonZeroUsize {
-        self.max_seen_statements
-    }
-
-    pub fn false_positive_rate(&self) -> f64 {
-        self.false_positive_rate
-    }
-
-    pub fn bloom_seed(&self) -> u128 {
-        self.bloom_seed
-    }
-
-    pub fn affinity_update_interval(&self) -> Duration {
-        self.affinity_update_interval
-    }
-}
 
 mod tasks;
 
@@ -186,8 +138,8 @@ pub struct ConfigChain {
     /// number of the finalized block at the time of the initialization.
     pub grandpa_protocol_finalized_block_height: Option<u64>,
 
-    /// If `Some`, enables the statement store protocol.
-    pub statement_protocol_config: Option<StatementProtocolConfig>,
+    /// If `true`, enables the statement store protocol.
+    pub enable_statement_protocol: bool,
 }
 
 pub struct NetworkService<TPlat: PlatformRef> {
@@ -307,7 +259,7 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
                         set_id: 0,
                     },
                 ),
-                enable_statement_protocol: config.statement_protocol_config.is_some(),
+                enable_statement_protocol: config.enable_statement_protocol,
                 fork_id: config.fork_id.clone(),
                 block_number_bytes: config.block_number_bytes,
                 best_hash: config.best_block.1,

--- a/wasm-node/rust/src/lib.rs
+++ b/wasm-node/rust/src/lib.rs
@@ -144,7 +144,7 @@ fn add_chain(
                     .map(|max_seen| {
                         let mut seed_bytes = [0u8; 16];
                         smoldot_light::platform::PlatformRef::fill_random_bytes(&platform::PLATFORM_REF, &mut seed_bytes);
-                        smoldot_light::network_service::StatementProtocolConfig::new(max_seen, statement_store_false_positive_rate, u128::from_le_bytes(seed_bytes), Duration::from_millis(u64::from(statement_store_affinity_update_interval_ms)))
+                        smoldot_light::StatementProtocolConfig::new(max_seen, statement_store_false_positive_rate, u128::from_le_bytes(seed_bytes), Duration::from_millis(u64::from(statement_store_affinity_update_interval_ms)))
                     }),
                 }) {
                 Ok(c) => c,


### PR DESCRIPTION
Fixes https://github.com/paritytech/smoldot/issues/3193

StatementProtocolConfig lived in network_service.rs, but the network service only ever called .is_some() on it — all four settings are read by the JSON-RPC statement code. ConfigChain now takes enable_statement_protocol: bool, and the config type moves next to its readers in json_rpc_service, re-exported as smoldot_light::StatementProtocolConfig.