### PR TITLE
wasm-node: skip send on RTCDataChannel that is no longer open

### DIFF
--- a/.github/workflows/zombienet.yml
+++ b/.github/workflows/zombienet.yml
@@ -102,6 +102,9 @@ jobs:
           # - job-name: "zombienet-smoldot-0014-webrtc_double_open"
           #   test: "webrtc_double_open"
           #   runner-type: "default"
+          # - job-name: "zombienet-smoldot-0015-webrtc_send_after_close"
+          #   test: "webrtc_send_after_close"
+          #   runner-type: "default"
 
     steps:
       - uses: actions/checkout@v6

--- a/e2e-tests/shared/webrtc_send_after_close.js
+++ b/e2e-tests/shared/webrtc_send_after_close.js
@@ -1,0 +1,217 @@
+// Smoldot
+// Copyright (C) 2019-2026  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Regression test for <https://github.com/paritytech/smoldot/issues/3322>:
+// an `RTCDataChannel` can leave the `open` state before its `close` event is
+// dispatched. Until that event runs (and reports the reset through
+// `onStreamReset`), smoldot still believes the stream is writable and can
+// issue a send, which used to throw an uncaught
+// `InvalidStateError: RTCDataChannel.readyState is not 'open'`.
+//
+// The body injects that fault, then runs the plain smoke test unchanged. For
+// the first few data channels: right after smoldot's `open` handler returns
+// (so smoldot has been told the stream is open and writable), the channel is
+// closed for real — `readyState` leaves `"open"` synchronously — and delivery
+// of the resulting `close`/`error` event to smoldot's handler is delayed by a
+// couple of seconds. smoldot's first write on a fresh substream (the
+// multistream-select negotiation) is issued on a later task than the `open`
+// event, so it lands inside that window and hits a genuinely non-open channel
+// through the real `send` path. Without the `readyState` guard in
+// `no-auto-bytecode-browser.ts` the browser throws and the client crashes;
+// with it the write is dropped, the delayed `close` event resets the stream,
+// and smoldot must recover and sync normally.
+//
+// Channels are intercepted at creation (`createDataChannel` for outbound,
+// `ondatachannel` for inbound), before smoldot attaches its handlers. The
+// first negotiated channel (the connection handshake) is left alone so the
+// connection itself survives. A wrapped `readyState` getter counts smoldot
+// consulting the guard inside the window, proving the race was actually
+// exercised and not silently missed.
+//
+// Browser-only: the fault lives in browser-only code
+// (`no-auto-bytecode-browser.ts`) and Node has no `RTCDataChannel`. The
+// globals it patches only exist inside the page, so they are touched inside
+// the function body (not at module top level), keeping the module importable
+// by the Node runner, which reads only the re-exports below.
+
+import smoke from "./smoke.js";
+
+export { fileInputs, envInputs } from "./smoke.js";
+
+// How many channels to force-close. Bounded so that, past the injection
+// phase, substream churn stops and the client can sync unimpeded.
+const MAX_INJECTED = 8;
+// How long delivery of the `close`/`error` event is withheld from smoldot.
+// This is the window during which smoldot believes a dead stream is writable.
+const EVENT_DELAY_MS = 2000;
+
+export default async function webrtcSendAfterClose(ctx) {
+  if (ctx.host !== "browser") {
+    throw new Error(
+      `webrtc_send_after_close is browser-only (WebRTC), got host "${ctx.host}"`,
+    );
+  }
+
+  const proto = RTCDataChannel.prototype;
+  const origOpen = Object.getOwnPropertyDescriptor(proto, "onopen");
+  const origClose = Object.getOwnPropertyDescriptor(proto, "onclose");
+  const origError = Object.getOwnPropertyDescriptor(proto, "onerror");
+  const origReadyState = Object.getOwnPropertyDescriptor(proto, "readyState");
+  const origCloseFn = proto.close;
+
+  let injected = 0;
+  let guardReads = 0;
+
+  const arm = (channel) => {
+    // One record per armed channel: the handlers smoldot currently has
+    // assigned (so a later `= null` cancels a pending delayed delivery) and
+    // the injection state.
+    const record = {
+      openHandler: null,
+      closeHandler: null,
+      errorHandler: null,
+      injected: false,
+      delivered: false,
+    };
+
+    // After smoldot's `open` handler has told the wasm that the stream is
+    // open and writable, close the channel for real. `readyState` leaves
+    // `"open"` synchronously; smoldot's first write arrives on a later task
+    // and finds a non-open channel.
+    Object.defineProperty(channel, "onopen", {
+      configurable: true,
+      get: () => record.openHandler,
+      set: (handler) => {
+        record.openHandler = handler;
+        origOpen.set.call(
+          channel,
+          handler === null
+            ? null
+            : (event) => {
+                record.openHandler?.call(channel, event);
+                if (
+                  injected < MAX_INJECTED &&
+                  origReadyState.get.call(channel) === "open"
+                ) {
+                  injected += 1;
+                  record.injected = true;
+                  origCloseFn.call(channel);
+                }
+              },
+        );
+      },
+    });
+
+    // Withhold the `close`/`error` event of an injected channel for
+    // EVENT_DELAY_MS. If smoldot has since reset the stream itself (it
+    // assigns `null` to the handler), the delivery is dropped, mirroring the
+    // real handler-detach semantics. Deliver at most once.
+    const wrapTeardownHandler = (desc, field) => {
+      Object.defineProperty(
+        channel,
+        field === "closeHandler" ? "onclose" : "onerror",
+        {
+          configurable: true,
+          get: () => record[field],
+          set: (handler) => {
+            record[field] = handler;
+            desc.set.call(
+              channel,
+              handler === null
+                ? null
+                : (event) => {
+                    if (!record.injected) {
+                      record[field]?.call(channel, event);
+                      return;
+                    }
+                    setTimeout(() => {
+                      if (record.delivered) return;
+                      const current = record[field];
+                      if (current === null) return;
+                      record.delivered = true;
+                      current.call(channel, event);
+                    }, EVENT_DELAY_MS);
+                  },
+            );
+          },
+        },
+      );
+    };
+    wrapTeardownHandler(origClose, "closeHandler");
+    wrapTeardownHandler(origError, "errorHandler");
+
+    // Count smoldot observing a non-open state inside the window. With the
+    // fix, the guard in `send` performs exactly this read before dropping the
+    // data; without the fix nothing reads it and the native `send` throws.
+    Object.defineProperty(channel, "readyState", {
+      configurable: true,
+      get: () => {
+        const value = origReadyState.get.call(channel);
+        if (record.injected && !record.delivered && value !== "open") {
+          guardReads += 1;
+        }
+        return value;
+      },
+    });
+  };
+
+  const origCreate = RTCPeerConnection.prototype.createDataChannel;
+  RTCPeerConnection.prototype.createDataChannel = function (...args) {
+    const channel = origCreate.apply(this, args);
+    // The negotiated channel carries the connection handshake; killing it
+    // would tear down the whole connection rather than a single substream.
+    if (args[1]?.negotiated !== true) arm(channel);
+    return channel;
+  };
+
+  const dcDesc = Object.getOwnPropertyDescriptor(
+    RTCPeerConnection.prototype,
+    "ondatachannel",
+  );
+  Object.defineProperty(RTCPeerConnection.prototype, "ondatachannel", {
+    configurable: true,
+    get: dcDesc.get,
+    set(handler) {
+      if (handler === null) {
+        dcDesc.set.call(this, null);
+        return;
+      }
+      dcDesc.set.call(this, (event) => {
+        arm(event.channel);
+        handler.call(this, event);
+      });
+    },
+  });
+
+  try {
+    await smoke(ctx);
+  } finally {
+    // Both faults must actually have been exercised, otherwise the run proves
+    // nothing. Reported even on failure so a mis-wired run fails loudly
+    // instead of degrading into a plain smoke test.
+    ctx.report(
+      "channels force-closed after open",
+      injected > 0,
+      `${injected} substreams`,
+    );
+    ctx.report(
+      "send attempted while channel not open",
+      guardReads > 0,
+      `${guardReads} guarded sends`,
+    );
+  }
+}

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -70,7 +70,8 @@ pub async fn run_shared_test(
         // The reason is a blocking fix needed upstream.
         // Waiting until it is fixed.
         // When re-enabling, also uncomment the browser-only
-        // `zombienet-smoldot-0014-webrtc_double_open` entry in
+        // `zombienet-smoldot-0014-webrtc_double_open` and
+        // `zombienet-smoldot-0015-webrtc_send_after_close` entries in
         // `.github/workflows/zombienet.yml`.
         // Host::Browser => "hosts/browser/run.js",
         _ => return Ok(()),

--- a/e2e-tests/tests/webrtc_send_after_close.rs
+++ b/e2e-tests/tests/webrtc_send_after_close.rs
@@ -1,0 +1,67 @@
+// Smoldot
+// Copyright (C) 2019-2026  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use anyhow::anyhow;
+use smoldot_e2e_tests::*;
+
+const REQUIRED_BLOCKS: u32 = 5;
+
+/// Regression test for <https://github.com/paritytech/smoldot/issues/3322>:
+/// sending on an `RTCDataChannel` that has left the `open` state before its
+/// `close` event is dispatched must not crash smoldot. Runs the smoke body on
+/// the browser host (WebRTC) with a fault injection that closes channels
+/// right after their `open` event and withholds the `close` event, so
+/// smoldot's next write lands on a non-open channel; without the `readyState`
+/// guard in `no-auto-bytecode-browser.ts` the browser throws an uncaught
+/// `InvalidStateError`. Browser-only: the Node host has no WebRTC.
+#[tokio::test(flavor = "multi_thread")]
+async fn webrtc_send_after_close() -> Result<(), anyhow::Error> {
+    let _ = env_logger::try_init_from_env(
+        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
+    );
+
+    let base_dir = resolve_base_dir()?;
+    let base_dir_str = base_dir.to_str().expect("UTF-8 path").to_owned();
+
+    let cfg = Scenario::Fresh;
+    let live = spawn_scenario(&cfg, &base_dir_str).await?;
+
+    log::info!("checking that alice has ≥{REQUIRED_BLOCKS} parachain blocks (best)");
+    live.network
+        .get_node("alice")?
+        .wait_metric_with_timeout(BEST_METRIC, |h| h >= REQUIRED_BLOCKS as f64, 180u64)
+        .await
+        .map_err(|e| anyhow!("alice did not produce parachain blocks: {e}"))?;
+
+    let relay_spec = live.relay_spec.to_str().expect("UTF-8 path");
+    let para_spec = live.para_spec.to_str().expect("UTF-8 path");
+    let required = REQUIRED_BLOCKS.to_string();
+    let expected_finalized = live.expected_initial_finalized.to_string();
+    let env_vars: Vec<(&str, &str)> = vec![
+        ("RELAY_CHAIN_SPEC", relay_spec),
+        ("PARA_CHAIN_SPEC", para_spec),
+        ("REQUIRED_BLOCKS", required.as_str()),
+        ("EXPECTED_INITIAL_FINALIZED", expected_finalized.as_str()),
+    ];
+
+    ensure_browser_deps_installed();
+    run_shared_test(Host::Browser, "webrtc_send_after_close", &env_vars)
+        .await
+        .map_err(|e| anyhow!("browser webrtc_send_after_close test failed: {e}"))?;
+
+    Ok(())
+}

--- a/wasm-node/javascript/src/no-auto-bytecode-browser.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-browser.ts
@@ -527,6 +527,14 @@ function connect(config: ConnectionConfig): Connection {
 
             send: (data: Array<Uint8Array>, streamId: number): void => {
                 const channel = state.dataChannels.get(streamId)!;
+                // The channel can leave the `open` state before its `close` event has been
+                // dispatched. Until that event runs (and reports the reset through
+                // `onStreamReset`), the coordinator still believes the stream is writable and
+                // can legitimately try to send. Calling `send` in that state would throw an
+                // `InvalidStateError`. Dropping the data is fine, as the stream is about to be
+                // reset anyway. See <https://github.com/paritytech/smoldot/issues/3322>.
+                if (channel.channel.readyState !== "open")
+                    return;
                 for (const buffer of data) {
                     channel.bufferedBytes += buffer.length;
                 }

--- a/wasm-node/javascript/src/no-auto-bytecode-browser.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-browser.ts
@@ -514,7 +514,11 @@ function connect(config: ConnectionConfig): Connection {
                     killAllJs();
 
                 } else {
-                    const channel = state.dataChannels.get(streamId)!;
+                    // The stream might have already been reset from the JS side, with the
+                    // notification still on its way to smoldot.
+                    const channel = state.dataChannels.get(streamId);
+                    if (channel === undefined)
+                        return;
                     channel.channel.onopen = null;
                     channel.channel.onerror = null;
                     channel.channel.onclose = null;
@@ -526,12 +530,13 @@ function connect(config: ConnectionConfig): Connection {
             },
 
             send: (data: Array<Uint8Array>, streamId: number): void => {
-                const channel = state.dataChannels.get(streamId)!;
-                // The channel can leave the `open` state before its `close` event (which
-                // reports the reset) is dispatched; sending would then throw. Dropping the
-                // data is fine, as the stream is about to be reset anyway.
+                // The stream might have already been reset from the JS side (entry removed),
+                // or the channel might have left the `open` state before its `close` event
+                // (which reports the reset) is dispatched; sending would then throw. Dropping
+                // the data is fine, as the stream is reset or about to be.
                 // See <https://github.com/paritytech/smoldot/issues/3322>.
-                if (channel.channel.readyState !== "open")
+                const channel = state.dataChannels.get(streamId);
+                if (channel === undefined || channel.channel.readyState !== "open")
                     return;
                 for (const buffer of data) {
                     channel.bufferedBytes += buffer.length;

--- a/wasm-node/javascript/src/no-auto-bytecode-browser.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-browser.ts
@@ -527,12 +527,10 @@ function connect(config: ConnectionConfig): Connection {
 
             send: (data: Array<Uint8Array>, streamId: number): void => {
                 const channel = state.dataChannels.get(streamId)!;
-                // The channel can leave the `open` state before its `close` event has been
-                // dispatched. Until that event runs (and reports the reset through
-                // `onStreamReset`), the coordinator still believes the stream is writable and
-                // can legitimately try to send. Calling `send` in that state would throw an
-                // `InvalidStateError`. Dropping the data is fine, as the stream is about to be
-                // reset anyway. See <https://github.com/paritytech/smoldot/issues/3322>.
+                // The channel can leave the `open` state before its `close` event (which
+                // reports the reset) is dispatched; sending would then throw. Dropping the
+                // data is fine, as the stream is about to be reset anyway.
+                // See <https://github.com/paritytech/smoldot/issues/3322>.
                 if (channel.channel.readyState !== "open")
                     return;
                 for (const buffer of data) {


### PR DESCRIPTION
## Problem

An `RTCDataChannel` can leave the `open` state before its `close` event is dispatched, and smoldot only learns about the reset from that event. In the window in between, the coordinator still believes the stream is writable and can issue a send, which threw an uncaught `InvalidStateError`. Closing-side sibling of the duplicate-`open` race fixed in #3309.

## Fix

Skip the send when `readyState` is not `"open"`. Dropping the data is safe: the pending `close` event resets the stream anyway. Same pattern as the existing WebSocket guard in the same file. Additionally, `send` and `reset` now treat a stream whose entry was already removed from the map as a no-op instead of `!`-asserting (uncaught `TypeError`), covering the window where the reset notification is still on its way to smoldot.

## Test

New browser-only e2e test `webrtc_send_after_close`: closes channels right after smoldot's `open` handler runs and withholds the `close` event for 2s, so smoldot's next write lands on a non-open channel. Without the guard the client crashes; with it it must sync normally. CI entry commented out until browser test execution is re-enabled.

Fixes #3322