### PR TITLE
executor: revert multi_miller_loop length mismatch check

### DIFF
--- a/lib/src/executor/host/elliptic_curves.rs
+++ b/lib/src/executor/host/elliptic_curves.rs
@@ -149,8 +149,8 @@ pub(super) fn bls12_381_msm_g2(
 
 /// `ext_host_calls_bls12_381_multi_miller_loop_version_1`.
 ///
-/// Miller loop over encoded `Vec<G1Affine>` and `Vec<G2Affine>` of equal
-/// lengths, producing an encoded target field element.
+/// Miller loop over encoded `Vec<G1Affine>` and `Vec<G2Affine>`, producing
+/// an encoded target field element.
 pub(super) fn bls12_381_multi_miller_loop(
     g1: &[u8],
     g2: &[u8],
@@ -158,9 +158,6 @@ pub(super) fn bls12_381_multi_miller_loop(
 ) -> Result<Vec<u8>, u32> {
     let g1 = decode::<Vec<ark_bls12_381::G1Affine>>(g1)?;
     let g2 = decode::<Vec<ark_bls12_381::G2Affine>>(g2)?;
-    if g1.len() != g2.len() {
-        return Err(ERROR_LENGTH_MISMATCH);
-    }
     let result = Bls12_381::multi_miller_loop(g1, g2);
     encode(&result.0, out_len)
 }

--- a/lib/src/executor/host/tests/elliptic_curves.rs
+++ b/lib/src/executor/host/tests/elliptic_curves.rs
@@ -266,22 +266,6 @@ fn bls_multi_miller_loop_matches_upstream_vector() {
 }
 
 #[test]
-fn bls_multi_miller_loop_length_mismatch_returns_error() {
-    // Two G1 points with a single G2 point.
-    let one_g2 = &hex::decode(MSM_G2_BASES).unwrap()[..200];
-    let mut one_g2 = one_g2.to_vec();
-    one_g2[0] = 1;
-    assert_eq!(
-        elliptic_curves::bls12_381_multi_miller_loop(
-            &hex::decode(MSM_G1_BASES).unwrap(),
-            &one_g2,
-            576
-        ),
-        Err(elliptic_curves::ERROR_LENGTH_MISMATCH)
-    );
-}
-
-#[test]
 fn bls_final_exponentiation_matches_upstream_vector() {
     let out =
         elliptic_curves::bls12_381_final_exponentiation(&hex::decode(MML_OUT).unwrap()).unwrap();


### PR DESCRIPTION
Reverts commit 24fd88d ("Add length mismatch fix") from #3331.

## What changes

- `bls12_381_multi_miller_loop` no longer checks that the decoded `Vec<G1Affine>`
  and `Vec<G2Affine>` have equal lengths, and no longer returns
  `ERROR_LENGTH_MISMATCH` (code 3) when they differ.
- Drops the accompanying test `bls_multi_miller_loop_length_mismatch_returns_error`.
- Restores the original doc comment on the function.