### PR TITLE
[WIP] statement-store: add the statement_unstable_submit JSON-RPC function

### DIFF
--- a/e2e-tests/shared/statement_store_submission.js
+++ b/e2e-tests/shared/statement_store_submission.js
@@ -53,23 +53,30 @@ export default async function statementStoreSubmission(ctx) {
 
   await new Promise((r) => setTimeout(r, PEER_SETTLE_MS));
 
-  let submitResult;
+  let ok = false;
+  let outcome;
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-    submitResult = await rpc.sendRpcAndWait(para, "statement_submit", [statementHex]);
+    // A statement reaching no peer is answered with a JSON-RPC error, which `sendRpcAndWait`
+    // throws. That is the expected answer while gossip peers are still settling, so it has to be
+    // retried like any other non-`new` one rather than aborting the test.
+    try {
+      const submitResult = await rpc.sendRpcAndWait(para, "statement_submit", [statementHex]);
+      // Smoldot returns {"status":"new"} on success
+      ok = submitResult?.status === "new";
+      outcome = JSON.stringify(submitResult);
+    } catch (error) {
+      outcome = error.message;
+    }
 
-    // Smoldot returns {"status":"new"} on success
-    if (submitResult?.status === "new") break;
+    if (ok) break;
     if (attempt < MAX_RETRIES - 1) {
-      ctx.log(
-        `statement_submit attempt ${attempt + 1} returned: ${JSON.stringify(submitResult)}, retrying in 5s...`,
-      );
+      ctx.log(`statement_submit attempt ${attempt + 1} returned: ${outcome}, retrying in 5s...`);
       await new Promise((r) => setTimeout(r, 5000));
     }
   }
 
-  const ok = submitResult?.status === "new";
-  report("statement_submit accepted", ok, JSON.stringify(submitResult));
+  report("statement_submit accepted", ok, outcome);
   if (!ok) {
-    throw new Error(`statement_submit never returned status "new": ${JSON.stringify(submitResult)}`);
+    throw new Error(`statement_submit never returned status "new": ${outcome}`);
   }
 }

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -464,12 +464,22 @@ define_methods! {
     /// Returns, as an opaque string, the version of the client serving these JSON-RPC requests.
     system_version() -> Cow<'a, str>,
 
+    // Legacy statement-store JSON RPC API
+
     /// Broadcast a new statement to peers (light node has no local statement-store).
     statement_submit(encoded: HexString) -> StatementSubmitResult,
     /// Subscribe to statements matching the given filter. Returns subscription ID.
     statement_subscribeStatement(filter: TopicFilter) -> Cow<'a, str>,
     /// Unsubscribe from statement notifications.
     statement_unsubscribeStatement(subscription: String) -> bool,
+
+    // Unstable statement-store JSON RPC API, defined in
+    // https://github.com/paritytech/json-rpc-interface-spec/ and implemented in polkadot-sdk by
+    // https://github.com/paritytech/polkadot-sdk/pull/11989. Where a storeless light client cannot
+    // reproduce the reference behavior, the divergence is documented on the item concerned.
+
+    /// Validate a SCALE-encoded statement and broadcast it to peers.
+    statement_unstable_submit(encoded: HexString) -> StatementSubmitOutcome,
 
     // The functions below are experimental and are defined in the document https://github.com/paritytech/json-rpc-interface-spec/
     chainHead_v1_body(
@@ -1129,6 +1139,44 @@ pub enum InternalError {
     NoConnectedPeers,
 }
 
+/// Outcome of a [`MethodCall::statement_unstable_submit`].
+///
+/// A light client keeps no statement store, so the specification's store-dependent statuses are
+/// omitted: `known` and every `rejected` reason. `known` is in any case unreachable through local RPC
+/// submission in polkadot-sdk too, a locally-sourced statement always being resubmittable.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "status", rename_all = "camelCase")]
+pub enum StatementSubmitOutcome {
+    /// The statement passed validation and was broadcast to at least one peer.
+    New,
+    /// The statement failed validation.
+    Invalid(StatementSubmitInvalidReason),
+}
+
+/// Reason of a [`StatementSubmitOutcome::Invalid`].
+///
+/// The specification's `badProof` is omitted: telling a bad proof from a good one means verifying a
+/// signature, more CPU than a light client should spend on a submission, so only the presence of a
+/// proof is checked. The trade-off is that a statement carrying an invalid signature is relayed, and
+/// the peers that do verify it answer with a reputation penalty.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "reason", rename_all = "camelCase")]
+pub enum StatementSubmitInvalidReason {
+    /// The statement has no authenticity proof.
+    NoProof,
+    /// The encoded statement exceeds the maximum allowed size.
+    EncodingTooLarge {
+        /// Size in bytes of the submitted encoding.
+        #[serde(rename = "submittedSize")]
+        submitted_size: usize,
+        /// Maximum allowed size in bytes.
+        #[serde(rename = "maxSize")]
+        max_size: usize,
+    },
+    /// The statement's expiry is in the past.
+    AlreadyExpired,
+}
+
 /// Notification event for statement subscriptions.
 ///
 /// JSON format is compatible with polkadot-sdk's `StatementEvent`.
@@ -1661,6 +1709,73 @@ mod tests {
             call,
             super::MethodCall::statement_unsubscribeStatement { .. }
         ));
+    }
+
+    #[test]
+    fn statement_unstable_submit_parse_valid() {
+        let (id, call) = super::parse_jsonrpc_client_to_server(
+            r#"{"jsonrpc":"2.0","id":5,"method":"statement_unstable_submit","params":["0x1234"]}"#,
+        )
+        .unwrap();
+
+        assert_eq!(id, "5");
+        assert!(matches!(
+            call,
+            super::MethodCall::statement_unstable_submit { .. }
+        ));
+    }
+
+    #[test]
+    fn statement_submit_outcome_serialization() {
+        assert_eq!(
+            serde_json::to_string(&super::StatementSubmitOutcome::New).unwrap(),
+            r#"{"status":"new"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&super::StatementSubmitOutcome::Invalid(
+                super::StatementSubmitInvalidReason::NoProof
+            ))
+            .unwrap(),
+            r#"{"status":"invalid","reason":"noProof"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&super::StatementSubmitOutcome::Invalid(
+                super::StatementSubmitInvalidReason::AlreadyExpired
+            ))
+            .unwrap(),
+            r#"{"status":"invalid","reason":"alreadyExpired"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&super::StatementSubmitOutcome::Invalid(
+                super::StatementSubmitInvalidReason::EncodingTooLarge {
+                    submitted_size: 2_000_000,
+                    max_size: 1_048_575,
+                }
+            ))
+            .unwrap(),
+            r#"{"status":"invalid","reason":"encodingTooLarge","submittedSize":2000000,"maxSize":1048575}"#
+        );
+    }
+
+    #[test]
+    fn statement_submit_outcome_deserialization_round_trip() {
+        for outcome in [
+            super::StatementSubmitOutcome::New,
+            super::StatementSubmitOutcome::Invalid(super::StatementSubmitInvalidReason::NoProof),
+            super::StatementSubmitOutcome::Invalid(
+                super::StatementSubmitInvalidReason::AlreadyExpired,
+            ),
+            super::StatementSubmitOutcome::Invalid(
+                super::StatementSubmitInvalidReason::EncodingTooLarge {
+                    submitted_size: 2_000_000,
+                    max_size: 1_048_575,
+                },
+            ),
+        ] {
+            let json = serde_json::to_string(&outcome).unwrap();
+            let decoded: super::StatementSubmitOutcome = serde_json::from_str(&json).unwrap();
+            assert_eq!(decoded, outcome);
+        }
     }
 
     #[test]

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -474,9 +474,7 @@ define_methods! {
     statement_unsubscribeStatement(subscription: String) -> bool,
 
     // Unstable statement-store JSON RPC API, defined in
-    // https://github.com/paritytech/json-rpc-interface-spec/ and implemented in polkadot-sdk by
-    // https://github.com/paritytech/polkadot-sdk/pull/11989. Where a storeless light client cannot
-    // reproduce the reference behavior, the divergence is documented on the item concerned.
+    // https://github.com/paritytech/json-rpc-interface-spec/
 
     /// Validate a SCALE-encoded statement and broadcast it to peers.
     statement_unstable_submit(encoded: HexString) -> StatementSubmitOutcome,
@@ -1141,9 +1139,8 @@ pub enum InternalError {
 
 /// Outcome of a [`MethodCall::statement_unstable_submit`].
 ///
-/// A light client keeps no statement store, so the specification's store-dependent statuses are
-/// omitted: `known` and every `rejected` reason. `known` is in any case unreachable through local RPC
-/// submission in polkadot-sdk too, a locally-sourced statement always being resubmittable.
+/// A light client keeps no local store, so the specification's store-dependent statuses are
+/// omitted: `known` and every `rejected` reason.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "status", rename_all = "camelCase")]
 pub enum StatementSubmitOutcome {
@@ -1155,10 +1152,7 @@ pub enum StatementSubmitOutcome {
 
 /// Reason of a [`StatementSubmitOutcome::Invalid`].
 ///
-/// The specification's `badProof` is omitted: telling a bad proof from a good one means verifying a
-/// signature, more CPU than a light client should spend on a submission, so only the presence of a
-/// proof is checked. The trade-off is that a statement carrying an invalid signature is relayed, and
-/// the peers that do verify it answer with a reputation penalty.
+/// The specification's `badProof` is omitted: signature verification is too heavy for light nodes.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "reason", rename_all = "camelCase")]
 pub enum StatementSubmitInvalidReason {

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -466,7 +466,9 @@ define_methods! {
 
     // Legacy statement-store JSON RPC API
 
-    /// Broadcast a new statement to peers (light node has no local statement-store).
+    /// Validate a SCALE-encoded statement and broadcast it to peers (light node has no local
+    /// statement-store). Validates exactly as [`MethodCall::statement_unstable_submit`], only
+    /// naming the outcome's fields differently.
     statement_submit(encoded: HexString) -> StatementSubmitResult,
     /// Subscribe to statements matching the given filter. Returns subscription ID.
     statement_subscribeStatement(filter: TopicFilter) -> Cow<'a, str>,
@@ -1112,29 +1114,41 @@ pub enum SystemPeerRole {
 
 /// Result of submitting a statement.
 ///
-/// JSON format is compatible with polkadot-sdk's `SubmitResult`.
+/// JSON format follows polkadot-sdk's `SubmitResult`. `known`, `knownExpired` and `rejected` are
+/// omitted: all three report a decision of a local statement store, which a light client has none
+/// of. Like polkadot-sdk, a failure that leaves no outcome to report — a payload that doesn't
+/// decode, or a statement that reached no peer — is answered with a JSON-RPC error rather than a
+/// variant of this type.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "status", rename_all = "camelCase")]
 pub enum StatementSubmitResult {
     New,
-    Invalid { reason: InvalidReason },
-    InternalError { error: InternalError },
+    Invalid(InvalidReason),
 }
 
 /// Reason why a submitted statement was rejected as invalid.
+///
+/// Mirrors polkadot-sdk's `InvalidReason`, including its `snake_case` field names, which differ
+/// from the `camelCase` of the otherwise identical [`StatementSubmitInvalidReason`] because the two
+/// types are spelled differently there.
+///
+/// `badProof` is never reported: telling a bad proof from a good one means verifying a signature,
+/// which is more CPU than a light client should spend on a submission, so only the presence of a
+/// proof is checked.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "reason", rename_all = "camelCase")]
 pub enum InvalidReason {
-    /// The SCALE-encoded statement failed to decode.
-    #[serde(rename = "Invalid statement encoding")]
-    Encoding,
-}
-
-/// Reason why a submitted statement could not be processed internally.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum InternalError {
-    /// The statement is valid but there were no connected peers to broadcast it to.
-    #[serde(rename = "No connected peers")]
-    NoConnectedPeers,
+    /// The statement has no authenticity proof.
+    NoProof,
+    /// The encoded statement exceeds the maximum allowed size.
+    EncodingTooLarge {
+        /// Size in bytes of the submitted encoding.
+        submitted_size: usize,
+        /// Maximum allowed size in bytes.
+        max_size: usize,
+    },
+    /// The statement's expiry is in the past.
+    AlreadyExpired,
 }
 
 /// Outcome of a [`MethodCall::statement_unstable_submit`].
@@ -1591,29 +1605,36 @@ mod tests {
 
     #[test]
     fn statement_submit_result_serialization() {
-        use super::{InternalError, InvalidReason, StatementSubmitResult};
+        use super::{InvalidReason, StatementSubmitResult};
 
         let new = StatementSubmitResult::New;
         assert_eq!(serde_json::to_string(&new).unwrap(), r#"{"status":"new"}"#);
 
-        let invalid = StatementSubmitResult::Invalid {
-            reason: InvalidReason::Encoding,
-        };
+        let no_proof = StatementSubmitResult::Invalid(InvalidReason::NoProof);
         assert_eq!(
-            serde_json::to_string(&invalid).unwrap(),
-            r#"{"status":"invalid","reason":"Invalid statement encoding"}"#
+            serde_json::to_string(&no_proof).unwrap(),
+            r#"{"status":"invalid","reason":"noProof"}"#
         );
 
-        let internal = StatementSubmitResult::InternalError {
-            error: InternalError::NoConnectedPeers,
-        };
+        let expired = StatementSubmitResult::Invalid(InvalidReason::AlreadyExpired);
         assert_eq!(
-            serde_json::to_string(&internal).unwrap(),
-            r#"{"status":"internalError","error":"No connected peers"}"#
+            serde_json::to_string(&expired).unwrap(),
+            r#"{"status":"invalid","reason":"alreadyExpired"}"#
+        );
+
+        // Field names are `snake_case` here and `camelCase` in `StatementSubmitInvalidReason`,
+        // matching how polkadot-sdk spells each of the two types.
+        let too_large = StatementSubmitResult::Invalid(InvalidReason::EncodingTooLarge {
+            submitted_size: 2_000_000,
+            max_size: 1_048_575,
+        });
+        assert_eq!(
+            serde_json::to_string(&too_large).unwrap(),
+            r#"{"status":"invalid","reason":"encodingTooLarge","submitted_size":2000000,"max_size":1048575}"#
         );
 
         // Round-trips: the typed fields deserialize back from their wire strings.
-        for value in [new, invalid, internal] {
+        for value in [new, no_proof, expired, too_large] {
             let json = serde_json::to_string(&value).unwrap();
             assert_eq!(
                 serde_json::from_str::<StatementSubmitResult>(&json).unwrap(),

--- a/lib/src/json_rpc/service/client_main_task.rs
+++ b/lib/src/json_rpc/service/client_main_task.rs
@@ -435,6 +435,7 @@ impl ClientMainTask {
                 | methods::MethodCall::system_removeReservedPeer { .. }
                 | methods::MethodCall::system_version { .. }
                 | methods::MethodCall::statement_submit { .. }
+                | methods::MethodCall::statement_unstable_submit { .. }
                 | methods::MethodCall::chainSpec_v1_chainName { .. }
                 | methods::MethodCall::chainSpec_v1_genesisHash { .. }
                 | methods::MethodCall::chainSpec_v1_properties { .. }

--- a/lib/src/network/codec/statement.rs
+++ b/lib/src/network/codec/statement.rs
@@ -32,6 +32,17 @@ pub const MAX_ANY_TOPICS: usize = 128;
 /// Maximum number of statements allowed in a single notification.
 const MAX_STATEMENTS_PER_NOTIFICATION: usize = 10_000;
 
+/// Maximum size in bytes of a single SCALE-encoded statement.
+///
+/// Matches the limit polkadot-sdk enforces, and is reported to JSON-RPC clients as the `maxSize` of
+/// an `encodingTooLarge` submission, so the two must agree for a client to predict what a full node
+/// will accept.
+///
+/// Note that a statement of exactly this size does not fit in a V2 notification: that framing adds
+/// a message tag on top of the vector length prefix, putting a single-element batch one byte over
+/// the 1 MiB notification limit.
+pub const MAX_STATEMENT_SIZE: usize = 1024 * 1024 - 1;
+
 const FIELD_PROOF: u8 = 0;
 const FIELD_DECRYPTION_KEY: u8 = 1;
 const FIELD_EXPIRY: u8 = 2;

--- a/lib/src/network/codec/statement.rs
+++ b/lib/src/network/codec/statement.rs
@@ -34,13 +34,7 @@ const MAX_STATEMENTS_PER_NOTIFICATION: usize = 10_000;
 
 /// Maximum size in bytes of a single SCALE-encoded statement.
 ///
-/// Matches the limit polkadot-sdk enforces, and is reported to JSON-RPC clients as the `maxSize` of
-/// an `encodingTooLarge` submission, so the two must agree for a client to predict what a full node
-/// will accept.
-///
-/// Note that a statement of exactly this size does not fit in a V2 notification: that framing adds
-/// a message tag on top of the vector length prefix, putting a single-element batch one byte over
-/// the 1 MiB notification limit.
+/// Matches the limit polkadot-sdk enforces.
 pub const MAX_STATEMENT_SIZE: usize = 1024 * 1024 - 1;
 
 const FIELD_PROOF: u8 = 0;

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -3007,19 +3007,45 @@ pub(super) async fn run<TPlat: PlatformRef>(
 
                     methods::MethodCall::statement_submit { encoded } => {
                         let network = me.network_service.clone();
-                        let result = super::statement::validate_and_broadcast_statement(
+                        let outcome = super::statement::validate_and_broadcast_statement(
                             &encoded.0,
+                            me.platform.now_from_unix_epoch(),
                             |bytes| async move { network.broadcast_statement(bytes).await },
                         )
                         .await;
 
-                        let _ = me
-                            .responses_tx
-                            .send(
-                                methods::Response::statement_submit(result)
-                                    .to_json_response(request_id_json),
-                            )
-                            .await;
+                        let response = match outcome {
+                            super::statement::SubmitOutcome::New => {
+                                methods::Response::statement_submit(
+                                    methods::StatementSubmitResult::New,
+                                )
+                                .to_json_response(request_id_json)
+                            }
+                            super::statement::SubmitOutcome::Invalid(reason) => {
+                                methods::Response::statement_submit(
+                                    methods::StatementSubmitResult::Invalid(reason.to_legacy()),
+                                )
+                                .to_json_response(request_id_json)
+                            }
+                            super::statement::SubmitOutcome::InvalidEncoding => {
+                                parse::build_error_response(
+                                    request_id_json,
+                                    parse::ErrorResponse::InvalidParams(Some(
+                                        "The `encoded` parameter doesn't decode into a statement",
+                                    )),
+                                    None,
+                                )
+                            }
+                            super::statement::SubmitOutcome::NoConnectedPeers => {
+                                parse::build_error_response(
+                                    request_id_json,
+                                    parse::ErrorResponse::InternalError,
+                                    Some(r#""No connected peers to broadcast the statement to""#),
+                                )
+                            }
+                        };
+
+                        let _ = me.responses_tx.send(response).await;
                     }
 
                     methods::MethodCall::statement_subscribeStatement { filter } => {
@@ -3068,17 +3094,27 @@ pub(super) async fn run<TPlat: PlatformRef>(
 
                     methods::MethodCall::statement_unstable_submit { encoded } => {
                         let network = me.network_service.clone();
-                        let result = super::statement::validate_and_broadcast_statement_unstable(
+                        let outcome = super::statement::validate_and_broadcast_statement(
                             &encoded.0,
                             me.platform.now_from_unix_epoch(),
                             |bytes| async move { network.broadcast_statement(bytes).await },
                         )
                         .await;
 
-                        let response = match result {
-                            Ok(outcome) => methods::Response::statement_unstable_submit(outcome)
-                                .to_json_response(request_id_json),
-                            Err(super::statement::StatementSubmitError::InvalidEncoding) => {
+                        let response = match outcome {
+                            super::statement::SubmitOutcome::New => {
+                                methods::Response::statement_unstable_submit(
+                                    methods::StatementSubmitOutcome::New,
+                                )
+                                .to_json_response(request_id_json)
+                            }
+                            super::statement::SubmitOutcome::Invalid(reason) => {
+                                methods::Response::statement_unstable_submit(
+                                    methods::StatementSubmitOutcome::Invalid(reason.to_unstable()),
+                                )
+                                .to_json_response(request_id_json)
+                            }
+                            super::statement::SubmitOutcome::InvalidEncoding => {
                                 parse::build_error_response(
                                     request_id_json,
                                     parse::ErrorResponse::InvalidParams(Some(
@@ -3087,7 +3123,7 @@ pub(super) async fn run<TPlat: PlatformRef>(
                                     None,
                                 )
                             }
-                            Err(super::statement::StatementSubmitError::NoConnectedPeers) => {
+                            super::statement::SubmitOutcome::NoConnectedPeers => {
                                 parse::build_error_response(
                                     request_id_json,
                                     parse::ErrorResponse::InternalError,

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -1001,6 +1001,7 @@ pub(super) async fn run<TPlat: PlatformRef>(
                     | methods::MethodCall::chainSpec_v1_genesisHash { .. }
                     | methods::MethodCall::chainSpec_v1_properties { .. }
                     | methods::MethodCall::rpc_methods { .. }
+                    | methods::MethodCall::statement_unstable_submit { .. }
                     | methods::MethodCall::sudo_unstable_p2pDiscover { .. }
                     | methods::MethodCall::sudo_unstable_version { .. }
                     | methods::MethodCall::transaction_v1_broadcast { .. }
@@ -3063,6 +3064,39 @@ pub(super) async fn run<TPlat: PlatformRef>(
                                     .to_json_response(request_id_json),
                             )
                             .await;
+                    }
+
+                    methods::MethodCall::statement_unstable_submit { encoded } => {
+                        let network = me.network_service.clone();
+                        let result = super::statement::validate_and_broadcast_statement_unstable(
+                            &encoded.0,
+                            me.platform.now_from_unix_epoch(),
+                            |bytes| async move { network.broadcast_statement(bytes).await },
+                        )
+                        .await;
+
+                        let response = match result {
+                            Ok(outcome) => methods::Response::statement_unstable_submit(outcome)
+                                .to_json_response(request_id_json),
+                            Err(super::statement::StatementSubmitError::InvalidEncoding) => {
+                                parse::build_error_response(
+                                    request_id_json,
+                                    parse::ErrorResponse::InvalidParams(Some(
+                                        "The `encoded` parameter doesn't decode into a statement",
+                                    )),
+                                    None,
+                                )
+                            }
+                            Err(super::statement::StatementSubmitError::NoConnectedPeers) => {
+                                parse::build_error_response(
+                                    request_id_json,
+                                    parse::ErrorResponse::InternalError,
+                                    Some(r#""No connected peers to broadcast the statement to""#),
+                                )
+                            }
+                        };
+
+                        let _ = me.responses_tx.send(response).await;
                     }
 
                     _method @ (methods::MethodCall::account_nextIndex { .. }

--- a/light-base/src/json_rpc_service/statement.rs
+++ b/light-base/src/json_rpc_service/statement.rs
@@ -18,10 +18,7 @@
 use crate::network_service::{self, BroadcastStatementResult};
 use alloc::{string::String, vec::Vec};
 use core::{num::NonZero, time::Duration};
-use smoldot::json_rpc::methods::{
-    HexString, InternalError, InvalidReason, StatementSubmitInvalidReason, StatementSubmitOutcome,
-    StatementSubmitResult, TopicFilter,
-};
+use smoldot::json_rpc::methods::{self, HexString, StatementSubmitInvalidReason, TopicFilter};
 use smoldot::network::codec;
 
 /// Configuration for the Statement Store protocol.
@@ -72,85 +69,110 @@ impl StatementProtocolConfig {
     }
 }
 
-/// Validates a SCALE-encoded statement and broadcasts it to the network.
-///
-/// Returns the appropriate [`StatementSubmitResult`] based on the decode and broadcast outcome.
-/// The `broadcast` closure is only called if the statement is valid.
-pub async fn validate_and_broadcast_statement<F, Fut>(
-    encoded: &[u8],
-    broadcast: F,
-) -> StatementSubmitResult
-where
-    F: FnOnce(Vec<u8>) -> Fut,
-    Fut: core::future::Future<Output = BroadcastStatementResult>,
-{
-    if codec::decode_statement(encoded).is_err() {
-        return StatementSubmitResult::Invalid {
-            reason: InvalidReason::Encoding,
-        };
+/// Reason why a submitted statement failed validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InvalidReason {
+    /// The statement's expiry is in the past.
+    AlreadyExpired,
+    /// The encoded statement exceeds [`codec::MAX_STATEMENT_SIZE`].
+    EncodingTooLarge {
+        /// Size in bytes of the submitted encoding.
+        submitted_size: usize,
+        /// Maximum allowed size in bytes.
+        max_size: usize,
+    },
+    /// The statement carries no authenticity proof.
+    NoProof,
+}
+
+impl InvalidReason {
+    /// Renders this reason the way `statement_submit` reports it.
+    pub fn to_legacy(&self) -> methods::InvalidReason {
+        match self {
+            InvalidReason::AlreadyExpired => methods::InvalidReason::AlreadyExpired,
+            InvalidReason::EncodingTooLarge {
+                submitted_size,
+                max_size,
+            } => methods::InvalidReason::EncodingTooLarge {
+                submitted_size: *submitted_size,
+                max_size: *max_size,
+            },
+            InvalidReason::NoProof => methods::InvalidReason::NoProof,
+        }
     }
 
-    let broadcasted = broadcast(encoded.to_vec()).await;
-    if broadcasted.total == 0 {
-        StatementSubmitResult::InternalError {
-            error: InternalError::NoConnectedPeers,
+    /// Renders this reason the way `statement_unstable_submit` reports it.
+    pub fn to_unstable(&self) -> StatementSubmitInvalidReason {
+        match self {
+            InvalidReason::AlreadyExpired => StatementSubmitInvalidReason::AlreadyExpired,
+            InvalidReason::EncodingTooLarge {
+                submitted_size,
+                max_size,
+            } => StatementSubmitInvalidReason::EncodingTooLarge {
+                submitted_size: *submitted_size,
+                max_size: *max_size,
+            },
+            InvalidReason::NoProof => StatementSubmitInvalidReason::NoProof,
         }
-    } else {
-        StatementSubmitResult::New
     }
 }
 
-/// Failure of a `statement_unstable_submit` request, reported as a JSON-RPC error rather than a
-/// [`StatementSubmitOutcome`].
+/// Outcome of [`validate_and_broadcast_statement`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum StatementSubmitError {
-    /// The submitted bytes don't decode into a statement.
+pub enum SubmitOutcome {
+    /// The statement passed validation and reached at least one peer.
+    New,
+    /// The submitted bytes don't decode into a statement. Kept apart from [`InvalidReason`]
+    /// because, like polkadot-sdk, both submission methods answer it with a JSON-RPC error rather
+    /// than an `invalid` outcome.
     InvalidEncoding,
-    /// The statement is valid but reached no peer.
+    /// The statement failed validation and was not broadcast.
+    Invalid(InvalidReason),
+    /// The statement is valid but reached no peer. Answered with a JSON-RPC error: a light client
+    /// keeps no store, so a statement nobody received is nowhere at all.
     NoConnectedPeers,
 }
 
-/// Validates a SCALE-encoded statement and broadcasts it, following the
-/// `statement_unstable_submit` semantics.
+/// Validates a SCALE-encoded statement and broadcasts it to the network.
+///
+/// Serves both `statement_submit` and `statement_unstable_submit`, which validate identically and
+/// differ only in how they render the outcome — mirroring polkadot-sdk, where both sit on the same
+/// `Store::submit`.
 ///
 /// The checks run in the order polkadot-sdk's `Store::submit` applies them — expiry, then size, then
 /// proof — so that a client submitting a statement failing several of them is told the same reason a
 /// full node would give. Checks needing a local store or chain state are skipped.
-pub async fn validate_and_broadcast_statement_unstable<F, Fut>(
+///
+/// The `broadcast` closure is only called if the statement is valid.
+pub async fn validate_and_broadcast_statement<F, Fut>(
     encoded: &[u8],
     now_from_unix_epoch: Duration,
     broadcast: F,
-) -> Result<StatementSubmitOutcome, StatementSubmitError>
+) -> SubmitOutcome
 where
     F: FnOnce(Vec<u8>) -> Fut,
     Fut: core::future::Future<Output = BroadcastStatementResult>,
 {
     let Ok(statement) = codec::decode_statement(encoded) else {
-        return Err(StatementSubmitError::InvalidEncoding);
+        return SubmitOutcome::InvalidEncoding;
     };
 
     // The most significant 32 bits of `expiry` are the expiration timestamp in seconds since
     // the UNIX epoch. A statement expiring exactly now is already expired, the deadline being the
     // first instant at which the statement no longer holds.
     if now_from_unix_epoch.as_secs() >= statement.expiry >> 32 {
-        return Ok(StatementSubmitOutcome::Invalid(
-            StatementSubmitInvalidReason::AlreadyExpired,
-        ));
+        return SubmitOutcome::Invalid(InvalidReason::AlreadyExpired);
     }
 
     if encoded.len() > codec::MAX_STATEMENT_SIZE {
-        return Ok(StatementSubmitOutcome::Invalid(
-            StatementSubmitInvalidReason::EncodingTooLarge {
-                submitted_size: encoded.len(),
-                max_size: codec::MAX_STATEMENT_SIZE,
-            },
-        ));
+        return SubmitOutcome::Invalid(InvalidReason::EncodingTooLarge {
+            submitted_size: encoded.len(),
+            max_size: codec::MAX_STATEMENT_SIZE,
+        });
     }
 
     if statement.proof.is_none() {
-        return Ok(StatementSubmitOutcome::Invalid(
-            StatementSubmitInvalidReason::NoProof,
-        ));
+        return SubmitOutcome::Invalid(InvalidReason::NoProof);
     }
 
     // Counted on `sent` rather than `total`: a peer can be gossip-connected while its statement
@@ -158,10 +180,10 @@ where
     // nobody and reporting `new` would tell the client it was published when it wasn't.
     let broadcasted = broadcast(encoded.to_vec()).await;
     if broadcasted.sent == 0 {
-        return Err(StatementSubmitError::NoConnectedPeers);
+        return SubmitOutcome::NoConnectedPeers;
     }
 
-    Ok(StatementSubmitOutcome::New)
+    SubmitOutcome::New
 }
 
 pub(super) struct StatementSubscription {
@@ -416,18 +438,6 @@ mod tests {
         }
     }
 
-    fn valid_statement() -> Vec<u8> {
-        codec::encode_statement(&codec::Statement {
-            proof: None,
-            decryption_key: None,
-            expiry: 42,
-            channel: None,
-            topics: Vec::new(),
-            data: None,
-        })
-        .unwrap()
-    }
-
     const NOW: Duration = Duration::from_secs(1_000);
 
     /// Expiration timestamp, in the most significant 32 bits, later than [`NOW`].
@@ -449,114 +459,91 @@ mod tests {
     }
 
     #[test]
-    fn unstable_submit_invalid_encoding() {
-        let result = block_on(validate_and_broadcast_statement_unstable(
+    fn submit_invalid_encoding() {
+        let result = block_on(validate_and_broadcast_statement(
             &[0xff, 0xff],
             NOW,
             |_| async { unreachable!() },
         ));
-        assert_eq!(result, Err(StatementSubmitError::InvalidEncoding));
+        assert_eq!(result, SubmitOutcome::InvalidEncoding);
     }
 
     #[test]
-    fn unstable_submit_already_expired() {
+    fn submit_already_expired() {
         // The statement also has no proof: the expiry check runs first.
         let encoded = encoded_statement(false, 500 << 32, None);
-        let result = block_on(validate_and_broadcast_statement_unstable(
-            &encoded,
-            NOW,
-            |_| async { unreachable!() },
-        ));
+        let result = block_on(validate_and_broadcast_statement(&encoded, NOW, |_| async {
+            unreachable!()
+        }));
         assert_eq!(
             result,
-            Ok(StatementSubmitOutcome::Invalid(
-                StatementSubmitInvalidReason::AlreadyExpired
-            ))
+            SubmitOutcome::Invalid(InvalidReason::AlreadyExpired)
         );
     }
 
     #[test]
-    fn unstable_submit_expiry_equal_to_now_is_expired() {
+    fn submit_expiry_equal_to_now_is_expired() {
         let encoded = encoded_statement(true, NOW.as_secs() << 32, None);
-        let result = block_on(validate_and_broadcast_statement_unstable(
-            &encoded,
-            NOW,
-            |_| async { unreachable!() },
-        ));
+        let result = block_on(validate_and_broadcast_statement(&encoded, NOW, |_| async {
+            unreachable!()
+        }));
         assert_eq!(
             result,
-            Ok(StatementSubmitOutcome::Invalid(
-                StatementSubmitInvalidReason::AlreadyExpired
-            ))
+            SubmitOutcome::Invalid(InvalidReason::AlreadyExpired)
         );
     }
 
     #[test]
-    fn unstable_submit_encoding_too_large() {
+    fn submit_encoding_too_large() {
         // The statement also has no proof: the size check runs before the proof check.
         let encoded = encoded_statement(false, FUTURE_EXPIRY, Some(vec![0; 1024 * 1024]));
         assert!(encoded.len() > codec::MAX_STATEMENT_SIZE);
-        let result = block_on(validate_and_broadcast_statement_unstable(
-            &encoded,
-            NOW,
-            |_| async { unreachable!() },
-        ));
+        let result = block_on(validate_and_broadcast_statement(&encoded, NOW, |_| async {
+            unreachable!()
+        }));
         assert_eq!(
             result,
-            Ok(StatementSubmitOutcome::Invalid(
-                StatementSubmitInvalidReason::EncodingTooLarge {
-                    submitted_size: encoded.len(),
-                    max_size: codec::MAX_STATEMENT_SIZE,
-                }
-            ))
+            SubmitOutcome::Invalid(InvalidReason::EncodingTooLarge {
+                submitted_size: encoded.len(),
+                max_size: codec::MAX_STATEMENT_SIZE,
+            })
         );
     }
 
     #[test]
-    fn unstable_submit_no_proof() {
+    fn submit_no_proof() {
         let encoded = encoded_statement(false, FUTURE_EXPIRY, None);
-        let result = block_on(validate_and_broadcast_statement_unstable(
-            &encoded,
-            NOW,
-            |_| async { unreachable!() },
-        ));
-        assert_eq!(
-            result,
-            Ok(StatementSubmitOutcome::Invalid(
-                StatementSubmitInvalidReason::NoProof
-            ))
-        );
+        let result = block_on(validate_and_broadcast_statement(&encoded, NOW, |_| async {
+            unreachable!()
+        }));
+        assert_eq!(result, SubmitOutcome::Invalid(InvalidReason::NoProof));
     }
 
     #[test]
-    fn unstable_submit_no_peers() {
+    fn submit_no_peers() {
         let encoded = encoded_statement(true, FUTURE_EXPIRY, None);
-        let result = block_on(validate_and_broadcast_statement_unstable(
-            &encoded,
-            NOW,
-            |_| async { BroadcastStatementResult { sent: 0, total: 0 } },
-        ));
-        assert_eq!(result, Err(StatementSubmitError::NoConnectedPeers));
+        let result = block_on(validate_and_broadcast_statement(&encoded, NOW, |_| async {
+            BroadcastStatementResult { sent: 0, total: 0 }
+        }));
+        assert_eq!(result, SubmitOutcome::NoConnectedPeers);
     }
 
     #[test]
-    fn unstable_submit_reaching_no_peer_is_not_new() {
+    fn submit_reaching_no_peer_is_not_new() {
         // Gossip-connected peers whose statement substream is missing or whose queue is full leave
         // the statement unsent. Answering `new` would tell the client it was published.
         let encoded = encoded_statement(true, FUTURE_EXPIRY, None);
-        let result = block_on(validate_and_broadcast_statement_unstable(
-            &encoded,
-            NOW,
-            |_| async { BroadcastStatementResult { sent: 0, total: 5 } },
-        ));
-        assert_eq!(result, Err(StatementSubmitError::NoConnectedPeers));
+        let result = block_on(validate_and_broadcast_statement(&encoded, NOW, |_| async {
+            BroadcastStatementResult { sent: 0, total: 5 }
+        }));
+        assert_eq!(result, SubmitOutcome::NoConnectedPeers);
     }
 
     #[test]
-    fn unstable_submit_new() {
+    fn submit_new() {
         let encoded = encoded_statement(true, FUTURE_EXPIRY, None);
         let expected_bytes = encoded.clone();
-        let result = block_on(validate_and_broadcast_statement_unstable(
+        let result = block_on(validate_and_broadcast_statement(
             &encoded,
             NOW,
             |bytes| async move {
@@ -564,43 +551,53 @@ mod tests {
                 BroadcastStatementResult { sent: 3, total: 5 }
             },
         ));
-        assert_eq!(result, Ok(StatementSubmitOutcome::New));
+        assert_eq!(result, SubmitOutcome::New);
     }
 
     #[test]
-    fn validate_and_broadcast_invalid_encoding() {
-        let result = block_on(validate_and_broadcast_statement(&[0xff, 0xff], |_| async {
-            unreachable!()
-        }));
+    fn invalid_reason_legacy_rendering() {
         assert_eq!(
-            result,
-            StatementSubmitResult::Invalid {
-                reason: InvalidReason::Encoding
+            InvalidReason::AlreadyExpired.to_legacy(),
+            methods::InvalidReason::AlreadyExpired
+        );
+        assert_eq!(
+            InvalidReason::NoProof.to_legacy(),
+            methods::InvalidReason::NoProof
+        );
+        assert_eq!(
+            InvalidReason::EncodingTooLarge {
+                submitted_size: 7,
+                max_size: 5,
+            }
+            .to_legacy(),
+            methods::InvalidReason::EncodingTooLarge {
+                submitted_size: 7,
+                max_size: 5,
             }
         );
     }
 
     #[test]
-    fn validate_and_broadcast_no_peers() {
-        let result = block_on(validate_and_broadcast_statement(
-            &valid_statement(),
-            |_| async { BroadcastStatementResult { sent: 0, total: 0 } },
-        ));
+    fn invalid_reason_unstable_rendering() {
         assert_eq!(
-            result,
-            StatementSubmitResult::InternalError {
-                error: InternalError::NoConnectedPeers
+            InvalidReason::AlreadyExpired.to_unstable(),
+            StatementSubmitInvalidReason::AlreadyExpired
+        );
+        assert_eq!(
+            InvalidReason::NoProof.to_unstable(),
+            StatementSubmitInvalidReason::NoProof
+        );
+        assert_eq!(
+            InvalidReason::EncodingTooLarge {
+                submitted_size: 7,
+                max_size: 5,
+            }
+            .to_unstable(),
+            StatementSubmitInvalidReason::EncodingTooLarge {
+                submitted_size: 7,
+                max_size: 5,
             }
         );
-    }
-
-    #[test]
-    fn validate_and_broadcast_new() {
-        let result = block_on(validate_and_broadcast_statement(
-            &valid_statement(),
-            |_| async { BroadcastStatementResult { sent: 3, total: 5 } },
-        ));
-        assert_eq!(result, StatementSubmitResult::New);
     }
 
     #[test]

--- a/light-base/src/json_rpc_service/statement.rs
+++ b/light-base/src/json_rpc_service/statement.rs
@@ -19,7 +19,8 @@ use crate::network_service::{self, BroadcastStatementResult};
 use alloc::{string::String, vec::Vec};
 use core::{num::NonZero, time::Duration};
 use smoldot::json_rpc::methods::{
-    HexString, InternalError, InvalidReason, StatementSubmitResult, TopicFilter,
+    HexString, InternalError, InvalidReason, StatementSubmitInvalidReason, StatementSubmitOutcome,
+    StatementSubmitResult, TopicFilter,
 };
 use smoldot::network::codec;
 
@@ -97,6 +98,70 @@ where
     } else {
         StatementSubmitResult::New
     }
+}
+
+/// Failure of a `statement_unstable_submit` request, reported as a JSON-RPC error rather than a
+/// [`StatementSubmitOutcome`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StatementSubmitError {
+    /// The submitted bytes don't decode into a statement.
+    InvalidEncoding,
+    /// The statement is valid but reached no peer.
+    NoConnectedPeers,
+}
+
+/// Validates a SCALE-encoded statement and broadcasts it, following the
+/// `statement_unstable_submit` semantics.
+///
+/// The checks run in the order polkadot-sdk's `Store::submit` applies them — expiry, then size, then
+/// proof — so that a client submitting a statement failing several of them is told the same reason a
+/// full node would give. Checks needing a local store or chain state are skipped.
+pub async fn validate_and_broadcast_statement_unstable<F, Fut>(
+    encoded: &[u8],
+    now_from_unix_epoch: Duration,
+    broadcast: F,
+) -> Result<StatementSubmitOutcome, StatementSubmitError>
+where
+    F: FnOnce(Vec<u8>) -> Fut,
+    Fut: core::future::Future<Output = BroadcastStatementResult>,
+{
+    let Ok(statement) = codec::decode_statement(encoded) else {
+        return Err(StatementSubmitError::InvalidEncoding);
+    };
+
+    // The most significant 32 bits of `expiry` are the expiration timestamp in seconds since
+    // the UNIX epoch. A statement expiring exactly now is already expired, the deadline being the
+    // first instant at which the statement no longer holds.
+    if now_from_unix_epoch.as_secs() >= statement.expiry >> 32 {
+        return Ok(StatementSubmitOutcome::Invalid(
+            StatementSubmitInvalidReason::AlreadyExpired,
+        ));
+    }
+
+    if encoded.len() > codec::MAX_STATEMENT_SIZE {
+        return Ok(StatementSubmitOutcome::Invalid(
+            StatementSubmitInvalidReason::EncodingTooLarge {
+                submitted_size: encoded.len(),
+                max_size: codec::MAX_STATEMENT_SIZE,
+            },
+        ));
+    }
+
+    if statement.proof.is_none() {
+        return Ok(StatementSubmitOutcome::Invalid(
+            StatementSubmitInvalidReason::NoProof,
+        ));
+    }
+
+    // Counted on `sent` rather than `total`: a peer can be gossip-connected while its statement
+    // substream is absent or its notification queue full, in which case the statement reached
+    // nobody and reporting `new` would tell the client it was published when it wasn't.
+    let broadcasted = broadcast(encoded.to_vec()).await;
+    if broadcasted.sent == 0 {
+        return Err(StatementSubmitError::NoConnectedPeers);
+    }
+
+    Ok(StatementSubmitOutcome::New)
 }
 
 pub(super) struct StatementSubscription {
@@ -361,6 +426,145 @@ mod tests {
             data: None,
         })
         .unwrap()
+    }
+
+    const NOW: Duration = Duration::from_secs(1_000);
+
+    /// Expiration timestamp, in the most significant 32 bits, later than [`NOW`].
+    const FUTURE_EXPIRY: u64 = 2_000 << 32;
+
+    fn encoded_statement(with_proof: bool, expiry: u64, data: Option<Vec<u8>>) -> Vec<u8> {
+        codec::encode_statement(&codec::Statement {
+            proof: with_proof.then_some(codec::Proof::Sr25519 {
+                signature: [0; 64],
+                signer: [0; 32],
+            }),
+            decryption_key: None,
+            expiry,
+            channel: None,
+            topics: Vec::new(),
+            data,
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn unstable_submit_invalid_encoding() {
+        let result = block_on(validate_and_broadcast_statement_unstable(
+            &[0xff, 0xff],
+            NOW,
+            |_| async { unreachable!() },
+        ));
+        assert_eq!(result, Err(StatementSubmitError::InvalidEncoding));
+    }
+
+    #[test]
+    fn unstable_submit_already_expired() {
+        // The statement also has no proof: the expiry check runs first.
+        let encoded = encoded_statement(false, 500 << 32, None);
+        let result = block_on(validate_and_broadcast_statement_unstable(
+            &encoded,
+            NOW,
+            |_| async { unreachable!() },
+        ));
+        assert_eq!(
+            result,
+            Ok(StatementSubmitOutcome::Invalid(
+                StatementSubmitInvalidReason::AlreadyExpired
+            ))
+        );
+    }
+
+    #[test]
+    fn unstable_submit_expiry_equal_to_now_is_expired() {
+        let encoded = encoded_statement(true, NOW.as_secs() << 32, None);
+        let result = block_on(validate_and_broadcast_statement_unstable(
+            &encoded,
+            NOW,
+            |_| async { unreachable!() },
+        ));
+        assert_eq!(
+            result,
+            Ok(StatementSubmitOutcome::Invalid(
+                StatementSubmitInvalidReason::AlreadyExpired
+            ))
+        );
+    }
+
+    #[test]
+    fn unstable_submit_encoding_too_large() {
+        // The statement also has no proof: the size check runs before the proof check.
+        let encoded = encoded_statement(false, FUTURE_EXPIRY, Some(vec![0; 1024 * 1024]));
+        assert!(encoded.len() > codec::MAX_STATEMENT_SIZE);
+        let result = block_on(validate_and_broadcast_statement_unstable(
+            &encoded,
+            NOW,
+            |_| async { unreachable!() },
+        ));
+        assert_eq!(
+            result,
+            Ok(StatementSubmitOutcome::Invalid(
+                StatementSubmitInvalidReason::EncodingTooLarge {
+                    submitted_size: encoded.len(),
+                    max_size: codec::MAX_STATEMENT_SIZE,
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn unstable_submit_no_proof() {
+        let encoded = encoded_statement(false, FUTURE_EXPIRY, None);
+        let result = block_on(validate_and_broadcast_statement_unstable(
+            &encoded,
+            NOW,
+            |_| async { unreachable!() },
+        ));
+        assert_eq!(
+            result,
+            Ok(StatementSubmitOutcome::Invalid(
+                StatementSubmitInvalidReason::NoProof
+            ))
+        );
+    }
+
+    #[test]
+    fn unstable_submit_no_peers() {
+        let encoded = encoded_statement(true, FUTURE_EXPIRY, None);
+        let result = block_on(validate_and_broadcast_statement_unstable(
+            &encoded,
+            NOW,
+            |_| async { BroadcastStatementResult { sent: 0, total: 0 } },
+        ));
+        assert_eq!(result, Err(StatementSubmitError::NoConnectedPeers));
+    }
+
+    #[test]
+    fn unstable_submit_reaching_no_peer_is_not_new() {
+        // Gossip-connected peers whose statement substream is missing or whose queue is full leave
+        // the statement unsent. Answering `new` would tell the client it was published.
+        let encoded = encoded_statement(true, FUTURE_EXPIRY, None);
+        let result = block_on(validate_and_broadcast_statement_unstable(
+            &encoded,
+            NOW,
+            |_| async { BroadcastStatementResult { sent: 0, total: 5 } },
+        ));
+        assert_eq!(result, Err(StatementSubmitError::NoConnectedPeers));
+    }
+
+    #[test]
+    fn unstable_submit_new() {
+        let encoded = encoded_statement(true, FUTURE_EXPIRY, None);
+        let expected_bytes = encoded.clone();
+        let result = block_on(validate_and_broadcast_statement_unstable(
+            &encoded,
+            NOW,
+            |bytes| async move {
+                assert_eq!(bytes, expected_bytes);
+                BroadcastStatementResult { sent: 3, total: 5 }
+            },
+        ));
+        assert_eq!(result, Ok(StatementSubmitOutcome::New));
     }
 
     #[test]

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Added
+
+- Add `statement_unstable_submit`, the statement-store submission function of the new JSON-RPC interface specification. It validates the statement exactly like `statement_submit` and differs only in the field names of its `encodingTooLarge` outcome, which are `camelCase` rather than `snake_case`. ([#3335](https://github.com/paritytech/smoldot/pull/3335))
+
+### Changed
+
+- **Breaking**: `statement_submit` now validates the statement the way a full node does before gossiping it, instead of only checking that it decodes. A statement that has already expired, exceeds the maximum statement size, or carries no proof is answered with `{"status":"invalid","reason":...}` and is no longer broadcast to peers. ([#3335](https://github.com/paritytech/smoldot/pull/3335))
+- **Breaking**: `statement_submit` no longer reports a payload that doesn't decode as `{"status":"invalid","reason":"Invalid statement encoding"}`, nor a statement that reached no peer as `{"status":"internalError",...}`. Matching polkadot-sdk, both are now JSON-RPC errors (`-32602` and `-32603` respectively). ([#3335](https://github.com/paritytech/smoldot/pull/3335))
+
+### Fixed
+
+- `statement_submit` no longer answers `{"status":"new"}` for a statement that reached no peer. Peers whose statement substream is absent or whose notification queue is full were counted as having received it. ([#3335](https://github.com/paritytech/smoldot/pull/3335))
+
 ## 3.3.2 - 2026-07-24
 
 ### Changed


### PR DESCRIPTION
PR series, in merge order:

- #3335 <-- CURRENT
- #3336
- #3337
- #3338
- #3339

Implements `statement_unstable_submit` from [json-rpc-interface-spec#185](https://github.com/paritytech/json-rpc-interface-spec/pull/185). See polkadot-sdk: [#11989](https://github.com/paritytech/polkadot-sdk/pull/11989). The legacy `statement_submit` stays untouched.

Validation mirrors polkadot-sdk's `Store::submit` order but limited:
- `known` and `rejected` are never returned: both report a store decision, and a light client keeps no store.
- `badProof` is not returned either: signature verification is too CPU heavy for light nodes. 
- `new` is reported only when at least one peer actually received the statement (`sent > 0`)