### PR TITLE
statement-store: add the statement_unstable_ subscription functions

### DIFF
--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -480,6 +480,15 @@ define_methods! {
 
     /// Validate a SCALE-encoded statement and broadcast it to peers.
     statement_unstable_submit(encoded: HexString) -> StatementSubmitOutcome,
+    /// Open a statement subscription. It starts with no filter attached, and therefore doesn't
+    /// generate any notification until one is added.
+    ///
+    /// Never fails with `-32800`: the number of statement subscriptions per client isn't capped. The
+    /// specification requires accepting at least two and only permits erroring beyond that.
+    statement_unstable_subscribe() -> Cow<'a, str>,
+    /// Stop a subscription started with `statement_unstable_subscribe`, together with all the
+    /// filters attached to it.
+    statement_unstable_unsubscribe(subscription: Cow<'a, str>) -> (),
 
     // The functions below are experimental and are defined in the document https://github.com/paritytech/json-rpc-interface-spec/
     chainHead_v1_body(
@@ -1723,6 +1732,42 @@ mod tests {
             call,
             super::MethodCall::statement_unstable_submit { .. }
         ));
+    }
+
+    #[test]
+    fn statement_unstable_subscribe_parse_valid() {
+        let (id, call) = super::parse_jsonrpc_client_to_server(
+            r#"{"jsonrpc":"2.0","id":6,"method":"statement_unstable_subscribe","params":[]}"#,
+        )
+        .unwrap();
+
+        assert_eq!(id, "6");
+        assert!(matches!(
+            call,
+            super::MethodCall::statement_unstable_subscribe {}
+        ));
+    }
+
+    #[test]
+    fn statement_unstable_unsubscribe_parse_valid() {
+        let (id, call) = super::parse_jsonrpc_client_to_server(
+            r#"{"jsonrpc":"2.0","id":7,"method":"statement_unstable_unsubscribe","params":["sub1"]}"#,
+        )
+        .unwrap();
+
+        assert_eq!(id, "7");
+        assert!(matches!(
+            call,
+            super::MethodCall::statement_unstable_unsubscribe { .. }
+        ));
+    }
+
+    #[test]
+    fn statement_unstable_unsubscribe_response_is_null() {
+        assert_eq!(
+            super::Response::statement_unstable_unsubscribe(()).to_json_response("1"),
+            r#"{"jsonrpc":"2.0","id":1,"result":null}"#
+        );
     }
 
     #[test]

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -486,6 +486,27 @@ define_methods! {
     /// Never fails with `-32800`: the number of statement subscriptions per client isn't capped. The
     /// specification requires accepting at least two and only permits erroring beyond that.
     statement_unstable_subscribe() -> Cow<'a, str>,
+    /// Attach a filter to a `statement_unstable_subscribe` subscription. A light client keeps no
+    /// statement store, so it replays no statement and emits `replayDone` right away.
+    ///
+    /// Two consequences of that emptiness, both diverging from what the specification assumes of a
+    /// full node:
+    ///
+    /// - `replayDone` doesn't mean the client holds what the server held. The statements matching the
+    ///   new filter arrive afterwards as `newStatements`, once peers learn about the updated topic
+    ///   affinity.
+    /// - Statements already delivered to this subscription are never re-announced under the new
+    ///   filter id, because re-reporting them is what the at-most-once guarantee forbids. Obtaining a
+    ///   full backlog for a filter requires a fresh subscription.
+    statement_unstable_add_filter(
+        subscription: Cow<'a, str>,
+        #[rename = "topicFilter"] topic_filter: StatementTopicFilter
+    ) -> StatementAddFilterResult<'a>,
+    /// Detach a filter from a `statement_unstable_subscribe` subscription.
+    statement_unstable_remove_filter(
+        subscription: Cow<'a, str>,
+        #[rename = "filterId"] filter_id: Cow<'a, str>
+    ) -> (),
     /// Stop a subscription started with `statement_unstable_subscribe`, together with all the
     /// filters attached to it.
     statement_unstable_unsubscribe(subscription: Cow<'a, str>) -> (),
@@ -585,6 +606,7 @@ define_methods! {
 
     // Statement notification sent when statements matching subscribed topics are received.
     statement_statement(subscription: Cow<'a, str>, result: StatementEvent) -> (),
+    statement_unstable_subscribeEvent(subscription: Cow<'a, str>, result: StatementSubscribeEvent<'a>) -> (),
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -1186,6 +1208,111 @@ pub enum StatementSubmitInvalidReason {
     AlreadyExpired,
 }
 
+/// Topic filter accepted by [`MethodCall::statement_unstable_add_filter`].
+///
+/// Only `"any"` and `{"matchAll": [...]}` are accepted, the specification defining no other
+/// variant. A `matchAll` must carry between 1 and 4 topics.
+#[derive(Debug, Clone)]
+pub struct StatementTopicFilter(pub TopicFilter);
+
+impl serde::Serialize for StatementTopicFilter {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StatementTopicFilter {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        // `TopicFilter` already rejects unknown variants, non-32-byte topics, and a `matchAll`
+        // of more than 4 topics. `matchAny`, which the specification doesn't define, and an
+        // empty `matchAll`, which it forbids, both remain accepted by the legacy API and are
+        // therefore only turned down here.
+        match TopicFilter::deserialize(deserializer)? {
+            TopicFilter::MatchAny(_) => Err(D::Error::custom(
+                r#"unknown filter key: matchAny, expected "matchAll""#,
+            )),
+            TopicFilter::MatchAll(topics) if topics.is_empty() => Err(D::Error::custom(
+                "Too few topics for MatchAll: got 0, min 1",
+            )),
+            filter => Ok(StatementTopicFilter(filter)),
+        }
+    }
+}
+
+/// Return value of [`MethodCall::statement_unstable_add_filter`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StatementAddFilterResult<'a> {
+    /// The filter was attached. Contains the opaque string identifying it within the subscription.
+    FilterId(Cow<'a, str>),
+    /// The subscription can't accept another filter. No filter was attached.
+    LimitReached,
+}
+
+impl<'a> serde::Serialize for StatementAddFilterResult<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+
+        match self {
+            StatementAddFilterResult::FilterId(filter_id) => serializer.serialize_str(filter_id),
+            StatementAddFilterResult::LimitReached => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("result", "limitReached")?;
+                map.end()
+            }
+        }
+    }
+}
+
+/// Notification event of a [`MethodCall::statement_unstable_subscribe`] subscription.
+///
+/// A light client keeps no statement store, so `replayStatements` is never emitted: every statement
+/// it learns about is reported through `newStatements`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "event", rename_all = "camelCase")]
+pub enum StatementSubscribeEvent<'a> {
+    /// Statements that were already in the store when a filter was attached.
+    ReplayStatements {
+        /// Filter that produced this batch.
+        #[serde(rename = "filterId")]
+        filter_id: Cow<'a, str>,
+        /// Never empty.
+        statements: Vec<HexString>,
+    },
+    /// The replay caused by attaching a filter is complete.
+    ReplayDone {
+        /// Filter whose replay completed.
+        #[serde(rename = "filterId")]
+        filter_id: Cow<'a, str>,
+    },
+    /// Statements that newly entered the store.
+    NewStatements {
+        /// Never empty.
+        statements: Vec<StatementSubscribeEventItem<'a>>,
+    },
+    /// The server can no longer maintain the guarantees of the subscription, which is now dead.
+    Stop,
+}
+
+/// Entry of a [`StatementSubscribeEvent::NewStatements`].
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct StatementSubscribeEventItem<'a> {
+    pub statement: HexString,
+    /// Filters of the subscription matching this statement. Never empty, free of duplicates.
+    #[serde(rename = "filterIds")]
+    pub filter_ids: Vec<Cow<'a, str>>,
+}
+
 /// Notification event for statement subscriptions.
 ///
 /// JSON format is compatible with polkadot-sdk's `StatementEvent`.
@@ -1760,6 +1887,110 @@ mod tests {
             call,
             super::MethodCall::statement_unstable_unsubscribe { .. }
         ));
+    }
+
+    #[test]
+    fn statement_unstable_add_filter_parse_any() {
+        let (_, call) = super::parse_jsonrpc_client_to_server(
+            r#"{"jsonrpc":"2.0","id":8,"method":"statement_unstable_add_filter","params":["sub1","any"]}"#,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            call,
+            super::MethodCall::statement_unstable_add_filter {
+                topic_filter: super::StatementTopicFilter(super::TopicFilter::Any),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn statement_unstable_add_filter_parse_match_all() {
+        let (_, call) = super::parse_jsonrpc_client_to_server(
+            r#"{"jsonrpc":"2.0","id":8,"method":"statement_unstable_add_filter","params":["sub1",{"matchAll":["0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"]}]}"#,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            call,
+            super::MethodCall::statement_unstable_add_filter {
+                topic_filter: super::StatementTopicFilter(super::TopicFilter::MatchAll(_)),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn statement_unstable_add_filter_rejects_unspecified_filters() {
+        // `matchAny` isn't part of the specification, and `matchAll` must carry 1 to 4 topics.
+        for params in [
+            r#"["sub1",{"matchAny":["0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"]}]"#,
+            r#"["sub1",{"matchAll":[]}]"#,
+            r#"["sub1","all"]"#,
+            r#"["sub1",{"matchAll":["0x12"]}]"#,
+        ] {
+            let request = alloc::format!(
+                r#"{{"jsonrpc":"2.0","id":8,"method":"statement_unstable_add_filter","params":{params}}}"#
+            );
+            assert!(
+                matches!(
+                    super::parse_jsonrpc_client_to_server(&request),
+                    Err(super::ParseClientToServerError::Method { .. })
+                ),
+                "expected {params} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn statement_add_filter_result_serialization() {
+        assert_eq!(
+            serde_json::to_string(&super::StatementAddFilterResult::FilterId(
+                alloc::borrow::Cow::Borrowed("7")
+            ))
+            .unwrap(),
+            r#""7""#
+        );
+        assert_eq!(
+            serde_json::to_string(&super::StatementAddFilterResult::LimitReached).unwrap(),
+            r#"{"result":"limitReached"}"#
+        );
+    }
+
+    #[test]
+    fn statement_subscribe_event_serialization() {
+        use alloc::borrow::Cow;
+
+        assert_eq!(
+            serde_json::to_string(&super::StatementSubscribeEvent::ReplayStatements {
+                filter_id: Cow::Borrowed("3"),
+                statements: vec![super::HexString(vec![0x12, 0x34])],
+            })
+            .unwrap(),
+            r#"{"event":"replayStatements","filterId":"3","statements":["0x1234"]}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&super::StatementSubscribeEvent::ReplayDone {
+                filter_id: Cow::Borrowed("3"),
+            })
+            .unwrap(),
+            r#"{"event":"replayDone","filterId":"3"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&super::StatementSubscribeEvent::NewStatements {
+                statements: vec![super::StatementSubscribeEventItem {
+                    statement: super::HexString(vec![0xab]),
+                    filter_ids: vec![Cow::Borrowed("1"), Cow::Borrowed("2")],
+                }],
+            })
+            .unwrap(),
+            r#"{"event":"newStatements","statements":[{"statement":"0xab","filterIds":["1","2"]}]}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&super::StatementSubscribeEvent::Stop).unwrap(),
+            r#"{"event":"stop"}"#
+        );
     }
 
     #[test]

--- a/lib/src/json_rpc/service/client_main_task.rs
+++ b/lib/src/json_rpc/service/client_main_task.rs
@@ -436,6 +436,8 @@ impl ClientMainTask {
                 | methods::MethodCall::system_version { .. }
                 | methods::MethodCall::statement_submit { .. }
                 | methods::MethodCall::statement_unstable_submit { .. }
+                | methods::MethodCall::statement_unstable_add_filter { .. }
+                | methods::MethodCall::statement_unstable_remove_filter { .. }
                 | methods::MethodCall::chainSpec_v1_chainName { .. }
                 | methods::MethodCall::chainSpec_v1_genesisHash { .. }
                 | methods::MethodCall::chainSpec_v1_properties { .. }

--- a/lib/src/json_rpc/service/client_main_task.rs
+++ b/lib/src/json_rpc/service/client_main_task.rs
@@ -471,6 +471,7 @@ impl ClientMainTask {
                 | methods::MethodCall::state_subscribeRuntimeVersion { .. }
                 | methods::MethodCall::state_subscribeStorage { .. }
                 | methods::MethodCall::statement_subscribeStatement { .. }
+                | methods::MethodCall::statement_unstable_subscribe { .. }
                 | methods::MethodCall::transaction_v1_broadcast { .. }
                 | methods::MethodCall::transactionWatch_v1_submitAndWatch { .. }
                 | methods::MethodCall::sudo_network_unstable_watch { .. }
@@ -551,6 +552,7 @@ impl ClientMainTask {
                 | methods::MethodCall::transactionWatch_v1_unwatch { subscription, .. }
                 | methods::MethodCall::sudo_network_unstable_unwatch { subscription, .. }
                 | methods::MethodCall::bitswap_unstable_unstream { subscription, .. }
+                | methods::MethodCall::statement_unstable_unsubscribe { subscription, .. }
                 | methods::MethodCall::chainHead_v1_unfollow {
                     follow_subscription: subscription,
                     ..
@@ -584,6 +586,9 @@ impl ClientMainTask {
                                     methods::MethodCall::bitswap_unstable_unstream { .. } => {
                                         methods::Response::bitswap_unstable_unstream(())
                                     }
+                                    methods::MethodCall::statement_unstable_unsubscribe {
+                                        ..
+                                    } => methods::Response::statement_unstable_unsubscribe(()),
                                     methods::MethodCall::chainHead_v1_unfollow { .. } => {
                                         methods::Response::chainHead_v1_unfollow(())
                                     }
@@ -612,6 +617,11 @@ impl ClientMainTask {
                                 methods::MethodCall::bitswap_unstable_unstream { .. } => {
                                     // Per spec: no error if subscription is unknown or already-completed.
                                     methods::Response::bitswap_unstable_unstream(())
+                                        .to_json_response(request_id)
+                                }
+                                methods::MethodCall::statement_unstable_unsubscribe { .. } => {
+                                    // Per spec: no error if subscription is unknown or already-completed.
+                                    methods::Response::statement_unstable_unsubscribe(())
                                         .to_json_response(request_id)
                                 }
                                 _ => parse::build_error_response(
@@ -1189,6 +1199,11 @@ impl SubscriptionStartProcess {
             }
             methods::MethodCall::statement_subscribeStatement { .. } => {
                 methods::Response::statement_subscribeStatement(Cow::Borrowed(
+                    &self.subscription_id,
+                ))
+            }
+            methods::MethodCall::statement_unstable_subscribe { .. } => {
+                methods::Response::statement_unstable_subscribe(Cow::Borrowed(
                     &self.subscription_id,
                 ))
             }

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -1002,6 +1002,8 @@ pub(super) async fn run<TPlat: PlatformRef>(
                     | methods::MethodCall::chainSpec_v1_properties { .. }
                     | methods::MethodCall::rpc_methods { .. }
                     | methods::MethodCall::statement_unstable_submit { .. }
+                    | methods::MethodCall::statement_unstable_subscribe { .. }
+                    | methods::MethodCall::statement_unstable_unsubscribe { .. }
                     | methods::MethodCall::sudo_unstable_p2pDiscover { .. }
                     | methods::MethodCall::sudo_unstable_version { .. }
                     | methods::MethodCall::transaction_v1_broadcast { .. }
@@ -3097,6 +3099,47 @@ pub(super) async fn run<TPlat: PlatformRef>(
                         };
 
                         let _ = me.responses_tx.send(response).await;
+                    }
+
+                    methods::MethodCall::statement_unstable_subscribe {} => {
+                        let subscription_id: String = {
+                            let mut id = [0u8; 32];
+                            me.randomness.fill_bytes(&mut id);
+                            hex::encode(id)
+                        };
+
+                        // The subscription starts with no filter attached. It therefore matches no
+                        // statement, and the topic affinity advertised to peers is unchanged.
+                        me.statement_subscriptions.insert_empty(
+                            subscription_id.clone(),
+                            me.statement_protocol_config
+                                .as_ref()
+                                .map(|c| c.max_seen_statements()),
+                        );
+
+                        let _ = me
+                            .responses_tx
+                            .send(
+                                methods::Response::statement_unstable_subscribe(Cow::Owned(
+                                    subscription_id,
+                                ))
+                                .to_json_response(request_id_json),
+                            )
+                            .await;
+                    }
+
+                    methods::MethodCall::statement_unstable_unsubscribe { subscription } => {
+                        if me.statement_subscriptions.remove(&subscription) {
+                            me.schedule_statement_affinity_update();
+                        }
+
+                        let _ = me
+                            .responses_tx
+                            .send(
+                                methods::Response::statement_unstable_unsubscribe(())
+                                    .to_json_response(request_id_json),
+                            )
+                            .await;
                     }
 
                     _method @ (methods::MethodCall::account_nextIndex { .. }

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -856,13 +856,40 @@ pub(super) async fn run<TPlat: PlatformRef>(
                 // The reverse `topic` -> `subscription` index inside `statement_subscriptions`
                 // keeps this proportional to the number of subscriptions sharing a topic with the
                 // incoming statements, rather than the total number of subscriptions.
-                for (sub_id, matching) in me.statement_subscriptions.matching(&statements) {
-                    let notification = methods::ServerToClient::statement_statement {
-                        subscription: Cow::Owned(sub_id),
-                        result: methods::StatementEvent::NewStatements {
-                            statements: matching,
-                            remaining: None,
-                        },
+                for (sub_id, matched) in me.statement_subscriptions.matching(&statements) {
+                    let notification = match matched.kind {
+                        super::statement::SubscriptionKind::Legacy => {
+                            methods::ServerToClient::statement_statement {
+                                subscription: Cow::Owned(sub_id),
+                                result: methods::StatementEvent::NewStatements {
+                                    statements: matched
+                                        .statements
+                                        .into_iter()
+                                        .map(|statement| statement.encoded)
+                                        .collect(),
+                                    remaining: None,
+                                },
+                            }
+                        }
+                        super::statement::SubscriptionKind::Unstable => {
+                            methods::ServerToClient::statement_unstable_subscribeEvent {
+                                subscription: Cow::Owned(sub_id),
+                                result: methods::StatementSubscribeEvent::NewStatements {
+                                    statements: matched
+                                        .statements
+                                        .into_iter()
+                                        .map(|statement| methods::StatementSubscribeEventItem {
+                                            statement: statement.encoded,
+                                            filter_ids: statement
+                                                .filter_ids
+                                                .into_iter()
+                                                .map(|id| Cow::Owned(id.to_string()))
+                                                .collect(),
+                                        })
+                                        .collect(),
+                                },
+                            }
+                        }
                     }
                     .to_json_request_object_parameters(None);
                     if me.responses_tx.send(notification).await.is_err() {
@@ -1003,6 +1030,8 @@ pub(super) async fn run<TPlat: PlatformRef>(
                     | methods::MethodCall::rpc_methods { .. }
                     | methods::MethodCall::statement_unstable_submit { .. }
                     | methods::MethodCall::statement_unstable_subscribe { .. }
+                    | methods::MethodCall::statement_unstable_add_filter { .. }
+                    | methods::MethodCall::statement_unstable_remove_filter { .. }
                     | methods::MethodCall::statement_unstable_unsubscribe { .. }
                     | methods::MethodCall::sudo_unstable_p2pDiscover { .. }
                     | methods::MethodCall::sudo_unstable_version { .. }
@@ -3053,7 +3082,9 @@ pub(super) async fn run<TPlat: PlatformRef>(
                     }
 
                     methods::MethodCall::statement_unsubscribeStatement { subscription } => {
-                        let existed = me.statement_subscriptions.remove(&subscription);
+                        let existed = me
+                            .statement_subscriptions
+                            .remove(&subscription, super::statement::SubscriptionKind::Legacy);
 
                         if existed {
                             me.schedule_statement_affinity_update();
@@ -3128,8 +3159,93 @@ pub(super) async fn run<TPlat: PlatformRef>(
                             .await;
                     }
 
+                    methods::MethodCall::statement_unstable_add_filter {
+                        subscription,
+                        topic_filter,
+                    } => {
+                        let mut added = None;
+
+                        let response = match me
+                            .statement_subscriptions
+                            .add_filter(&subscription, topic_filter.0)
+                        {
+                            Ok(filter_id) => {
+                                me.schedule_statement_affinity_update();
+                                added = Some(filter_id);
+                                methods::Response::statement_unstable_add_filter(
+                                    methods::StatementAddFilterResult::FilterId(Cow::Owned(
+                                        filter_id.to_string(),
+                                    )),
+                                )
+                                .to_json_response(request_id_json)
+                            }
+                            Err(super::statement::AddFilterError::LimitReached) => {
+                                methods::Response::statement_unstable_add_filter(
+                                    methods::StatementAddFilterResult::LimitReached,
+                                )
+                                .to_json_response(request_id_json)
+                            }
+                            Err(super::statement::AddFilterError::UnknownSubscription) => {
+                                parse::build_error_response(
+                                    request_id_json,
+                                    parse::ErrorResponse::ApplicationDefined(
+                                        -32801,
+                                        "unknown subscription",
+                                    ),
+                                    None,
+                                )
+                            }
+                        };
+
+                        let _ = me.responses_tx.send(response).await;
+
+                        // A light client keeps no statement store, so the replay of a newly-added
+                        // filter runs over an empty snapshot and completes right away. The
+                        // statements that peers send once they learn about the updated topic
+                        // affinity are reported through `newStatements`.
+                        //
+                        // `replayDone` therefore precedes the statements matching the filter rather
+                        // than following them, by up to the affinity update interval. A client
+                        // reading it as "I now hold what the server holds" concludes too early.
+                        if let Some(filter_id) = added {
+                            let notification =
+                                methods::ServerToClient::statement_unstable_subscribeEvent {
+                                    subscription,
+                                    result: methods::StatementSubscribeEvent::ReplayDone {
+                                        filter_id: Cow::Owned(filter_id.to_string()),
+                                    },
+                                }
+                                .to_json_request_object_parameters(None);
+                            let _ = me.responses_tx.send(notification).await;
+                        }
+                    }
+
+                    methods::MethodCall::statement_unstable_remove_filter {
+                        subscription,
+                        filter_id,
+                    } => {
+                        if let Some(filter_id) = super::statement::FilterId::from_string(&filter_id)
+                            && me
+                                .statement_subscriptions
+                                .remove_filter(&subscription, filter_id)
+                        {
+                            me.schedule_statement_affinity_update();
+                        }
+
+                        let _ = me
+                            .responses_tx
+                            .send(
+                                methods::Response::statement_unstable_remove_filter(())
+                                    .to_json_response(request_id_json),
+                            )
+                            .await;
+                    }
+
                     methods::MethodCall::statement_unstable_unsubscribe { subscription } => {
-                        if me.statement_subscriptions.remove(&subscription) {
+                        if me
+                            .statement_subscriptions
+                            .remove(&subscription, super::statement::SubscriptionKind::Unstable)
+                        {
                             me.schedule_statement_affinity_update();
                         }
 

--- a/light-base/src/json_rpc_service/statement.rs
+++ b/light-base/src/json_rpc_service/statement.rs
@@ -269,6 +269,13 @@ impl StatementSubscriptions {
         self.subscriptions.is_empty()
     }
 
+    /// Inserts a new subscription with no filter attached. Until a filter is added, it matches no
+    /// statement.
+    pub(super) fn insert_empty(&mut self, id: String, max_seen: Option<NonZero<usize>>) {
+        self.subscriptions
+            .insert(id, StatementSubscription::new(max_seen));
+    }
+
     /// Inserts a new subscription holding `topic_filter` as its only filter.
     pub(super) fn insert(
         &mut self,
@@ -920,6 +927,33 @@ mod tests {
         // The topic entry must have been cleaned up, so a matching statement finds nothing.
         let matches = subs.matching(&[batch_entry(0xaa, vec![t1])]);
         assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn insert_empty_matches_nothing_until_a_filter_is_added() {
+        let t1 = [1u8; 32];
+        let mut subs = StatementSubscriptions::with_capacity(1);
+        subs.insert_empty("a".to_string(), None);
+
+        assert!(!subs.is_empty());
+        // No filter attached yet, so no statement can match.
+        let matches = subs.matching(&[batch_entry(0x01, vec![t1]), batch_entry(0x02, vec![])]);
+        assert!(matches.is_empty());
+
+        subs.add_filter("a", TopicFilter::match_any(vec![t1]).unwrap())
+            .unwrap();
+        let matches = subs.matching(&[batch_entry(0x03, vec![t1])]);
+        assert_eq!(matched_ids(&matches), vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn insert_empty_contributes_no_topic_affinity() {
+        let config = test_config();
+        let mut subs = StatementSubscriptions::with_capacity(1);
+        subs.insert_empty("a".to_string(), None);
+
+        let filter = subs.build_combined_affinity_filter(&config);
+        assert!(!filter.contains(&[1u8; 32]));
     }
 
     #[test]

--- a/light-base/src/json_rpc_service/statement.rs
+++ b/light-base/src/json_rpc_service/statement.rs
@@ -17,7 +17,7 @@
 
 use crate::network_service::{self, BroadcastStatementResult};
 use alloc::{string::String, vec::Vec};
-use core::{num::NonZero, time::Duration};
+use core::{fmt, num::NonZero, time::Duration};
 use smoldot::json_rpc::methods::{
     HexString, InternalError, InvalidReason, StatementSubmitInvalidReason, StatementSubmitOutcome,
     StatementSubmitResult, TopicFilter,
@@ -164,12 +164,67 @@ where
     Ok(StatementSubmitOutcome::New)
 }
 
+/// Maximum number of filters attached to a single subscription.
+///
+/// Keeps one subscription useful for multiplexing while bounding the per-statement list of matching
+/// filter ids. Matches the limit polkadot-sdk enforces, so that a client which stays within it is
+/// accepted by both.
+pub(super) const MAX_FILTERS_PER_SUBSCRIPTION: usize = 128;
+
 /// Identifies a filter within the subscription it is attached to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(super) struct FilterId(u64);
 
+impl FilterId {
+    /// Parses the string representation returned by [`fmt::Display`].
+    pub(super) fn from_string(value: &str) -> Option<Self> {
+        value.parse().ok().map(FilterId)
+    }
+}
+
+impl fmt::Display for FilterId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+/// Why a filter couldn't be attached to a subscription.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum AddFilterError {
+    /// No subscription with the given id.
+    UnknownSubscription,
+    /// The subscription already holds [`MAX_FILTERS_PER_SUBSCRIPTION`] filters.
+    LimitReached,
+}
+
+/// A statement accepted by a subscription, together with the filters that matched it.
+pub(super) struct MatchedStatement {
+    /// Re-encoded statement.
+    pub(super) encoded: HexString,
+    /// Filters of the subscription matching this statement. Never empty, free of duplicates.
+    pub(super) filter_ids: Vec<FilterId>,
+}
+
+/// Which JSON-RPC API a subscription was created through, and therefore in which format its
+/// notifications are sent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SubscriptionKind {
+    /// `statement_subscribeStatement`, holding the single filter given at creation.
+    Legacy,
+    /// `statement_unstable_subscribe`, whose filters are attached and detached dynamically.
+    Unstable,
+}
+
+/// Statements one subscription accepted out of a batch.
+pub(super) struct MatchedSubscription {
+    pub(super) kind: SubscriptionKind,
+    pub(super) statements: Vec<MatchedStatement>,
+}
+
 /// One statement subscription: a set of topic filters sharing one deduplication cache.
 pub(super) struct StatementSubscription {
+    kind: SubscriptionKind,
+
     filters: hashbrown::HashMap<FilterId, TopicFilter, fnv::FnvBuildHasher>,
 
     /// Id given to the next filter attached to this subscription. Ids are never reused, so that a
@@ -180,8 +235,9 @@ pub(super) struct StatementSubscription {
 }
 
 impl StatementSubscription {
-    fn new(max_seen: Option<NonZero<usize>>) -> Self {
+    fn new(kind: SubscriptionKind, max_seen: Option<NonZero<usize>>) -> Self {
         Self {
+            kind,
             filters: hashbrown::HashMap::with_hasher(Default::default()),
             next_filter_id: 0,
             seen: max_seen
@@ -197,11 +253,13 @@ impl StatementSubscription {
         filter_id
     }
 
-    /// Returns whether at least one filter of this subscription matches `topics`.
-    fn matches(&self, topics: &[codec::Topic]) -> bool {
+    /// Returns the ids of all the filters of this subscription that match `topics`.
+    fn matching_filters(&self, topics: &[codec::Topic]) -> Vec<FilterId> {
         self.filters
-            .values()
-            .any(|topic_filter| topic_filter.matches(topics))
+            .iter()
+            .filter(|(_, topic_filter)| topic_filter.matches(topics))
+            .map(|(filter_id, _)| *filter_id)
+            .collect()
     }
 
     /// Returns the topics that at least one filter of this subscription references, and whether one
@@ -269,37 +327,68 @@ impl StatementSubscriptions {
         self.subscriptions.is_empty()
     }
 
-    /// Inserts a new subscription with no filter attached. Until a filter is added, it matches no
-    /// statement.
+    /// Inserts a new `statement_unstable_subscribe` subscription, with no filter attached. Until a
+    /// filter is added, it matches no statement.
     pub(super) fn insert_empty(&mut self, id: String, max_seen: Option<NonZero<usize>>) {
-        self.subscriptions
-            .insert(id, StatementSubscription::new(max_seen));
+        self.subscriptions.insert(
+            id,
+            StatementSubscription::new(SubscriptionKind::Unstable, max_seen),
+        );
     }
 
-    /// Inserts a new subscription holding `topic_filter` as its only filter.
+    /// Inserts a new `statement_subscribeStatement` subscription, holding `topic_filter` as its
+    /// only filter.
     pub(super) fn insert(
         &mut self,
         id: String,
         topic_filter: TopicFilter,
         max_seen: Option<NonZero<usize>>,
     ) {
-        self.subscriptions
-            .insert(id.clone(), StatementSubscription::new(max_seen));
-        self.add_filter(&id, topic_filter)
-            .expect("subscription was just inserted; qed");
+        self.subscriptions.insert(
+            id.clone(),
+            StatementSubscription::new(SubscriptionKind::Legacy, max_seen),
+        );
+        self.add_filter_of_any_kind(&id, topic_filter)
+            .expect("subscription was just inserted and holds no filter yet; qed");
     }
 
-    /// Attaches a filter to an existing subscription and updates the reverse index. Returns the id
-    /// identifying the filter within that subscription, or `None` if the subscription is unknown.
+    /// Attaches a filter to an existing `statement_unstable_subscribe` subscription and updates the
+    /// reverse index. Returns the id identifying the filter within that subscription.
+    ///
+    /// A legacy subscription is reported as unknown. Both APIs share this registry and a single
+    /// subscription-id namespace, so without this check a `statement_subscribeStatement` id would be
+    /// accepted here, and its holder would start receiving events of an API it never called.
     pub(super) fn add_filter(
         &mut self,
         sub_id: &str,
         topic_filter: TopicFilter,
-    ) -> Option<FilterId> {
+    ) -> Result<FilterId, AddFilterError> {
+        if self.subscriptions.get(sub_id).map(|sub| sub.kind) != Some(SubscriptionKind::Unstable) {
+            return Err(AddFilterError::UnknownSubscription);
+        }
+        self.add_filter_of_any_kind(sub_id, topic_filter)
+    }
+
+    /// [`StatementSubscriptions::add_filter`] without the subscription-kind check, so that a legacy
+    /// subscription can be given the single filter it is created with.
+    fn add_filter_of_any_kind(
+        &mut self,
+        sub_id: &str,
+        topic_filter: TopicFilter,
+    ) -> Result<FilterId, AddFilterError> {
         // Determined before handing the filter over to the subscription, which then owns it.
         let indexed_topics = indexed_topics(&topic_filter);
 
-        let filter_id = self.subscriptions.get_mut(sub_id)?.add_filter(topic_filter);
+        let filter_id = {
+            let sub = self
+                .subscriptions
+                .get_mut(sub_id)
+                .ok_or(AddFilterError::UnknownSubscription)?;
+            if sub.filters.len() >= MAX_FILTERS_PER_SUBSCRIPTION {
+                return Err(AddFilterError::LimitReached);
+            }
+            sub.add_filter(topic_filter)
+        };
 
         match indexed_topics {
             None => {
@@ -315,12 +404,65 @@ impl StatementSubscriptions {
             }
         }
 
-        Some(filter_id)
+        Ok(filter_id)
+    }
+
+    /// Detaches a filter from a `statement_unstable_subscribe` subscription and updates the reverse
+    /// index. Returns whether that filter was attached to that subscription.
+    ///
+    /// A legacy subscription answers `false`, for the reason given on
+    /// [`StatementSubscriptions::add_filter`]. Detaching its only filter would otherwise leave it
+    /// alive and matching nothing, with no way for its holder to tell.
+    pub(super) fn remove_filter(&mut self, sub_id: &str, filter_id: FilterId) -> bool {
+        let Some(sub) = self.subscriptions.get_mut(sub_id) else {
+            return false;
+        };
+        if !matches!(sub.kind, SubscriptionKind::Unstable) {
+            return false;
+        }
+        let Some(removed) = sub.filters.remove(&filter_id) else {
+            return false;
+        };
+
+        // The index entries of the removed filter are dropped only where no remaining filter of
+        // the subscription still references them.
+        let removed_topics = indexed_topics(&removed);
+        let (remaining_topics, remaining_wildcard) = sub.indexed_topics();
+
+        match removed_topics {
+            None => {
+                if !remaining_wildcard {
+                    self.wildcard.remove(sub_id);
+                }
+            }
+            Some(topics) => {
+                for topic in topics {
+                    if remaining_topics.contains(&topic) {
+                        continue;
+                    }
+                    if let Some(ids) = self.by_topic.get_mut(&topic) {
+                        ids.remove(sub_id);
+                        if ids.is_empty() {
+                            self.by_topic.remove(&topic);
+                        }
+                    }
+                }
+            }
+        }
+
+        true
     }
 
     /// Removes a subscription together with all its filters, and cleans up the reverse index.
-    /// Returns whether it existed.
-    pub(super) fn remove(&mut self, id: &str) -> bool {
+    /// Returns whether a subscription of that kind existed under this id.
+    ///
+    /// `kind` guards against one API tearing down the other's subscription, for the reason given on
+    /// [`StatementSubscriptions::add_filter`]. Cancelling an unstable subscription through the legacy
+    /// method would otherwise drop it without ever sending the `stop` event its holder waits for.
+    pub(super) fn remove(&mut self, id: &str, kind: SubscriptionKind) -> bool {
+        if self.subscriptions.get(id).map(|sub| sub.kind) != Some(kind) {
+            return false;
+        }
         let Some(sub) = self.subscriptions.remove(id) else {
             return false;
         };
@@ -357,15 +499,15 @@ impl StatementSubscriptions {
 
     /// Matches a batch of statements against the subscriptions.
     ///
-    /// Returns, for every subscription that accepts at least one statement, the list of re-encoded
-    /// matching statements. Uses the reverse index to only consider subscriptions that either match
-    /// everything or share a topic with the statement; the precise per-filter check and the
-    /// deduplication are then applied to each candidate. A statement matched by several filters of
-    /// the same subscription is reported once.
+    /// Returns, for every subscription that accepts at least one statement, those statements
+    /// together with the filters that matched each of them. Uses the reverse index to only consider
+    /// subscriptions that either match everything or share a topic with the statement; the precise
+    /// per-filter check and the deduplication are then applied to each candidate. A statement
+    /// matched by several filters of the same subscription is reported once, carrying all of them.
     pub(super) fn matching(
         &mut self,
         statements: &[([u8; 32], codec::Statement)],
-    ) -> Vec<(String, Vec<HexString>)> {
+    ) -> Vec<(String, MatchedSubscription)> {
         // Disjoint borrows: `subscriptions` is mutated while `by_topic`/`wildcard` are only read.
         let Self {
             subscriptions,
@@ -373,8 +515,8 @@ impl StatementSubscriptions {
             wildcard,
         } = self;
 
-        // Subscription ID -> its matching re-encoded statements.
-        let mut out: hashbrown::HashMap<&str, Vec<HexString>, fnv::FnvBuildHasher> =
+        // Subscription ID -> the statements it accepted.
+        let mut out: hashbrown::HashMap<&str, MatchedSubscription, fnv::FnvBuildHasher> =
             hashbrown::HashMap::with_hasher(Default::default());
         // Reused across statements to avoid reallocating.
         let mut candidates: hashbrown::HashSet<&str, fnv::FnvBuildHasher> =
@@ -395,20 +537,30 @@ impl StatementSubscriptions {
                 let sub = subscriptions
                     .get_mut(*id)
                     .expect("`candidates` is a subset of `subscriptions`; qed");
-                if sub.matches(&statement.topics) && sub.accept(hash) {
+                let filter_ids = sub.matching_filters(&statement.topics);
+                if !filter_ids.is_empty() && sub.accept(hash) {
                     let encoded = encoded.get_or_insert_with(|| {
                         HexString(
                             codec::encode_statement(statement)
                                 .expect("re-encoding a decoded statement always succeeds; qed"),
                         )
                     });
-                    out.entry(*id).or_default().push(encoded.clone());
+                    out.entry(*id)
+                        .or_insert_with(|| MatchedSubscription {
+                            kind: sub.kind,
+                            statements: Vec::new(),
+                        })
+                        .statements
+                        .push(MatchedStatement {
+                            encoded: encoded.clone(),
+                            filter_ids,
+                        });
                 }
             }
         }
 
         out.into_iter()
-            .map(|(id, matching)| (String::from(id), matching))
+            .map(|(id, matched)| (String::from(id), matched))
             .collect()
     }
 
@@ -475,6 +627,21 @@ mod tests {
         let mut subs = StatementSubscriptions::with_capacity(entries.len());
         for (id, filter, max_seen) in entries {
             subs.insert(id.to_string(), filter, max_seen);
+        }
+        subs
+    }
+
+    /// Builds one `statement_unstable_subscribe` subscription holding `filters`. Unstable
+    /// subscriptions are the only ones that can hold more than one filter.
+    fn make_unstable_subscription(
+        id: &str,
+        filters: Vec<TopicFilter>,
+        max_seen: Option<NonZero<usize>>,
+    ) -> StatementSubscriptions {
+        let mut subs = StatementSubscriptions::with_capacity(1);
+        subs.insert_empty(id.to_string(), max_seen);
+        for filter in filters {
+            subs.add_filter(id, filter).unwrap();
         }
         subs
     }
@@ -720,13 +887,13 @@ mod tests {
 
     #[test]
     fn accept_fresh_statement_passes() {
-        let mut sub = StatementSubscription::new(NonZero::new(8));
+        let mut sub = StatementSubscription::new(SubscriptionKind::Unstable, NonZero::new(8));
         assert!(sub.accept(&[0xbb; 32]));
     }
 
     #[test]
     fn accept_duplicate_returns_false() {
-        let mut sub = StatementSubscription::new(NonZero::new(8));
+        let mut sub = StatementSubscription::new(SubscriptionKind::Unstable, NonZero::new(8));
         let hash = [0xcc; 32];
         assert!(sub.accept(&hash));
         assert!(!sub.accept(&hash));
@@ -734,7 +901,7 @@ mod tests {
 
     #[test]
     fn accept_lru_eviction_allows_resubmit() {
-        let mut sub = StatementSubscription::new(NonZero::new(2));
+        let mut sub = StatementSubscription::new(SubscriptionKind::Unstable, NonZero::new(2));
         let h_a = [0xa; 32];
         let h_b = [0xb; 32];
         let h_c = [0xc; 32];
@@ -749,8 +916,8 @@ mod tests {
 
     #[test]
     fn dedup_is_per_subscription() {
-        let mut sub_a = StatementSubscription::new(NonZero::new(8));
-        let mut sub_b = StatementSubscription::new(NonZero::new(8));
+        let mut sub_a = StatementSubscription::new(SubscriptionKind::Unstable, NonZero::new(8));
+        let mut sub_b = StatementSubscription::new(SubscriptionKind::Unstable, NonZero::new(8));
         let hash = [0xee; 32];
 
         assert!(sub_a.accept(&hash));
@@ -760,23 +927,31 @@ mod tests {
     }
 
     #[test]
-    fn matches_when_any_filter_does() {
+    fn matching_filters_returns_every_match() {
         let t1 = [1u8; 32];
         let t2 = [2u8; 32];
-        let mut sub = StatementSubscription::new(None);
-        sub.add_filter(TopicFilter::match_any(vec![t1]).unwrap());
-        sub.add_filter(TopicFilter::match_any(vec![t2]).unwrap());
+        let mut sub = StatementSubscription::new(SubscriptionKind::Unstable, None);
+        let f1 = sub.add_filter(TopicFilter::match_any(vec![t1]).unwrap());
+        let f2 = sub.add_filter(TopicFilter::match_any(vec![t2]).unwrap());
+        let any = sub.add_filter(TopicFilter::Any);
 
-        assert!(sub.matches(&[t1]));
-        assert!(sub.matches(&[t2]));
-        assert!(!sub.matches(&[[9u8; 32]]));
+        let sorted = |mut ids: Vec<FilterId>| {
+            ids.sort_unstable();
+            ids
+        };
+
+        // Each topic matches its own filter plus the wildcard one.
+        assert_eq!(sorted(sub.matching_filters(&[t1])), sorted(vec![f1, any]));
+        assert_eq!(sorted(sub.matching_filters(&[t2])), sorted(vec![f2, any]));
+        // An unrelated topic matches the wildcard filter only.
+        assert_eq!(sub.matching_filters(&[[9u8; 32]]), vec![any]);
     }
 
     #[test]
     fn indexed_topics_gathers_every_filter() {
         let t1 = [1u8; 32];
         let t2 = [2u8; 32];
-        let mut sub = StatementSubscription::new(None);
+        let mut sub = StatementSubscription::new(SubscriptionKind::Unstable, None);
         sub.add_filter(TopicFilter::match_any(vec![t1]).unwrap());
         sub.add_filter(TopicFilter::match_all(vec![t2]).unwrap());
 
@@ -792,7 +967,7 @@ mod tests {
 
     #[test]
     fn filter_ids_are_never_reused() {
-        let mut sub = StatementSubscription::new(None);
+        let mut sub = StatementSubscription::new(SubscriptionKind::Unstable, None);
         let first = sub.add_filter(TopicFilter::Any);
         sub.filters.remove(&first);
         let second = sub.add_filter(TopicFilter::Any);
@@ -805,7 +980,7 @@ mod tests {
     }
 
     /// Collects the IDs of all subscriptions that matched at least once.
-    fn matched_ids(matches: &[(String, Vec<HexString>)]) -> Vec<String> {
+    fn matched_ids(matches: &[(String, MatchedSubscription)]) -> Vec<String> {
         let mut ids: Vec<String> = matches.iter().map(|(id, _)| id.clone()).collect();
         ids.sort();
         ids
@@ -896,7 +1071,7 @@ mod tests {
         let entry = batch_entry(0xaa, vec![t1]);
         let matches = subs.matching(core::slice::from_ref(&entry));
         assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].1.len(), 1);
+        assert_eq!(matches[0].1.statements.len(), 1);
 
         // The same statement hash is deduplicated and produces no further notification.
         let matches = subs.matching(&[entry]);
@@ -912,7 +1087,7 @@ mod tests {
         let matches = subs.matching(&[batch_entry(0x01, vec![t1]), batch_entry(0x02, vec![t1])]);
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0, "a");
-        assert_eq!(matches[0].1.len(), 2);
+        assert_eq!(matches[0].1.statements.len(), 2);
     }
 
     #[test]
@@ -921,8 +1096,8 @@ mod tests {
         let mut subs =
             make_subscriptions(vec![("a", TopicFilter::match_any(vec![t1]).unwrap(), None)]);
 
-        assert!(subs.remove("a"));
-        assert!(!subs.remove("a"));
+        assert!(subs.remove("a", SubscriptionKind::Legacy));
+        assert!(!subs.remove("a", SubscriptionKind::Legacy));
         assert!(subs.is_empty());
         // The topic entry must have been cleaned up, so a matching statement finds nothing.
         let matches = subs.matching(&[batch_entry(0xaa, vec![t1])]);
@@ -957,24 +1132,168 @@ mod tests {
     }
 
     #[test]
-    fn add_filter_on_unknown_subscription_returns_none() {
+    fn add_filter_on_unknown_subscription_is_reported() {
         let mut subs = make_subscriptions(vec![]);
-        assert!(subs.add_filter("nope", TopicFilter::Any).is_none());
+        assert_eq!(
+            subs.add_filter("nope", TopicFilter::Any),
+            Err(AddFilterError::UnknownSubscription)
+        );
+    }
+
+    #[test]
+    fn add_filter_stops_at_the_limit() {
+        let mut subs = StatementSubscriptions::with_capacity(1);
+        subs.insert_empty("a".to_string(), None);
+
+        for _ in 0..MAX_FILTERS_PER_SUBSCRIPTION {
+            subs.add_filter("a", TopicFilter::Any).unwrap();
+        }
+        assert_eq!(
+            subs.add_filter("a", TopicFilter::Any),
+            Err(AddFilterError::LimitReached)
+        );
+    }
+
+    #[test]
+    fn the_unstable_api_cannot_reach_a_legacy_subscription() {
+        let t1 = [1u8; 32];
+        let mut subs =
+            make_subscriptions(vec![("a", TopicFilter::match_any(vec![t1]).unwrap(), None)]);
+
+        // Both APIs share one id namespace, so a legacy id must read as unknown here rather than
+        // let its holder be widened, stripped, or torn down through the other API.
+        assert_eq!(
+            subs.add_filter("a", TopicFilter::Any),
+            Err(AddFilterError::UnknownSubscription)
+        );
+        assert!(!subs.remove_filter("a", FilterId(0)));
+        assert!(!subs.remove("a", SubscriptionKind::Unstable));
+
+        // The subscription is untouched: still alive, still matching only its own topic.
+        let matches = subs.matching(&[batch_entry(0x01, vec![t1])]);
+        assert_eq!(matched_ids(&matches), vec!["a".to_string()]);
+        let matches = subs.matching(&[batch_entry(0x02, vec![[9u8; 32]])]);
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn the_legacy_api_cannot_reach_an_unstable_subscription() {
+        let mut subs = make_unstable_subscription("a", vec![TopicFilter::Any], None);
+
+        // Cancelling it here would drop it without ever sending the `stop` event its holder waits
+        // for.
+        assert!(!subs.remove("a", SubscriptionKind::Legacy));
+        assert!(!subs.is_empty());
+        assert!(subs.remove("a", SubscriptionKind::Unstable));
+        assert!(subs.is_empty());
+    }
+
+    #[test]
+    fn remove_filter_keeps_the_topics_of_the_other_filters() {
+        let t1 = [1u8; 32];
+        let t2 = [2u8; 32];
+        let mut subs = StatementSubscriptions::with_capacity(1);
+        subs.insert_empty("a".to_string(), None);
+        let f1 = subs
+            .add_filter("a", TopicFilter::match_any(vec![t1, t2]).unwrap())
+            .unwrap();
+        subs.add_filter("a", TopicFilter::match_any(vec![t2]).unwrap())
+            .unwrap();
+
+        assert!(subs.remove_filter("a", f1));
+        // `t2` is still referenced by the remaining filter, `t1` is not.
+        let matches = subs.matching(&[batch_entry(0x01, vec![t2])]);
+        assert_eq!(matched_ids(&matches), vec!["a".to_string()]);
+        let matches = subs.matching(&[batch_entry(0x02, vec![t1])]);
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn remove_filter_reports_unknown_ids() {
+        let mut subs = StatementSubscriptions::with_capacity(1);
+        subs.insert_empty("a".to_string(), None);
+        let f1 = subs.add_filter("a", TopicFilter::Any).unwrap();
+
+        assert!(!subs.remove_filter("nope", f1));
+        assert!(subs.remove_filter("a", f1));
+        // Removing twice reports that nothing was attached anymore.
+        assert!(!subs.remove_filter("a", f1));
+    }
+
+    #[test]
+    fn matching_reports_the_filters_that_matched() {
+        let t1 = [1u8; 32];
+        let t2 = [2u8; 32];
+        let mut subs = StatementSubscriptions::with_capacity(1);
+        subs.insert_empty("a".to_string(), None);
+        let f1 = subs
+            .add_filter("a", TopicFilter::match_any(vec![t1]).unwrap())
+            .unwrap();
+        let f2 = subs
+            .add_filter("a", TopicFilter::match_any(vec![t2]).unwrap())
+            .unwrap();
+
+        // Both filters match, so both ids are reported for the single accepted statement.
+        let matches = subs.matching(&[batch_entry(0x01, vec![t1, t2])]);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].1.statements.len(), 1);
+        let mut filter_ids = matches[0].1.statements[0].filter_ids.clone();
+        filter_ids.sort_unstable();
+        let mut expected = vec![f1, f2];
+        expected.sort_unstable();
+        assert_eq!(filter_ids, expected);
+    }
+
+    #[test]
+    fn matching_reports_the_subscription_kind() {
+        let t1 = [1u8; 32];
+        let mut subs = make_subscriptions(vec![(
+            "legacy",
+            TopicFilter::match_any(vec![t1]).unwrap(),
+            None,
+        )]);
+        subs.insert_empty("unstable".to_string(), None);
+        subs.add_filter("unstable", TopicFilter::match_any(vec![t1]).unwrap())
+            .unwrap();
+
+        let matches = subs.matching(&[batch_entry(0x01, vec![t1])]);
+        for (id, matched) in matches {
+            match id.as_str() {
+                "legacy" => assert_eq!(matched.kind, SubscriptionKind::Legacy),
+                "unstable" => assert_eq!(matched.kind, SubscriptionKind::Unstable),
+                other => panic!("unexpected subscription {other}"),
+            }
+        }
+    }
+
+    #[test]
+    fn filter_id_string_round_trip() {
+        let mut sub = StatementSubscription::new(SubscriptionKind::Unstable, None);
+        let filter_id = sub.add_filter(TopicFilter::Any);
+        assert_eq!(
+            FilterId::from_string(&filter_id.to_string()),
+            Some(filter_id)
+        );
+        assert_eq!(FilterId::from_string("not-a-number"), None);
     }
 
     #[test]
     fn matching_accepts_a_statement_matched_by_any_filter() {
         let t1 = [1u8; 32];
         let t2 = [2u8; 32];
-        let mut subs =
-            make_subscriptions(vec![("a", TopicFilter::match_any(vec![t1]).unwrap(), None)]);
-        subs.add_filter("a", TopicFilter::match_any(vec![t2]).unwrap())
-            .unwrap();
+        let mut subs = make_unstable_subscription(
+            "a",
+            vec![
+                TopicFilter::match_any(vec![t1]).unwrap(),
+                TopicFilter::match_any(vec![t2]).unwrap(),
+            ],
+            None,
+        );
 
         // Each filter pulls in the statements of its own topic.
         let matches = subs.matching(&[batch_entry(0x01, vec![t1]), batch_entry(0x02, vec![t2])]);
         assert_eq!(matched_ids(&matches), vec!["a".to_string()]);
-        assert_eq!(matches[0].1.len(), 2);
+        assert_eq!(matches[0].1.statements.len(), 2);
 
         // A statement matching none of the filters is not accepted.
         let matches = subs.matching(&[batch_entry(0x03, vec![[9u8; 32]])]);
@@ -985,19 +1304,20 @@ mod tests {
     fn matching_reports_a_statement_once_per_subscription() {
         let t1 = [1u8; 32];
         let t2 = [2u8; 32];
-        let mut subs = make_subscriptions(vec![(
+        let mut subs = make_unstable_subscription(
             "a",
-            TopicFilter::match_any(vec![t1]).unwrap(),
+            vec![
+                TopicFilter::match_any(vec![t1]).unwrap(),
+                TopicFilter::match_any(vec![t2]).unwrap(),
+                TopicFilter::Any,
+            ],
             NonZero::new(8),
-        )]);
-        subs.add_filter("a", TopicFilter::match_any(vec![t2]).unwrap())
-            .unwrap();
-        subs.add_filter("a", TopicFilter::Any).unwrap();
+        );
 
         // All three filters match, yet the statement is reported a single time.
         let matches = subs.matching(&[batch_entry(0xaa, vec![t1, t2])]);
         assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].1.len(), 1);
+        assert_eq!(matches[0].1.statements.len(), 1);
     }
 
     #[test]
@@ -1014,20 +1334,24 @@ mod tests {
 
         let matches = subs.matching(&[batch_entry(0xaa, vec![t1, t2])]);
         assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].1.len(), 1);
+        assert_eq!(matches[0].1.statements.len(), 1);
     }
 
     #[test]
     fn remove_cleans_up_every_filter() {
         let t1 = [1u8; 32];
         let t2 = [2u8; 32];
-        let mut subs =
-            make_subscriptions(vec![("a", TopicFilter::match_any(vec![t1]).unwrap(), None)]);
-        subs.add_filter("a", TopicFilter::match_any(vec![t2]).unwrap())
-            .unwrap();
-        subs.add_filter("a", TopicFilter::Any).unwrap();
+        let mut subs = make_unstable_subscription(
+            "a",
+            vec![
+                TopicFilter::match_any(vec![t1]).unwrap(),
+                TopicFilter::match_any(vec![t2]).unwrap(),
+                TopicFilter::Any,
+            ],
+            None,
+        );
 
-        assert!(subs.remove("a"));
+        assert!(subs.remove("a", SubscriptionKind::Unstable));
         assert!(subs.is_empty());
         // Neither the topic entries nor the wildcard entry may survive.
         let matches = subs.matching(&[batch_entry(0xaa, vec![t1]), batch_entry(0xbb, vec![t2])]);
@@ -1039,10 +1363,14 @@ mod tests {
         let config = test_config();
         let t1 = [1u8; 32];
         let t2 = [2u8; 32];
-        let mut subs =
-            make_subscriptions(vec![("a", TopicFilter::match_any(vec![t1]).unwrap(), None)]);
-        subs.add_filter("a", TopicFilter::match_any(vec![t2]).unwrap())
-            .unwrap();
+        let subs = make_unstable_subscription(
+            "a",
+            vec![
+                TopicFilter::match_any(vec![t1]).unwrap(),
+                TopicFilter::match_any(vec![t2]).unwrap(),
+            ],
+            None,
+        );
 
         let filter = subs.build_combined_affinity_filter(&config);
         assert!(filter.contains(&t1));
@@ -1053,9 +1381,11 @@ mod tests {
     fn affinity_matches_all_when_one_filter_is_any() {
         let config = test_config();
         let t1 = [1u8; 32];
-        let mut subs =
-            make_subscriptions(vec![("a", TopicFilter::match_any(vec![t1]).unwrap(), None)]);
-        subs.add_filter("a", TopicFilter::Any).unwrap();
+        let subs = make_unstable_subscription(
+            "a",
+            vec![TopicFilter::match_any(vec![t1]).unwrap(), TopicFilter::Any],
+            None,
+        );
 
         let filter = subs.build_combined_affinity_filter(&config);
         assert!(filter.contains(&[99u8; 32]));


### PR DESCRIPTION
PR series, in merge order:

- #3335
- #3336
- #3337 <-- CURRENT
- #3338
- #3339

Adds `statement_unstable_subscribe` / `unsubscribe`, `statement_unstable_add_filter` / `remove_filter`, and the `statement_unstable_subscribeEvent` notification from [json-rpc-interface-spec#185](https://github.com/paritytech/json-rpc-interface-spec/pull/185). Part 3/5 of the series splitting #3330.

One registry serves both APIs. Each API can only reach its own subscriptions: both share a single id namespace, so without that check a legacy id passed to `add_filter` would start receiving events of an API it never called, and an unstable id passed to the legacy unsubscribe would be dropped without the `stop` event its holder waits for.

Filters are capped at 128 per subscription, matching polkadot-sdk; `add_filter` answers `{"result":"limitReached"}` beyond that, and `-32801` for an unknown subscription. `topicFilter` accepts only `"any"` and `{"matchAll": [1..4 topics]}` — `matchAny` and an empty `matchAll` are turned down with `-32602`, as in polkadot-sdk. Both remain accepted by the legacy API, whose behavior is unchanged.

`add_filter` emits `replayDone` immediately over an empty snapshot, `replayStatements` never being emitted: a light client keeps no statement store, so the replay is legitimately empty. Peers then resend everything matching the updated affinity filter, and the per-subscription deduplication drops what was already delivered, so only unseen statements reach the client through `newStatements`, each carrying the ids of the filters that matched it.

`-32800` is never returned, as the number of statement subscriptions per client is not capped. The specification requires accepting at least 2 and only permits erroring beyond that, so this is compliant.

Divergences from what the specification assumes of a full node, to raise on the spec PR (see #3330 for the discussion):

1. `replayDone` arrives before the effective backlog, which arrives afterwards through `newStatements`, delayed by up to the affinity update interval.
2. Adding a filter never re-announces already-delivered statements under the new filter id, since re-emitting them through `newStatements` is what the at-most-once guarantee forbids. A complete backlog for a filter requires a fresh subscription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

