### PR TITLE
move chain_getBlock justifications out of the block object to fix relayer decode issue

### DIFF
--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -1403,11 +1403,7 @@ impl serde::Serialize for Block {
     where
         S: serde::Serializer,
     {
-        // The shape below must match `sp_runtime::generic::SignedBlock`, whose `justifications`
-        // field is a *sibling* of `block` and not one of its members. Both `SignedBlock` and the
-        // inner `Block` are annotated with `deny_unknown_fields`, so putting `justifications` in
-        // the wrong object makes the response impossible to decode for Substrate-based clients,
-        // even when there is no justification to report.
+        // The shape below must match `sp_runtime::generic::SignedBlock`.
         #[derive(serde::Serialize)]
         struct SerdeBlock<'a> {
             block: SerdeBlockInner<'a>,

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -1403,28 +1403,33 @@ impl serde::Serialize for Block {
     where
         S: serde::Serializer,
     {
+        // The shape below must match `sp_runtime::generic::SignedBlock`, whose `justifications`
+        // field is a *sibling* of `block` and not one of its members. Both `SignedBlock` and the
+        // inner `Block` are annotated with `deny_unknown_fields`, so putting `justifications` in
+        // the wrong object makes the response impossible to decode for Substrate-based clients,
+        // even when there is no justification to report.
         #[derive(serde::Serialize)]
         struct SerdeBlock<'a> {
             block: SerdeBlockInner<'a>,
+            justifications: Option<Vec<Vec<Vec<u8>>>>,
         }
 
         #[derive(serde::Serialize)]
         struct SerdeBlockInner<'a> {
             extrinsics: &'a [HexString],
             header: &'a Header,
-            justifications: Option<Vec<Vec<Vec<u8>>>>,
         }
 
         SerdeBlock {
             block: SerdeBlockInner {
                 extrinsics: &self.extrinsics,
                 header: &self.header,
-                justifications: self.justifications.as_ref().map(|list| {
-                    list.iter()
-                        .map(|(e, j)| vec![e.to_vec(), j.clone()])
-                        .collect()
-                }),
             },
+            justifications: self.justifications.as_ref().map(|list| {
+                list.iter()
+                    .map(|(e, j)| vec![e.to_vec(), j.clone()])
+                    .collect()
+            }),
         }
         .serialize(serializer)
     }
@@ -1795,6 +1800,50 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&evt).unwrap(),
             r#"{"event":"streamDone"}"#
+        );
+    }
+
+    /// Builds a `chain_getBlock` response with an empty header and the given justifications.
+    fn block_response(justifications: Option<Vec<([u8; 4], Vec<u8>)>>) -> String {
+        serde_json::to_string(&super::Block {
+            extrinsics: Vec::new(),
+            header: super::Header {
+                parent_hash: super::HashHexString([0; 32]),
+                extrinsics_root: super::HashHexString([0; 32]),
+                state_root: super::HashHexString([0; 32]),
+                number: 0,
+                digest: super::HeaderDigest { logs: Vec::new() },
+            },
+            justifications,
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn chain_get_block_justifications_are_a_sibling_of_block() {
+        // The wire type is `sp_runtime::generic::SignedBlock`, in which `justifications` sits
+        // next to `block` rather than inside it. Both that struct and the inner block are
+        // `deny_unknown_fields`, so the exact placement is what makes the response decodable;
+        // it is therefore pinned here with a literal JSON assertion.
+        assert_eq!(
+            block_response(None),
+            r#"{"block":{"extrinsics":[],"header":{"parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000","extrinsicsRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","stateRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","number":"0x0","digest":{"logs":[]}}},"justifications":null}"#
+        );
+    }
+
+    #[test]
+    fn chain_get_block_justification_encoding() {
+        // A justification is a `(ConsensusEngineId, Vec<u8>)` pair, both serialized as arrays of
+        // bytes, matching `sp_runtime::Justifications`.
+        let json = block_response(Some(vec![(*b"FRNK", vec![1, 2, 3])]));
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(
+            parsed["block"].get("justifications").is_none(),
+            "justifications must not be nested inside `block`"
+        );
+        assert_eq!(
+            parsed["justifications"],
+            serde_json::json!([[[70, 82, 78, 75], [1, 2, 3]]])
         );
     }
 }

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- `chain_getBlock` no longer returns the `justifications` field nested inside the `block` object. The response type is `sp_runtime::generic::SignedBlock`, in which `justifications` is a sibling of `block`, and both that struct and the inner block are `deny_unknown_fields`, so the misplaced field made the response impossible to decode for Substrate-based JSON-RPC clients even when there was no justification to report.
+
 ## 3.4.1 - 2026-08-13
 
 ### Fixed


### PR DESCRIPTION
This is prerequisite for paritytech/parity-bridges-common#3270 (light-client bridge relayers),
and for paritytech/smoldot#3288 (exposing GRANDPA justifications over JSON-RPC).

## Why

The relayer's job is to submit a finalized source-chain header **plus its SCALE-encoded GRANDPA justification** to a bridge pallet on the target chain, which re-verifies GRANDPA on-chain.
When the Polkadot ↔ Kusama `substrate-relay` is ran against an embedded smoldot light client, it is found that the smoldot response does not decode.

`chain_getBlock` is one of the two paths a justification would have to travel over (the other being a `grandpa_subscribeJustifications` feed), and its response shape is wrong in a way that makes it un-decodable for the client the relayer uses.

### What is required in smoldot

`chain_getBlock`'s response type is `sp_runtime::generic::SignedBlock`:

```rust
#[serde(deny_unknown_fields)]
pub struct SignedBlock<Block> {
    pub block: Block,                          // itself deny_unknown_fields
    pub justifications: Option<Justifications>,
}
```

justifications is a sibling of block, not one of its members, and both SignedBlock and the inner Block carry deny_unknown_fields. smoldot serialized it nested inside block, which fails to decode twice over: the inner block rejects the
unknown justifications key, and the outer struct never sees the field it expects.

Because `deny_unknown_fields` rejects the key, not a value, this broke even when there was nothing to report — and smoldot always reported null here, so the field was never populated and the misplacement went unnoticed. Any Substrate-based JSON-RPC client (subxt, substrate-relay, anything decoding into sp_runtime types) got a deserialization error rather than an empty justification list.

So before a justification can be delivered over chain_getBlock at all, the envelope has to be the shape Substrate clients expect.

How this PR solves it:

- serde::Serialize for methods::Block now emits justifications as a sibling of   block, matching SignedBlock. block contains only header and extrinsics.
- The Block struct itself, and every other API, are unchanged — this is purely the   wire encoding, so there is no impact on callers inside smoldot.
- A comment at the serializer records why the placement matters, so it doesn't get   "tidied" back into the block object later.

The justification encoding is unchanged and already matched `sp_runtime::Justifications` — a list of (`ConsensusEngineId, Vec<u8>`) pairs, each serialized as a two-element array of byte arrays.

Result

`chain_getBlock` responses now decode into `sp_runtime::generic::SignedBlock`, this lets the light-client relayer of #3270 read a block , and what makes the justifications field a usable delivery path once #3288 starts populating it.