### PR TITLE
ci: bump ci-unified image to drop expired bullseye-security apt source

### DIFF
--- a/.github/workflows/zombienet.yml
+++ b/.github/workflows/zombienet.yml
@@ -164,6 +164,11 @@ jobs:
         run: |
           set -euo pipefail
           npm ci
+          # Debian 11 LTS ended on 2026-08-31 and bullseye-security is no
+          # longer re-signed, so apt-get update inside the bullseye-based
+          # ci-unified image fails on its expired InRelease. Drop the source
+          # until the image moves to a supported Debian release.
+          sed -i '/bullseye-security/d' /etc/apt/sources.list
           npx playwright install --with-deps chromium
 
       # Pull binaries from polkadot-sdk's per-merge CI images (see

--- a/.github/workflows/zombienet.yml
+++ b/.github/workflows/zombienet.yml
@@ -164,11 +164,6 @@ jobs:
         run: |
           set -euo pipefail
           npm ci
-          # Debian 11 LTS ended on 2026-08-31 and bullseye-security is no
-          # longer re-signed, so apt-get update inside the bullseye-based
-          # ci-unified image fails on its expired InRelease. Drop the source
-          # until the image moves to a supported Debian release.
-          sed -i '/bullseye-security/d' /etc/apt/sources.list
           npx playwright install --with-deps chromium
 
       # Pull binaries from polkadot-sdk's per-merge CI images (see

--- a/.github/zombienet-env
+++ b/.github/zombienet-env
@@ -5,7 +5,7 @@ ZOMBIE_PROVIDER=native
 
 # Container image that executes the test harness. Pinned for reproducibility;
 # bump together with polkadot-sdk's `.github/env` to stay on a common toolchain.
-ZOMBIENET_SDK_IMAGE_FOR_NATIVE=docker.io/paritytech/ci-unified:bullseye-1.93.0-2026-01-27-v202604100059
+ZOMBIENET_SDK_IMAGE_FOR_NATIVE=docker.io/paritytech/ci-unified:bullseye-1.93.0-2026-01-27-v202609081126
 
 # Parity self-hosted runner pool used by polkadot-sdk's zombienet tests.
 ZOMBIENET_SDK_DEFAULT_RUNNER_FOR_NATIVE=parity-zombienet-native-default


### PR DESCRIPTION
All zombienet jobs fail in "Install e2e-tests JS deps and Chromium" since 2026-09-07:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired
```

Debian 11 LTS ended on 2026-08-31 (https://www.debian.org/News/2026/20260831) and bullseye-security is no longer re-signed, so `apt-get update` in the bullseye-based `ci-unified` image fails.

Example: https://github.com/paritytech/smoldot/actions/runs/34208869540/job/102004862689

Fix: bump `ZOMBIENET_SDK_IMAGE_FOR_NATIVE` to `ci-unified:bullseye-1.93.0-2026-01-27-v202609081126`, which ships without the bullseye-security source. Same toolchain otherwise (rustc 1.93.0, Debian 11).

The image is still Debian 11; moving `ci-unified` to a supported release is a separate infra task.
