### PR TITLE
npm smoldot v3.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light-wasm"
-version = "3.4.1"
+version = "3.5.0"
 dependencies = [
  "async-lock",
  "async-task",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -7498,7 +7498,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "ark-bls12-381 0.6.0",
  "ark-ec 0.6.0",
@@ -7579,7 +7579,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smoldot 2.2.0",
+ "smoldot 3.0.0",
  "tempfile",
  "tokio",
  "zombienet-sdk",

--- a/benchmarks/js/package-lock.json
+++ b/benchmarks/js/package-lock.json
@@ -11,7 +11,7 @@
     },
     "../../wasm-node/javascript": {
       "name": "smoldot",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -7458,7 +7458,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "ark-bls12-381 0.6.0",
  "ark-ec 0.6.0",
@@ -7524,7 +7524,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "smoldot 2.2.0",
+ "smoldot 3.0.0",
  "tempfile",
  "tokio",
  "zombienet-sdk",

--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -11,7 +11,7 @@
     },
     "../wasm-node/javascript": {
       "name": "smoldot",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/full-node/Cargo.toml
+++ b/full-node/Cargo.toml
@@ -37,6 +37,6 @@ serde_json = { version = "1.0.104", default-features = false, features = ["std"]
 siphasher = { version = "1.0.1", default-features = false }
 soketto = { version = "0.8.0", features = ["deflate"] }
 smol = "2.0.0"
-smoldot = { version = "2.0.0", path = "../lib", default-features = false, features = ["database-sqlite", "std", "wasmtime"] }
+smoldot = { version = "3.0.0", path = "../lib", default-features = false, features = ["database-sqlite", "std", "wasmtime"] }
 terminal_size = "0.4.0"
 zeroize = { version = "1.7.0", default-features = false, features = ["alloc"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot"
-version = "2.2.0"
+version = "3.0.0"
 description = "Primitives to build a client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot"
 keywords = ["blockchain", "peer-to-peer"]

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light"
-version = "2.0.1"
+version = "2.0.2"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot-light"
 authors.workspace = true
@@ -37,7 +37,7 @@ serde = { version = "1.0.183", default-features = false, features = ["alloc", "d
 serde_json = { version = "1.0.104", default-features = false, features = ["alloc"] }
 siphasher = { version = "1.0.1", default-features = false }
 slab = { version = "0.4.8", default-features = false }
-smoldot = { version = "2.0.0", path = "../lib", default-features = false }
+smoldot = { version = "3.0.0", path = "../lib", default-features = false }
 zeroize = { version = "1.7.0", default-features = false, features = ["alloc"] }
 
 # `std` feature

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,9 +2,19 @@
 
 ## Unreleased
 
+## 3.5.0 - 2026-09-09
+
+### Changed
+
+- `statement_submit` now validates statements the way a full node does before broadcasting them, running the expiry, size and proof checks in the same order as polkadot-sdk's statement store. Statements that fail are answered with `{"status":"invalid","reason":...}` where the reason is `alreadyExpired`, `encodingTooLarge` or `noProof`, so a caller gets the same answer smoldot and a full node would give. A payload that does not decode, or a statement that no connected peer accepted, is now a JSON-RPC error with code `7001` (polkadot-sdk's statement-store error code) instead of a successful result. Broadcast success is counted on statements actually sent, so a gossip peer with no open statement substream no longer counts as a delivery. Note that a small opaque `expiry` value is now read as a UNIX timestamp and answered with `alreadyExpired`. ([#3344](https://github.com/paritytech/smoldot/pull/3344); fixes [#3349](https://github.com/paritytech/smoldot/issues/3349))
+
 ### Fixed
 
-- `chain_getBlock` no longer returns the `justifications` field nested inside the `block` object. The response type is `sp_runtime::generic::SignedBlock`, in which `justifications` is a sibling of `block`, and both that struct and the inner block are `deny_unknown_fields`, so the misplaced field made the response impossible to decode for Substrate-based JSON-RPC clients even when there was no justification to report.
+- `chain_getBlock` no longer returns the `justifications` field nested inside the `block` object. The response type is `sp_runtime::generic::SignedBlock`, in which `justifications` is a sibling of `block`, and both that struct and the inner block are `deny_unknown_fields`, so the misplaced field made the response impossible to decode for Substrate-based JSON-RPC clients even when there was no justification to report. ([#3363](https://github.com/paritytech/smoldot/pull/3363); related to [#3288](https://github.com/paritytech/smoldot/issues/3288))
+- WebRTC connections to a peer that restarted are now recovered. A restarted peer leaves the browser's `RTCPeerConnection` in the `connected` state with every data channel dead, so no reset was ever reported and the connection stayed up but unusable. Each outbound substream open now has a 20 second deadline; when it expires the connection is reset and the peer is dialed again. ([#3361](https://github.com/paritytech/smoldot/pull/3361))
+- Fix a panic in the connection task when a notifications substream close, or an outgoing notification, crosses a reset of that substream by the remote. ([#3361](https://github.com/paritytech/smoldot/pull/3361))
+- No longer ban a peer for sending a justification that targets a block too far ahead of the local finalized block. The justification is valid, the local node just has not caught up yet, so it is treated the same as an unknown target block. ([#3361](https://github.com/paritytech/smoldot/pull/3361))
+- Update the `arkworks` crates from 0.5 to 0.6, matching polkadot-sdk. A malformed input to the elliptic curve host functions whose length prefix claimed a huge number of elements made `arkworks` 0.5 preallocate and abort the process; 0.6 decodes element by element and returns a decode error instead. ([#3356](https://github.com/paritytech/smoldot/pull/3356))
 
 ## 3.4.1 - 2026-08-13
 

--- a/wasm-node/javascript/package-lock.json
+++ b/wasm-node/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smoldot",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smoldot",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/wasm-node/javascript/package.json
+++ b/wasm-node/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoldot",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Light client that connects to Polkadot and Substrate-based blockchains",
   "contributors": [
     "Parity Technologies <admin@parity.io>",

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light-wasm"
-version = "3.4.1"
+version = "3.5.0"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 authors.workspace = true
 license.workspace = true
@@ -29,5 +29,5 @@ hashbrown = { version = "0.16.0", default-features = false }
 nom = { version = "8.0.0", default-features = false }
 pin-project = "1.1.5"
 slab = { version = "0.4.8", default-features = false }
-smoldot = { version = "2.0.0", path = "../../lib", default-features = false }
+smoldot = { version = "3.0.0", path = "../../lib", default-features = false }
 smoldot-light = { version = "2.0.0", path = "../../light-base", default-features = false }


### PR DESCRIPTION
This is to:
- publish `smoldot-v3.5.0` npm.
- publish crates `smoldot-light v2.0.2`, `smoldot v3.0.0`

## Changes

### Changed

- `statement_submit` validates statements like a full node (expiry, size, proof) and answers `invalid` with `alreadyExpired`, `encodingTooLarge` or `noProof`. Undecodable payloads and statements no peer accepted are now JSON-RPC error `7001`. ([#3344](https://github.com/paritytech/smoldot/pull/3344); fixes [#3349](https://github.com/paritytech/smoldot/issues/3349))

### Fixed

- `chain_getBlock` returns `justifications` as a sibling of `block`, matching `SignedBlock`, so Substrate clients can decode the response. ([#3363](https://github.com/paritytech/smoldot/pull/3363); related to [#3288](https://github.com/paritytech/smoldot/issues/3288))
- Recover WebRTC connections after a peer restart: substream opens time out after 20 s and the connection is reset and re-dialed. ([#3361](https://github.com/paritytech/smoldot/pull/3361))
- Fix a connection task panic when a substream close or notification crosses a remote reset. ([#3361](https://github.com/paritytech/smoldot/pull/3361))
- No longer ban peers for justifications that target a block too far ahead. ([#3361](https://github.com/paritytech/smoldot/pull/3361))
- Bump `arkworks` to 0.6; a malformed elliptic curve host function input no longer aborts the process. ([#3356](https://github.com/paritytech/smoldot/pull/3356))