### PR TITLE
wasm-node: don't open a substream on a closed connection

### DIFF
--- a/.github/workflows/zombienet.yml
+++ b/.github/workflows/zombienet.yml
@@ -105,6 +105,9 @@ jobs:
           # - job-name: "zombienet-smoldot-0015-webrtc_send_after_close"
           #   test: "webrtc_send_after_close"
           #   runner-type: "default"
+          # - job-name: "zombienet-smoldot-0016-webrtc_open_after_pc_close"
+          #   test: "webrtc_open_after_pc_close"
+          #   runner-type: "default"
 
     steps:
       - uses: actions/checkout@v6

--- a/e2e-tests/shared/webrtc_open_after_pc_close.js
+++ b/e2e-tests/shared/webrtc_open_after_pc_close.js
@@ -1,0 +1,170 @@
+// Smoldot
+// Copyright (C) 2019-2026  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Regression test for <https://github.com/paritytech/smoldot/issues/3325>:
+// an `RTCPeerConnection` can move to the `closed` state before the
+// `connectionstatechange` event reporting it is dispatched. Until that event
+// runs, smoldot still believes the connection is alive and can ask to open a
+// substream; `createDataChannel()` then used to throw an uncaught
+// `InvalidStateError` (connection-level twin of #3322).
+//
+// The body injects that fault, then runs the plain smoke test unchanged. On
+// one connection: after a few outbound channels have been created (so the
+// injection lands inside smoldot's substream-opening burst), the peer
+// connection is closed for real — `signalingState` flips to `"closed"`
+// synchronously. Browsers dispatch no events at all for a locally-closed
+// connection, so the injection also synthesizes the late notification: after
+// a couple of seconds it invokes smoldot's `connectionstatechange` handler,
+// which reads the (genuinely closed) connection state and resets the
+// connection. Everything smoldot does in between happens on a closed
+// connection it believes is alive. Without the `signalingState` guard in
+// `openOutSubstream` the next substream request crashes the client; with it
+// the request is dropped, the synthesized event resets the connection, and
+// smoldot must recover and sync normally.
+//
+// A wrapped `signalingState` getter counts smoldot consulting the guard
+// inside the window, proving the race was actually exercised.
+//
+// Browser-only: the fault lives in browser-only code
+// (`no-auto-bytecode-browser.ts`) and Node has no `RTCPeerConnection`. The
+// globals it patches only exist inside the page, so they are touched inside
+// the function body (not at module top level), keeping the module importable
+// by the Node runner, which reads only the re-exports below.
+
+import smoke from "./smoke.js";
+
+export { fileInputs, envInputs } from "./smoke.js";
+
+// Close the connection after this many outbound channels, so the injection
+// lands mid-burst and smoldot's next `openOutSubstream` hits the window.
+const CLOSE_AFTER_CHANNELS = 3;
+// How long smoldot is left believing the closed connection is alive before
+// the synthesized `connectionstatechange` notification is delivered.
+const EVENT_DELAY_MS = 2000;
+// How many connections to sabotage. One is enough to prove the point and
+// leaves the rest of the network usable for syncing.
+const MAX_INJECTED_PCS = 1;
+
+export default async function webrtcOpenAfterPcClose(ctx) {
+  if (ctx.host !== "browser") {
+    throw new Error(
+      `webrtc_open_after_pc_close is browser-only (WebRTC), got host "${ctx.host}"`,
+    );
+  }
+
+  const OrigPC = RTCPeerConnection;
+  const proto = OrigPC.prototype;
+  const origCreate = proto.createDataChannel;
+  const origClose = proto.close;
+  const origSignaling = Object.getOwnPropertyDescriptor(proto, "signalingState");
+  const origStateChange = Object.getOwnPropertyDescriptor(
+    proto,
+    "onconnectionstatechange",
+  );
+
+  let injectedPcs = 0;
+  let guardReads = 0;
+
+  const armPc = (pc) => {
+    const record = { stateHandler: null, injected: false, delivered: false };
+    let channelsCreated = 0;
+
+    // Keep hold of whatever handler smoldot assigns, so the synthesized late
+    // notification below can invoke it (or skip, if smoldot detached it).
+    Object.defineProperty(pc, "onconnectionstatechange", {
+      configurable: true,
+      get: () => record.stateHandler,
+      set: (handler) => {
+        record.stateHandler = handler;
+        origStateChange.set.call(pc, handler);
+      },
+    });
+
+    // After the Nth outbound channel, close the connection for real —
+    // `signalingState` leaves `"stable"` synchronously — and schedule the
+    // late notification. Browsers fire no events for a local `close()`, so
+    // the "event still pending" window of the real bug is modeled by
+    // invoking smoldot's handler ourselves after EVENT_DELAY_MS; the handler
+    // reads the genuinely-closed connection state and resets the connection.
+    Object.defineProperty(pc, "createDataChannel", {
+      configurable: true,
+      value: (...args) => {
+        const channel = origCreate.apply(pc, args);
+        channelsCreated += 1;
+        if (
+          !record.injected &&
+          injectedPcs < MAX_INJECTED_PCS &&
+          channelsCreated >= CLOSE_AFTER_CHANNELS
+        ) {
+          injectedPcs += 1;
+          record.injected = true;
+          queueMicrotask(() => {
+            origClose.call(pc);
+            setTimeout(() => {
+              if (record.delivered) return;
+              const handler = record.stateHandler;
+              if (handler === null) return;
+              record.delivered = true;
+              handler.call(pc, new Event("connectionstatechange"));
+            }, EVENT_DELAY_MS);
+          });
+        }
+        return channel;
+      },
+    });
+
+    // Count smoldot observing the closed state inside the window. With the
+    // fix, the guard in `openOutSubstream` performs exactly this read before
+    // dropping the request; without the fix nothing reads it and the native
+    // `createDataChannel` throws.
+    Object.defineProperty(pc, "signalingState", {
+      configurable: true,
+      get: () => {
+        const value = origSignaling.get.call(pc);
+        if (record.injected && !record.delivered && value === "closed") {
+          guardReads += 1;
+        }
+        return value;
+      },
+    });
+  };
+
+  globalThis.RTCPeerConnection = class extends OrigPC {
+    constructor(...args) {
+      super(...args);
+      armPc(this);
+    }
+  };
+
+  try {
+    await smoke(ctx);
+  } finally {
+    // Both faults must actually have been exercised, otherwise the run proves
+    // nothing. Reported even on failure so a mis-wired run fails loudly
+    // instead of degrading into a plain smoke test.
+    ctx.report(
+      "peer connection force-closed mid-burst",
+      injectedPcs > 0,
+      `${injectedPcs} connections`,
+    );
+    ctx.report(
+      "substream open attempted on closed connection",
+      guardReads > 0,
+      `${guardReads} guarded opens`,
+    );
+  }
+}

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -70,8 +70,9 @@ pub async fn run_shared_test(
         // The reason is a blocking fix needed upstream.
         // Waiting until it is fixed.
         // When re-enabling, also uncomment the browser-only
-        // `zombienet-smoldot-0014-webrtc_double_open` and
-        // `zombienet-smoldot-0015-webrtc_send_after_close` entries in
+        // `zombienet-smoldot-0014-webrtc_double_open`,
+        // `zombienet-smoldot-0015-webrtc_send_after_close` and
+        // `zombienet-smoldot-0016-webrtc_open_after_pc_close` entries in
         // `.github/workflows/zombienet.yml`.
         // Host::Browser => "hosts/browser/run.js",
         _ => return Ok(()),

--- a/e2e-tests/tests/webrtc_open_after_pc_close.rs
+++ b/e2e-tests/tests/webrtc_open_after_pc_close.rs
@@ -1,0 +1,67 @@
+// Smoldot
+// Copyright (C) 2019-2026  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use anyhow::anyhow;
+use smoldot_e2e_tests::*;
+
+const REQUIRED_BLOCKS: u32 = 5;
+
+/// Regression test for <https://github.com/paritytech/smoldot/issues/3325>:
+/// asking to open a substream on an `RTCPeerConnection` that has moved to the
+/// `closed` state before its `connectionstatechange` event was dispatched
+/// must not crash smoldot. Runs the smoke body on the browser host (WebRTC)
+/// with a fault injection that closes one connection mid-substream-burst and
+/// delivers the state-change notification late; without the `signalingState`
+/// guard in `openOutSubstream` the next `createDataChannel` throws an
+/// uncaught `InvalidStateError`. Browser-only: the Node host has no WebRTC.
+#[tokio::test(flavor = "multi_thread")]
+async fn webrtc_open_after_pc_close() -> Result<(), anyhow::Error> {
+    let _ = env_logger::try_init_from_env(
+        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
+    );
+
+    let base_dir = resolve_base_dir()?;
+    let base_dir_str = base_dir.to_str().expect("UTF-8 path").to_owned();
+
+    let cfg = Scenario::Fresh;
+    let live = spawn_scenario(&cfg, &base_dir_str).await?;
+
+    log::info!("checking that alice has ≥{REQUIRED_BLOCKS} parachain blocks (best)");
+    live.network
+        .get_node("alice")?
+        .wait_metric_with_timeout(BEST_METRIC, |h| h >= REQUIRED_BLOCKS as f64, 180u64)
+        .await
+        .map_err(|e| anyhow!("alice did not produce parachain blocks: {e}"))?;
+
+    let relay_spec = live.relay_spec.to_str().expect("UTF-8 path");
+    let para_spec = live.para_spec.to_str().expect("UTF-8 path");
+    let required = REQUIRED_BLOCKS.to_string();
+    let expected_finalized = live.expected_initial_finalized.to_string();
+    let env_vars: Vec<(&str, &str)> = vec![
+        ("RELAY_CHAIN_SPEC", relay_spec),
+        ("PARA_CHAIN_SPEC", para_spec),
+        ("REQUIRED_BLOCKS", required.as_str()),
+        ("EXPECTED_INITIAL_FINALIZED", expected_finalized.as_str()),
+    ];
+
+    ensure_browser_deps_installed();
+    run_shared_test(Host::Browser, "webrtc_open_after_pc_close", &env_vars)
+        .await
+        .map_err(|e| anyhow!("browser webrtc_open_after_pc_close test failed: {e}"))?;
+
+    Ok(())
+}

--- a/wasm-node/javascript/src/no-auto-bytecode-browser.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-browser.ts
@@ -549,6 +549,13 @@ function connect(config: ConnectionConfig): Connection {
             openOutSubstream: () => {
                 // `openOutSubstream` can only be called after we have called `config.onOpen`,
                 // therefore `pc` is guaranteed to be non-null.
+                // The browser can however move the connection to `closed` before the
+                // `connectionstatechange` event (which reports the reset) is dispatched;
+                // `createDataChannel` would then throw. Doing nothing is fine, as the
+                // connection is about to be reset anyway.
+                // See <https://github.com/paritytech/smoldot/issues/3325>.
+                if (state.pc!.signalingState === "closed")
+                    return;
                 // Note that the label passed to `createDataChannel` is required to be empty as
                 // per the libp2p WebRTC specification.
                 // TODO: adjusting the options based on the first substream is a bit hacky


### PR DESCRIPTION
Fixes #3325
Fixes DOTLI-B9

## Problem

An `RTCPeerConnection` can move to `closed` before its `connectionstatechange` event is dispatched. Until the event runs, smoldot still believes the connection is alive and can ask to open a substream; `createDataChannel()` then throws an uncaught `InvalidStateError`. Connection-level twin of #3322, observed in production (smoldot 3.3.2, Chrome 151, Sentry DOTLI-B9).

## Fix

`openOutSubstream` is now a no-op when `signalingState` is `closed` — the pending state-change event resets the connection anyway. Same shape as the send guard from #3324.

## Test

New browser-only e2e test `webrtc_open_after_pc_close`: closes one connection mid-substream-burst and delivers the state-change notification 2s late (browsers fire no events for a local `close()`, so the late event is synthesized), so smoldot's next `openOutSubstream` lands on a closed connection. Without the guard the client crashes; with it it must sync normally. A wrapped `signalingState` getter asserts the race was actually exercised. CI entry commented out until browser test execution is re-enabled (as with the other `webrtc_*` tests).