### PR TITLE
npm smoldot v3.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "1.3.2"
+version = "2.0.0"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light-wasm"
-version = "3.3.2"
+version = "3.4.0"
 dependencies = [
  "async-lock",
  "async-task",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -7356,7 +7356,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "ark-bls12-381 0.5.0",
  "ark-ec 0.5.0",
@@ -7437,7 +7437,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smoldot 2.1.1",
+ "smoldot 2.2.0",
  "tempfile",
  "tokio",
  "zombienet-sdk",

--- a/benchmarks/js/package-lock.json
+++ b/benchmarks/js/package-lock.json
@@ -11,7 +11,7 @@
     },
     "../../wasm-node/javascript": {
       "name": "smoldot",
-      "version": "3.3.2",
+      "version": "3.4.0",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -7316,7 +7316,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "ark-bls12-381 0.5.0",
  "ark-ec 0.5.0",
@@ -7382,7 +7382,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smoldot 2.1.1",
+ "smoldot 2.2.0",
  "tempfile",
  "tokio",
  "zombienet-sdk",

--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -11,7 +11,7 @@
     },
     "../wasm-node/javascript": {
       "name": "smoldot",
-      "version": "3.3.2",
+      "version": "3.4.0",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot"
-version = "2.1.1"
+version = "2.2.0"
 description = "Primitives to build a client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot"
 keywords = ["blockchain", "peer-to-peer"]

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light"
-version = "1.3.2"
+version = "2.0.0"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot-light"
 authors.workspace = true

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## 3.4.0 - 2026-08-07
+
+### Added
+
+- Implement the [RFC-0163](https://github.com/polkadot-fellows/RFCs/blob/main/text/0163-ec-host-functions.md) elliptic curve host functions: scalar multiplication and multi-scalar multiplication on bandersnatch (`ed_on_bls12_381_bandersnatch`), and scalar multiplication, multi-scalar multiplication, multi Miller loop and final exponentiation on BLS12-381. This lets smoldot execute runtimes that verify bandersnatch ring-VRF proofs (proof-of-personhood chains). The remaining RFC-0163 functions (Pallas, Vesta) are registered but unimplemented. ([#3331](https://github.com/paritytech/smoldot/pull/3331); fixes [#3328](https://github.com/paritytech/smoldot/issues/3328))
+
+### Fixed
+
+- Fix a panic (`assertion failed: task.event_pending_send.is_none()` in debug builds) or a silently lost connection event (release builds, later causing a sync service panic on an unmatched `Disconnected`) when a peer ban raced with a network event that was still being delivered to subscribers. ([#3314](https://github.com/paritytech/smoldot/pull/3314); fixes [#3312](https://github.com/paritytech/smoldot/issues/3312))
+- No longer crash with an uncaught `InvalidStateError` when sending on an `RTCDataChannel` that left the `open` state before its `close` event was delivered; the send is skipped, since the pending `close` event resets the stream anyway. ([#3324](https://github.com/paritytech/smoldot/pull/3324); fixes [#3322](https://github.com/paritytech/smoldot/issues/3322))
+- In remote-instance mode, no longer crash with an uncaught `TypeError` when a message addressed to the first substream of a WebRTC connection (stream id 0) raced with that substream's reset: stream id 0 was accidentally exempt from the stale-message check. ([#3326](https://github.com/paritytech/smoldot/pull/3326); related to [#3322](https://github.com/paritytech/smoldot/issues/3322))
+- No longer crash with an uncaught `InvalidStateError` when opening a substream on an `RTCPeerConnection` that moved to `closed` before its `connectionstatechange` event was delivered. ([#3327](https://github.com/paritytech/smoldot/pull/3327); fixes [#3325](https://github.com/paritytech/smoldot/issues/3325))
+- Fix a panic in the connection task when the remote resets an inbound notifications substream while a message about that substream is still in flight (a duplicate reject, or a close right after an accept). ([#3329](https://github.com/paritytech/smoldot/pull/3329); fixes [#3304](https://github.com/paritytech/smoldot/issues/3304))
+
 ## 3.3.2 - 2026-07-24
 
 ### Changed

--- a/wasm-node/javascript/package-lock.json
+++ b/wasm-node/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smoldot",
-  "version": "3.3.2",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smoldot",
-      "version": "3.3.2",
+      "version": "3.4.0",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/wasm-node/javascript/package.json
+++ b/wasm-node/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoldot",
-  "version": "3.3.2",
+  "version": "3.4.0",
   "description": "Light client that connects to Polkadot and Substrate-based blockchains",
   "contributors": [
     "Parity Technologies <admin@parity.io>",

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light-wasm"
-version = "3.3.2"
+version = "3.4.0"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 authors.workspace = true
 license.workspace = true
@@ -30,4 +30,4 @@ nom = { version = "8.0.0", default-features = false }
 pin-project = "1.1.5"
 slab = { version = "0.4.8", default-features = false }
 smoldot = { version = "2.0.0", path = "../../lib", default-features = false }
-smoldot-light = { version = "1.0.0", path = "../../light-base", default-features = false }
+smoldot-light = { version = "2.0.0", path = "../../light-base", default-features = false }


### PR DESCRIPTION
This is to:
- publish `smoldot-v3.4.0` npm.
- publish crates `smoldot-light v2.0.0`, `smoldot v2.2.0`

## Changes

### Added

- Implement the [RFC-0163](https://github.com/polkadot-fellows/RFCs/blob/main/text/0163-ec-host-functions.md) elliptic curve host functions: scalar multiplication and multi-scalar multiplication on bandersnatch (`ed_on_bls12_381_bandersnatch`), and scalar multiplication, multi-scalar multiplication, multi Miller loop and final exponentiation on BLS12-381. This lets smoldot execute runtimes that verify bandersnatch ring-VRF proofs (proof-of-personhood chains). The remaining RFC-0163 functions (Pallas, Vesta) are registered but unimplemented. ([#3331](https://github.com/paritytech/smoldot/pull/3331); fixes [#3328](https://github.com/paritytech/smoldot/issues/3328))

### Fixed

- Fix a panic (`assertion failed: task.event_pending_send.is_none()` in debug builds) or a silently lost connection event (release builds, later causing a sync service panic on an unmatched `Disconnected`) when a peer ban raced with a network event that was still being delivered to subscribers. ([#3314](https://github.com/paritytech/smoldot/pull/3314); fixes [#3312](https://github.com/paritytech/smoldot/issues/3312))
- No longer crash with an uncaught `InvalidStateError` when sending on an `RTCDataChannel` that left the `open` state before its `close` event was delivered; the send is skipped, since the pending `close` event resets the stream anyway. ([#3324](https://github.com/paritytech/smoldot/pull/3324); fixes [#3322](https://github.com/paritytech/smoldot/issues/3322))
- In remote-instance mode, no longer crash with an uncaught `TypeError` when a message addressed to the first substream of a WebRTC connection (stream id 0) raced with that substream's reset: stream id 0 was accidentally exempt from the stale-message check. ([#3326](https://github.com/paritytech/smoldot/pull/3326); related to [#3322](https://github.com/paritytech/smoldot/issues/3322))
- No longer crash with an uncaught `InvalidStateError` when opening a substream on an `RTCPeerConnection` that moved to `closed` before its `connectionstatechange` event was delivered. ([#3327](https://github.com/paritytech/smoldot/pull/3327); fixes [#3325](https://github.com/paritytech/smoldot/issues/3325))
- Fix a panic in the connection task when the remote resets an inbound notifications substream while a message about that substream is still in flight (a duplicate reject, or a close right after an accept). ([#3329](https://github.com/paritytech/smoldot/pull/3329); fixes [#3304](https://github.com/paritytech/smoldot/issues/3304))