### PR TITLE
Expose GRANDPA finality justifications over JSON-RPC

### DIFF
--- a/lib/src/finality.rs
+++ b/lib/src/finality.rs
@@ -26,4 +26,5 @@
 //! that they are known by the node.
 
 pub mod decode;
+pub mod encode;
 pub mod verify;

--- a/lib/src/finality/encode.rs
+++ b/lib/src/finality/encode.rs
@@ -1,0 +1,514 @@
+// Smoldot
+// Copyright (C) 2019-2022  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Encoding of Grandpa finality proofs.
+//!
+//! Commits and justifications carry the same information - a round number, a target block and
+//! signed pre-commits - and differ only in their encoding and in how they are transmitted:
+//! commits are gossiped, justifications are stored by full nodes and served over block requests
+//! and warp sync. Consumers that verify Grandpa on their own expect the justification encoding,
+//! which this module produces from a gossiped commit.
+
+use crate::{finality::decode, header, util};
+
+use alloc::{collections::BTreeSet, vec::Vec};
+
+/// Turns a SCALE-encoded Grandpa commit into a SCALE-encoded Grandpa justification targeting the
+/// same block.
+///
+/// The commit **must** have been verified beforehand (see
+/// [`crate::finality::verify::verify_commit`]), as this function performs no verification
+/// of its own beyond decoding.
+///
+/// # Vote ancestries
+///
+/// A commit assumes that its receiver already knows the blocks that the pre-commits target, while
+/// a justification must be verifiable in isolation and therefore also carries the headers linking
+/// each pre-commit target back to the finalized block: the `votes_ancestries` field.
+/// `scale_encoded_header_by_hash` provides those headers, returning `None` for a block the caller
+/// doesn't know about.
+///
+/// Pre-commits that can't be linked back are **left out**: a verifier gives no voting weight to a
+/// pre-commit whose ancestry it can't check, so dropping one doesn't change whether the
+/// justification is accepted, and keeps it smaller. Pre-commits targeting the finalized block
+/// itself, which is the vast majority of them, need no ancestry at all.
+pub fn grandpa_commit_to_justification(
+    scale_encoded_commit: &[u8],
+    block_number_bytes: usize,
+    mut scale_encoded_header_by_hash: impl FnMut(&[u8; 32]) -> Option<Vec<u8>>,
+) -> Result<Vec<u8>, CommitToJustificationError> {
+    let commit = decode::decode_grandpa_commit(scale_encoded_commit, block_number_bytes)
+        .map_err(|_| CommitToJustificationError::CommitDecode)?;
+
+    // The commit stores the signatures and public keys of the pre-commits separately from the
+    // pre-commits themselves, while the justification stores them inline. The two lists
+    // consequently must have the same length.
+    if commit.precommits.len() != commit.auth_data.len() {
+        return Err(CommitToJustificationError::PrecommitsAuthDataMismatch);
+    }
+
+    // SCALE-encoded headers of the `votes_ancestries` field, and the hashes of the blocks that
+    // they correspond to. A block is added to this list at most once, and only if it is on the
+    // path between a pre-commit target and the target of the commit. Verifiers reject
+    // justifications that carry a header that no pre-commit needs.
+    let mut votes_ancestries = Vec::new();
+    let mut votes_ancestries_hashes = BTreeSet::new();
+
+    // SCALE-encoded pre-commits that are kept, and how many of them there are. Built separately
+    // from `out`, as the number of pre-commits isn't known until the ancestry of all of them has
+    // been resolved.
+    let mut precommits =
+        Vec::with_capacity(commit.precommits.len() * (32 + block_number_bytes + 64 + 32));
+    let mut num_precommits = 0;
+
+    for (precommit, (signature, authority_public_key)) in
+        commit.precommits.iter().zip(commit.auth_data.iter())
+    {
+        match ancestry_of(
+            precommit.target_hash,
+            precommit.target_number,
+            commit.target_hash,
+            commit.target_number,
+            block_number_bytes,
+            &votes_ancestries_hashes,
+            &mut scale_encoded_header_by_hash,
+        ) {
+            Some(headers) => {
+                for (hash, scale_encoded_header) in headers {
+                    votes_ancestries_hashes.insert(hash);
+                    votes_ancestries.push(scale_encoded_header);
+                }
+            }
+            // The pre-commit targets a block that isn't known to be a descendant of the block
+            // that the commit finalizes. See the documentation of this function.
+            None => continue,
+        }
+
+        precommits.extend_from_slice(precommit.target_hash);
+        push_block_number(&mut precommits, precommit.target_number, block_number_bytes)?;
+        precommits.extend_from_slice(&signature[..]);
+        precommits.extend_from_slice(&authority_public_key[..]);
+        num_precommits += 1;
+    }
+
+    let mut out = Vec::with_capacity(
+        8 + 32
+            + block_number_bytes
+            + 5
+            + precommits.len()
+            + 5
+            + votes_ancestries.iter().map(|h| h.len()).sum::<usize>(),
+    );
+
+    // `round: u64`
+    out.extend_from_slice(&commit.round_number.to_le_bytes());
+    // `commit.target_hash: [u8; 32]`
+    out.extend_from_slice(commit.target_hash);
+    // `commit.target_number`, encoded on `block_number_bytes` bytes, little endian.
+    push_block_number(&mut out, commit.target_number, block_number_bytes)?;
+
+    // `commit.precommits: Vec<SignedPrecommit>`
+    out.extend_from_slice(util::encode_scale_compact_usize(num_precommits).as_ref());
+    out.extend_from_slice(&precommits);
+
+    // `votes_ancestries: Vec<Header>`
+    out.extend_from_slice(util::encode_scale_compact_usize(votes_ancestries.len()).as_ref());
+    for scale_encoded_header in votes_ancestries {
+        out.extend_from_slice(&scale_encoded_header);
+    }
+
+    Ok(out)
+}
+
+/// Returns the headers of the blocks on the path that goes from `precommit_target` (included) down
+/// to `commit_target` (excluded), or `None` if no such path can be built out of the blocks that
+/// `scale_encoded_header_by_hash` knows about.
+///
+/// Blocks that are in `already_known` are assumed to have been returned by an earlier call and to
+/// already be linked to `commit_target`, and the walk stops there. They are not returned again.
+fn ancestry_of(
+    precommit_target_hash: &[u8; 32],
+    precommit_target_number: u64,
+    commit_target_hash: &[u8; 32],
+    commit_target_number: u64,
+    block_number_bytes: usize,
+    already_known: &BTreeSet<[u8; 32]>,
+    scale_encoded_header_by_hash: &mut impl FnMut(&[u8; 32]) -> Option<Vec<u8>>,
+) -> Option<Vec<([u8; 32], Vec<u8>)>> {
+    // A pre-commit that targets the block being finalized needs no ancestry at all. This is the
+    // common case.
+    if precommit_target_hash == commit_target_hash {
+        return Some(Vec::new());
+    }
+
+    // Only a descendant of the block being finalized can be linked back to it, and a descendant
+    // always has a higher height. This also bounds the number of iterations of the loop below.
+    if precommit_target_number <= commit_target_number {
+        return None;
+    }
+
+    let mut out = Vec::new();
+    let mut current_hash = *precommit_target_hash;
+    let mut remaining_steps = precommit_target_number - commit_target_number;
+
+    loop {
+        if current_hash == *commit_target_hash || already_known.contains(&current_hash) {
+            return Some(out);
+        }
+
+        if remaining_steps == 0 {
+            // The chain of parents is longer than the difference of heights, meaning that one of
+            // the headers is inconsistent with the height of the block that it is supposed to be.
+            return None;
+        }
+        remaining_steps -= 1;
+
+        let scale_encoded_header = scale_encoded_header_by_hash(&current_hash)?;
+        let parent_hash = *header::decode(&scale_encoded_header, block_number_bytes)
+            .ok()?
+            .parent_hash;
+        out.push((current_hash, scale_encoded_header));
+        current_hash = parent_hash;
+    }
+}
+
+/// Appends `value` to `out`, encoded on `block_number_bytes` bytes in little endian order.
+fn push_block_number(
+    out: &mut Vec<u8>,
+    value: u64,
+    block_number_bytes: usize,
+) -> Result<(), CommitToJustificationError> {
+    let bytes = value.to_le_bytes();
+
+    // Any byte that we are about to truncate away must be zero, otherwise the encoding would
+    // silently alter the block number.
+    if bytes
+        .iter()
+        .skip(core::cmp::min(8, block_number_bytes))
+        .any(|b| *b != 0)
+    {
+        return Err(CommitToJustificationError::BlockNumberTooLarge);
+    }
+
+    for n in 0..block_number_bytes {
+        out.push(bytes.get(n).copied().unwrap_or(0));
+    }
+
+    Ok(())
+}
+
+/// Error potentially returned by [`grandpa_commit_to_justification`].
+#[derive(Debug, derive_more::Display, derive_more::Error, Clone, PartialEq, Eq)]
+pub enum CommitToJustificationError {
+    /// Failed to decode the commit.
+    #[display("Failed to decode the Grandpa commit")]
+    CommitDecode,
+    /// The number of pre-commits and the number of signatures in the commit differ.
+    #[display("Mismatch between the number of pre-commits and of signatures")]
+    PrecommitsAuthDataMismatch,
+    /// A block number of the commit doesn't fit in `block_number_bytes` bytes.
+    #[display("Block number doesn't fit in the block number encoding of the chain")]
+    BlockNumberTooLarge,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::header;
+    use alloc::{vec, vec::Vec};
+
+    /// Builds a SCALE-encoded Grandpa commit targeting block `0xaa..aa` at height 1234, with one
+    /// pre-commit per entry of `precommit_targets`.
+    fn build_commit(precommit_targets: &[([u8; 32], u64)], block_number_bytes: usize) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&5u64.to_le_bytes()); // round number
+        out.extend_from_slice(&12u64.to_le_bytes()); // set id
+        out.extend_from_slice(&[0xaa; 32]); // target hash
+        out.extend_from_slice(&1234u64.to_le_bytes()[..block_number_bytes]); // target number
+
+        out.extend_from_slice(
+            crate::util::encode_scale_compact_usize(precommit_targets.len()).as_ref(),
+        );
+        for (hash, number) in precommit_targets {
+            out.extend_from_slice(hash);
+            out.extend_from_slice(&number.to_le_bytes()[..block_number_bytes]);
+        }
+
+        out.extend_from_slice(
+            crate::util::encode_scale_compact_usize(precommit_targets.len()).as_ref(),
+        );
+        for n in 0..precommit_targets.len() {
+            out.extend_from_slice(&[u8::try_from(n).unwrap(); 64]); // signature
+            out.extend_from_slice(&[u8::try_from(n).unwrap(); 32]); // public key
+        }
+
+        out
+    }
+
+    /// Builds a commit whose pre-commits all target the commit's own target block.
+    fn build_simple_commit(num_precommits: usize, block_number_bytes: usize) -> Vec<u8> {
+        let targets = vec![([0xaa; 32], 1234); num_precommits];
+        build_commit(&targets, block_number_bytes)
+    }
+
+    /// Builds a header whose only meaningful field is its parent hash.
+    fn build_header(parent_hash: [u8; 32], number: u64) -> Vec<u8> {
+        header::HeaderRef {
+            parent_hash: &parent_hash,
+            number,
+            extrinsics_root: &[0; 32],
+            state_root: &[0; 32],
+            digest: header::DigestRef::empty(),
+        }
+        .scale_encoding_vec(4)
+    }
+
+    /// Re-implements the ancestry walk that `bp_header_chain`'s justification verifier performs,
+    /// in order to check that the `votes_ancestries` we produce is the list that it expects: every
+    /// pre-commit must be reachable from the block being finalized, and no header may be left
+    /// unvisited.
+    fn verifier_ancestry_check(justification: &[u8], block_number_bytes: usize) {
+        use alloc::collections::{BTreeMap, BTreeSet};
+
+        let decoded = crate::finality::decode::decode_grandpa_justification(
+            justification,
+            block_number_bytes,
+        )
+        .unwrap();
+
+        let mut parents = BTreeMap::new();
+        let mut unvisited = BTreeSet::new();
+        for ancestor in decoded.votes_ancestries.clone() {
+            let hash = ancestor.hash(block_number_bytes);
+            assert!(
+                parents.insert(hash, *ancestor.parent_hash).is_none(),
+                "duplicate header in votes_ancestries"
+            );
+            unvisited.insert(hash);
+        }
+
+        for precommit in decoded.precommits.iter() {
+            let mut current = *precommit.target_hash;
+            let mut route = Vec::new();
+            while current != *decoded.target_hash {
+                let parent = parents
+                    .get(&current)
+                    .unwrap_or_else(|| panic!("pre-commit is not linked to the finalized block"));
+                route.push(current);
+                current = *parent;
+            }
+            for hash in route {
+                unvisited.remove(&hash);
+            }
+        }
+
+        assert!(
+            unvisited.is_empty(),
+            "votes_ancestries carries {} header(s) that no pre-commit needs",
+            unvisited.len()
+        );
+    }
+
+    #[test]
+    fn commit_to_justification_round_trip() {
+        let scale_encoded_commit = build_simple_commit(7, 4);
+
+        let justification =
+            super::grandpa_commit_to_justification(&scale_encoded_commit, 4, |_| None).unwrap();
+
+        let commit =
+            crate::finality::decode::decode_grandpa_commit(&scale_encoded_commit, 4).unwrap();
+        let decoded =
+            crate::finality::decode::decode_grandpa_justification(&justification, 4).unwrap();
+
+        assert_eq!(decoded.round, commit.round_number);
+        assert_eq!(decoded.target_hash, commit.target_hash);
+        assert_eq!(decoded.target_number, commit.target_number);
+        assert_eq!(decoded.votes_ancestries.len(), 0);
+        assert_eq!(decoded.precommits.iter().len(), commit.precommits.len());
+
+        for (justification_precommit, (commit_precommit, (signature, public_key))) in decoded
+            .precommits
+            .iter()
+            .zip(commit.precommits.iter().zip(commit.auth_data.iter()))
+        {
+            assert_eq!(
+                justification_precommit.target_hash,
+                commit_precommit.target_hash
+            );
+            assert_eq!(
+                justification_precommit.target_number,
+                commit_precommit.target_number
+            );
+            assert_eq!(justification_precommit.signature, *signature);
+            assert_eq!(justification_precommit.authority_public_key, *public_key);
+        }
+
+        verifier_ancestry_check(&justification, 4);
+    }
+
+    #[test]
+    fn commit_to_justification_descendant_precommits_get_an_ancestry() {
+        // Chain: target(#1234, 0xaa..) <- child(#1235) <- grandchild(#1236).
+        let child = build_header([0xaa; 32], 1235);
+        let child_hash = header::hash_from_scale_encoded_header(&child);
+        let grandchild = build_header(child_hash, 1236);
+        let grandchild_hash = header::hash_from_scale_encoded_header(&grandchild);
+
+        // One vote on the finalized block, one on its child, one on its grandchild.
+        let scale_encoded_commit = build_commit(
+            &[
+                ([0xaa; 32], 1234),
+                (child_hash, 1235),
+                (grandchild_hash, 1236),
+            ],
+            4,
+        );
+
+        let justification =
+            super::grandpa_commit_to_justification(&scale_encoded_commit, 4, |hash| {
+                if *hash == child_hash {
+                    Some(child.clone())
+                } else if *hash == grandchild_hash {
+                    Some(grandchild.clone())
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+
+        let decoded =
+            crate::finality::decode::decode_grandpa_justification(&justification, 4).unwrap();
+
+        // All three votes are kept, ...
+        assert_eq!(decoded.precommits.iter().len(), 3);
+        // ... and the two headers that link them to the finalized block are carried along, each
+        // one exactly once even though the grandchild's route goes through the child.
+        let ancestries = decoded
+            .votes_ancestries
+            .clone()
+            .map(|h| h.hash(4))
+            .collect::<Vec<_>>();
+        assert_eq!(ancestries.len(), 2);
+        assert!(ancestries.contains(&child_hash));
+        assert!(ancestries.contains(&grandchild_hash));
+
+        verifier_ancestry_check(&justification, 4);
+    }
+
+    #[test]
+    fn commit_to_justification_drops_unresolvable_precommits() {
+        // A vote on a block whose header we don't know can't be linked to the finalized block. It
+        // would count for zero weight on the verifier's side and make strict verification fail
+        // outright, so it must not appear in the justification.
+        let scale_encoded_commit = build_commit(&[([0xaa; 32], 1234), ([0xbb; 32], 1235)], 4);
+
+        let justification =
+            super::grandpa_commit_to_justification(&scale_encoded_commit, 4, |_| None).unwrap();
+
+        let decoded =
+            crate::finality::decode::decode_grandpa_justification(&justification, 4).unwrap();
+        assert_eq!(decoded.precommits.iter().len(), 1);
+        assert_eq!(
+            decoded.precommits.iter().next().unwrap().target_hash,
+            &[0xaa; 32]
+        );
+        assert_eq!(decoded.votes_ancestries.len(), 0);
+
+        verifier_ancestry_check(&justification, 4);
+    }
+
+    #[test]
+    fn commit_to_justification_drops_precommits_below_the_target() {
+        // A vote on a block that is not above the finalized one can't be a descendant of it.
+        let scale_encoded_commit = build_commit(&[([0xaa; 32], 1234), ([0xcc; 32], 1233)], 4);
+
+        let justification =
+            super::grandpa_commit_to_justification(&scale_encoded_commit, 4, |_| {
+                panic!("no header lookup should be needed")
+            })
+            .unwrap();
+
+        let decoded =
+            crate::finality::decode::decode_grandpa_justification(&justification, 4).unwrap();
+        assert_eq!(decoded.precommits.iter().len(), 1);
+        assert_eq!(decoded.votes_ancestries.len(), 0);
+    }
+
+    #[test]
+    fn commit_to_justification_rejects_inconsistent_ancestry() {
+        // A header that claims a height one above the finalized block but whose parent isn't the
+        // finalized block leads nowhere. The walk must stop rather than follow the chain forever.
+        let bogus = build_header([0xdd; 32], 1235);
+        let bogus_hash = header::hash_from_scale_encoded_header(&bogus);
+        let scale_encoded_commit = build_commit(&[(bogus_hash, 1235)], 4);
+
+        let justification =
+            super::grandpa_commit_to_justification(&scale_encoded_commit, 4, |hash| {
+                if *hash == bogus_hash {
+                    Some(bogus.clone())
+                } else {
+                    // Pretend that every other block exists and is its own parent, so that only
+                    // the height bound can stop the walk.
+                    Some(build_header(*hash, 0))
+                }
+            })
+            .unwrap();
+
+        let decoded =
+            crate::finality::decode::decode_grandpa_justification(&justification, 4).unwrap();
+        assert_eq!(decoded.precommits.iter().len(), 0);
+        assert_eq!(decoded.votes_ancestries.len(), 0);
+    }
+
+    #[test]
+    fn commit_to_justification_block_number_bytes() {
+        // `decode_grandpa_justification` assumes that block numbers are encoded on 4 bytes (see
+        // `PRECOMMIT_ENCODED_LEN`), so the encoding is checked by hand here rather than by
+        // decoding it back.
+        let scale_encoded_commit = build_simple_commit(3, 8);
+        let justification =
+            super::grandpa_commit_to_justification(&scale_encoded_commit, 8, |_| None).unwrap();
+
+        assert_eq!(
+            justification.len(),
+            8 + 32 + 8 + 1 + 3 * (32 + 8 + 64 + 32) + 1
+        );
+        assert_eq!(&justification[..8], &5u64.to_le_bytes());
+        assert_eq!(&justification[8..40], &[0xaa; 32]);
+        assert_eq!(&justification[40..48], &1234u64.to_le_bytes());
+        // Compact-encoded length of the list of pre-commits.
+        assert_eq!(justification[48], 3 << 2);
+        // Compact-encoded length of the (empty) list of vote ancestries.
+        assert_eq!(*justification.last().unwrap(), 0);
+    }
+
+    #[test]
+    fn commit_to_justification_block_number_too_large() {
+        let mut scale_encoded_commit = build_simple_commit(1, 4);
+        // Overwrite the target number with a value that doesn't fit on two bytes.
+        scale_encoded_commit[48..52].copy_from_slice(&70000u32.to_le_bytes());
+        assert_eq!(
+            super::grandpa_commit_to_justification(&scale_encoded_commit, 2, |_| None),
+            Err(super::CommitToJustificationError::CommitDecode)
+        );
+    }
+
+    #[test]
+    fn commit_to_justification_invalid_commit() {
+        assert!(super::grandpa_commit_to_justification(&[0, 1, 2, 3], 4, |_| None).is_err());
+    }
+}

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -424,6 +424,8 @@ define_methods! {
     childstate_getStorageHash() -> (), // TODO:
     childstate_getStorageSize() -> (), // TODO:
     grandpa_roundState() -> (), // TODO:
+    grandpa_subscribeJustifications() -> Cow<'a, str>,
+    grandpa_unsubscribeJustifications(subscription: String) -> bool,
     offchain_localStorageGet() -> (), // TODO:
     offchain_localStorageSet() -> (), // TODO:
     payment_queryInfo(extrinsic: HexString, hash: Option<HashHexString>) -> RuntimeDispatchInfo,
@@ -554,6 +556,9 @@ define_methods! {
     chain_allHead(subscription: Cow<'a, str>, result: Header) -> (),
     state_runtimeVersion(subscription: Cow<'a, str>, result: Option<RuntimeVersion<'a>>) -> (), // TODO: the Option is a custom addition
     state_storage(subscription: Cow<'a, str>, result: StorageChangeSet) -> (),
+    /// Notification of `grandpa_subscribeJustifications`. Contains the SCALE-encoded
+    /// Grandpa justification of a block that has just been finalized.
+    grandpa_justifications(subscription: Cow<'a, str>, result: HexString) -> (),
 
     // The functions below are experimental and are defined in the document https://github.com/paritytech/json-rpc-interface-spec/
     chainHead_v1_followEvent(subscription: Cow<'a, str>, result: FollowEvent<'a>) -> (),

--- a/lib/src/json_rpc/service/client_main_task.rs
+++ b/lib/src/json_rpc/service/client_main_task.rs
@@ -470,6 +470,7 @@ impl ClientMainTask {
                 | methods::MethodCall::state_subscribeRuntimeVersion { .. }
                 | methods::MethodCall::state_subscribeStorage { .. }
                 | methods::MethodCall::statement_subscribeStatement { .. }
+                | methods::MethodCall::grandpa_subscribeJustifications { .. }
                 | methods::MethodCall::transaction_v1_broadcast { .. }
                 | methods::MethodCall::transactionWatch_v1_submitAndWatch { .. }
                 | methods::MethodCall::sudo_network_unstable_watch { .. }
@@ -638,7 +639,8 @@ impl ClientMainTask {
                 methods::MethodCall::chain_unsubscribeAllHeads { subscription, .. }
                 | methods::MethodCall::chain_unsubscribeFinalizedHeads { subscription, .. }
                 | methods::MethodCall::chain_unsubscribeNewHeads { subscription, .. }
-                | methods::MethodCall::statement_unsubscribeStatement { subscription, .. } => {
+                | methods::MethodCall::statement_unsubscribeStatement { subscription, .. }
+                | methods::MethodCall::grandpa_unsubscribeJustifications { subscription, .. } => {
                     // TODO: DRY with above
                     // TODO: must check whether type of subscription matches
                     match self.inner.active_subscriptions.get_mut(&**subscription) {
@@ -663,6 +665,10 @@ impl ClientMainTask {
                                     methods::Response::statement_unsubscribeStatement(true)
                                         .to_json_response(request_id)
                                 }
+                                methods::MethodCall::grandpa_unsubscribeJustifications {
+                                    ..
+                                } => methods::Response::grandpa_unsubscribeJustifications(true)
+                                    .to_json_response(request_id),
                                 _ => unreachable!(),
                             });
 
@@ -687,6 +693,10 @@ impl ClientMainTask {
                                     methods::Response::statement_unsubscribeStatement(false)
                                         .to_json_response(request_id)
                                 }
+                                methods::MethodCall::grandpa_unsubscribeJustifications {
+                                    ..
+                                } => methods::Response::grandpa_unsubscribeJustifications(false)
+                                    .to_json_response(request_id),
                                 _ => unreachable!(),
                             };
 

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -2290,6 +2290,21 @@ impl<TRq, TSrc, TBl> FinalityProofVerify<TRq, TSrc, TBl> {
         )
     }
 
+    /// Returns the finality proof that is about to be verified.
+    ///
+    /// See [`all_forks::FinalityProofVerify::finality_proof`].
+    pub fn finality_proof(&self) -> all_forks::FinalityProofRef<'_> {
+        self.inner.finality_proof()
+    }
+
+    /// Returns the SCALE-encoded header of a non-finalized block, identified by its hash, or
+    /// `None` if that block isn't known.
+    ///
+    /// See [`all_forks::FinalityProofVerify::non_finalized_block_header`].
+    pub fn non_finalized_block_header(&self, hash: &[u8; 32]) -> Option<&[u8]> {
+        self.inner.non_finalized_block_header(hash)
+    }
+
     /// Perform the verification.
     ///
     /// A randomness seed must be provided and will be used during the verification. Note that the
@@ -2413,6 +2428,14 @@ impl<TRq, TSrc, TBl> WarpSyncFragmentVerify<TRq, TSrc, TBl> {
             ud.outer_source_id,
             &self.shared.sources[ud.outer_source_id.0].user_data,
         ))
+    }
+
+    /// Returns the SCALE-encoded header and justification of the fragment that [`Self::perform`]
+    /// is about to verify.
+    ///
+    /// See [`warp_sync::VerifyWarpSyncFragment::fragment`].
+    pub fn fragment(&self) -> Option<(&[u8], &[u8])> {
+        self.inner.fragment()
     }
 
     /// Perform the verification.

--- a/lib/src/sync/all_forks.rs
+++ b/lib/src/sync/all_forks.rs
@@ -404,6 +404,18 @@ enum FinalityProof {
     Justification(([u8; 4], Vec<u8>)),
 }
 
+/// Reference to a finality proof. See [`FinalityProofVerify::finality_proof`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum FinalityProofRef<'a> {
+    /// SCALE-encoded Grandpa commit message.
+    GrandpaCommit(&'a [u8]),
+    /// SCALE-encoded justification, and the consensus engine id it is meant for.
+    Justification {
+        consensus_engine_id: [u8; 4],
+        scale_encoded_justification: &'a [u8],
+    },
+}
+
 impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     /// Initializes a new [`AllForksSync`].
     pub fn new(config: Config) -> Self {
@@ -2191,6 +2203,30 @@ impl<TBl, TRq, TSrc> FinalityProofVerify<TBl, TRq, TSrc> {
     /// Returns the source the justification was obtained from.
     pub fn sender(&self) -> (SourceId, &TSrc) {
         (self.source_id, &self.parent[self.source_id])
+    }
+
+    /// Returns the finality proof that is about to be verified.
+    ///
+    /// Exposed so that the proof can be kept and handed over to a third party that verifies
+    /// finality on its own.
+    pub fn finality_proof(&self) -> FinalityProofRef<'_> {
+        match &self.finality_proof_to_verify {
+            FinalityProof::GrandpaCommit(commit) => FinalityProofRef::GrandpaCommit(commit),
+            FinalityProof::Justification((consensus_engine_id, justification)) => {
+                FinalityProofRef::Justification {
+                    consensus_engine_id: *consensus_engine_id,
+                    scale_encoded_justification: justification,
+                }
+            }
+        }
+    }
+
+    /// Returns the SCALE-encoded header of a non-finalized block, or `None` if it isn't known.
+    ///
+    /// Must be called before [`FinalityProofVerify::perform`], which consumes the state machine
+    /// and removes the newly-finalized blocks from it.
+    pub fn non_finalized_block_header(&self, hash: &[u8; 32]) -> Option<&[u8]> {
+        self.parent.chain.non_finalized_block_header(hash)
     }
 
     /// Perform the verification.

--- a/lib/src/sync/warp_sync.rs
+++ b/lib/src/sync/warp_sync.rs
@@ -1576,6 +1576,25 @@ impl<TSrc, TRq> VerifyWarpSyncFragment<TSrc, TRq> {
         Some((source_id, &self.inner.sources[source_id.0].user_data))
     }
 
+    /// Returns the SCALE-encoded header and justification of the fragment that [`Self::verify`]
+    /// is about to verify, or `None` if the source has sent an empty list of fragments.
+    ///
+    /// Exposed so that the justification, which is otherwise dropped once verified, can be kept:
+    /// every fragment is an authority-set-change block, and a consumer that verifies Grandpa
+    /// itself cannot skip one of those.
+    pub fn fragment(&self) -> Option<(&[u8], &[u8])> {
+        let entry = self
+            .inner
+            .verify_queue
+            .front()
+            .unwrap_or_else(|| unreachable!());
+        let fragment = entry.fragments.get(entry.next_fragment_to_verify_index)?;
+        Some((
+            &fragment.scale_encoded_header,
+            &fragment.scale_encoded_justification,
+        ))
+    }
+
     /// Verify one warp sync fragment.
     ///
     /// Must be passed a randomly-generated value that is used by the verification process. Note

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -96,6 +96,13 @@ pub(super) struct Config<TPlat: PlatformRef> {
     pub statement_protocol_config: Option<StatementProtocolConfig>,
 }
 
+/// Number of finality proofs the sync service may buffer for the JSON-RPC service before it
+/// starts discarding them.
+///
+/// Discarding one only means that `grandpa_subscribeJustifications` subscribers miss a
+/// justification, which a full node does too.
+const FINALITY_PROOFS_BUFFER_SIZE: usize = 16;
+
 /// Fields used to process JSON-RPC requests in the background.
 struct Background<TPlat: PlatformRef> {
     /// Target to use for all the logs.
@@ -168,6 +175,12 @@ struct Background<TPlat: PlatformRef> {
     /// List of all active `state_subscribeRuntimeVersion` subscriptions, indexed by the
     /// subscription ID.
     runtime_version_subscriptions: hashbrown::HashSet<String, fnv::FnvBuildHasher>,
+    /// List of all active `grandpa_subscribeJustifications` subscriptions, indexed by the
+    /// subscription ID.
+    grandpa_justifications_subscriptions: hashbrown::HashSet<String, fnv::FnvBuildHasher>,
+    /// `true` if a task that pulls finality proofs out of the sync service is currently present
+    /// in [`Background::background_tasks`]. Set back to `false` if the stream ever ends.
+    grandpa_justifications_stream_active: bool,
     /// List of all active `author_submitAndWatchExtrinsic`, `transaction_v1_broadcast`, and
     /// `transactionWatch_v1_submitAndWatch` subscriptions, indexed by the subscription ID.
     /// When it comes to `author_submitAndWatchExtrinsic` and
@@ -448,7 +461,17 @@ enum Event<TPlat: PlatformRef> {
         request_id_json: String,
         result: Result<codec::BlockData, ()>,
         expected_block_hash: [u8; 32],
+        /// Finality proof of the block, if the sync service happens to still have it.
+        finality_proof: Option<sync_service::FinalityProof>,
     },
+    /// A finality proof has been verified by the sync service. Sent to the
+    /// `grandpa_subscribeJustifications` subscribers.
+    FinalityProof {
+        proof: sync_service::FinalityProof,
+        stream: Pin<Box<async_channel::Receiver<sync_service::FinalityProof>>>,
+    },
+    /// The stream of finality proofs of the sync service has ended.
+    FinalityProofsStreamDead,
     ChainHeadSubscriptionWithRuntimeReady {
         subscription_id: String,
         subscription: runtime_service::SubscribeAll<TPlat>,
@@ -609,6 +632,11 @@ pub(super) async fn run<TPlat: PlatformRef>(
             2,
             Default::default(),
         ),
+        grandpa_justifications_subscriptions: hashbrown::HashSet::with_capacity_and_hasher(
+            0,
+            Default::default(),
+        ),
+        grandpa_justifications_stream_active: false,
         transactions_subscriptions: hashbrown::HashMap::with_capacity_and_hasher(
             2,
             Default::default(),
@@ -932,6 +960,8 @@ pub(super) async fn run<TPlat: PlatformRef>(
                     | methods::MethodCall::childstate_getStorageHash { .. }
                     | methods::MethodCall::childstate_getStorageSize { .. }
                     | methods::MethodCall::grandpa_roundState { .. }
+                    | methods::MethodCall::grandpa_subscribeJustifications { .. }
+                    | methods::MethodCall::grandpa_unsubscribeJustifications { .. }
                     | methods::MethodCall::offchain_localStorageGet { .. }
                     | methods::MethodCall::offchain_localStorageSet { .. }
                     | methods::MethodCall::payment_queryInfo { .. }
@@ -1458,6 +1488,61 @@ pub(super) async fn run<TPlat: PlatformRef>(
                             .responses_tx
                             .send(
                                 methods::Response::chain_unsubscribeAllHeads(exists)
+                                    .to_json_response(request_id_json),
+                            )
+                            .await;
+                    }
+
+                    methods::MethodCall::grandpa_subscribeJustifications {} => {
+                        let subscription_id = {
+                            let mut subscription_id = [0u8; 32];
+                            me.randomness.fill_bytes(&mut subscription_id);
+                            bs58::encode(subscription_id).into_string()
+                        };
+
+                        let _ = me
+                            .responses_tx
+                            .send(
+                                methods::Response::grandpa_subscribeJustifications(Cow::Borrowed(
+                                    &subscription_id,
+                                ))
+                                .to_json_response(request_id_json),
+                            )
+                            .await;
+
+                        me.grandpa_justifications_subscriptions
+                            .insert(subscription_id);
+
+                        // The sync service builds proofs whether or not anybody is listening,
+                        // so this only decides when forwarding starts. Proofs from before the
+                        // first subscription stay reachable through `chain_getBlock`.
+                        if !me.grandpa_justifications_stream_active {
+                            me.grandpa_justifications_stream_active = true;
+                            me.background_tasks.push(Box::pin({
+                                let sync_service = me.sync_service.clone();
+                                async move {
+                                    let mut stream = Box::pin(
+                                        sync_service
+                                            .subscribe_finality_proofs(FINALITY_PROOFS_BUFFER_SIZE)
+                                            .await,
+                                    );
+                                    match stream.next().await {
+                                        Some(proof) => Event::FinalityProof { proof, stream },
+                                        None => Event::FinalityProofsStreamDead,
+                                    }
+                                }
+                            }));
+                        }
+                    }
+
+                    methods::MethodCall::grandpa_unsubscribeJustifications { subscription } => {
+                        let exists = me
+                            .grandpa_justifications_subscriptions
+                            .remove(&subscription);
+                        let _ = me
+                            .responses_tx
+                            .send(
+                                methods::Response::grandpa_unsubscribeJustifications(exists)
                                     .to_json_response(request_id_json),
                             )
                             .await;
@@ -3218,13 +3303,17 @@ pub(super) async fn run<TPlat: PlatformRef>(
                     Box::pin(async move {
                         let result = if let Some(block_number) = block_number {
                             sync_service
+                                .clone()
                                 .block_query(
                                     block_number,
                                     block_hash,
                                     codec::BlocksRequestFields {
                                         header: true,
                                         body: true,
-                                        justifications: false,
+                                        // Costs no extra round trip, and is the only way to
+                                        // reach the proof of a block finalized before this node
+                                        // started. See `verified_finality_proof_from_block`.
+                                        justifications: true,
                                     },
                                     3,
                                     Duration::from_secs(8),
@@ -3233,12 +3322,14 @@ pub(super) async fn run<TPlat: PlatformRef>(
                                 .await
                         } else {
                             sync_service
+                                .clone()
                                 .block_query_unknown_number(
                                     block_hash,
                                     codec::BlocksRequestFields {
                                         header: true,
                                         body: true,
-                                        justifications: false,
+                                        // See above.
+                                        justifications: true,
                                     },
                                     3,
                                     Duration::from_secs(8),
@@ -3246,10 +3337,24 @@ pub(super) async fn run<TPlat: PlatformRef>(
                                 )
                                 .await
                         };
+                        // Prefer the proof the sync service verified while finalizing; fall
+                        // back to the one the peer sent, which is verified locally.
+                        let finality_proof = match sync_service.finality_proof(&block_hash).await {
+                            Some(proof) => Some(proof),
+                            None => match result.as_ref() {
+                                Ok(block) => {
+                                    sync_service
+                                        .verified_finality_proof_from_block(&block_hash, block)
+                                        .await
+                                }
+                                Err(_) => None,
+                            },
+                        };
                         Event::ChainGetBlockResult {
                             request_id_json,
                             result,
                             expected_block_hash: block_hash,
+                            finality_proof,
                         }
                     })
                 });
@@ -5751,10 +5856,50 @@ pub(super) async fn run<TPlat: PlatformRef>(
                 }));
             }
 
+            WakeUpReason::Event(Event::FinalityProof { proof, mut stream }) => {
+                log!(
+                    &me.platform,
+                    Debug,
+                    &me.log_target,
+                    "grandpa-justification",
+                    target_hash = HashDisplay(&proof.target_hash),
+                    target_number = proof.target_number,
+                    subscribers = me.grandpa_justifications_subscriptions.len(),
+                );
+
+                for subscription_id in &me.grandpa_justifications_subscriptions {
+                    let _ = me
+                        .responses_tx
+                        .send(
+                            methods::ServerToClient::grandpa_justifications {
+                                subscription: Cow::Borrowed(&**subscription_id),
+                                result: methods::HexString(
+                                    proof.scale_encoded_justification.clone(),
+                                ),
+                            }
+                            .to_json_request_object_parameters(None),
+                        )
+                        .await;
+                }
+
+                me.background_tasks.push(Box::pin(async move {
+                    match stream.next().await {
+                        Some(proof) => Event::FinalityProof { proof, stream },
+                        None => Event::FinalityProofsStreamDead,
+                    }
+                }));
+            }
+
+            WakeUpReason::Event(Event::FinalityProofsStreamDead) => {
+                // Happens for parachains, which never report a finality proof.
+                me.grandpa_justifications_stream_active = false;
+            }
+
             WakeUpReason::Event(Event::ChainGetBlockResult {
                 request_id_json,
                 mut result,
                 expected_block_hash,
+                finality_proof,
             }) => {
                 // A network request necessary to fulfill `chain_getBlock` has finished.
 
@@ -5800,9 +5945,14 @@ pub(super) async fn run<TPlat: PlatformRef>(
                                     me.sync_service.block_number_bytes(),
                                 )
                                 .unwrap(),
-                                // There's no way to verify the correctness of the justifications, consequently
-                                // we always return an empty list.
-                                justifications: None,
+                                // Only ever a locally-verified justification; see where
+                                // `finality_proof` is built.
+                                justifications: finality_proof.map(|proof| {
+                                    vec![(
+                                        proof.consensus_engine_id,
+                                        proof.scale_encoded_justification,
+                                    )]
+                                }),
                             })
                             .to_json_response(&request_id_json),
                         )

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -39,6 +39,7 @@ use rand_chacha::rand_core::SeedableRng as _;
 use smoldot::{
     chain,
     executor::host,
+    finality, header,
     libp2p::PeerId,
     network::{codec, service},
     trie::{self, Nibble, minimize_proof, prefix_proof, proof_decode},
@@ -234,6 +235,161 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
                 send_back,
                 buffer_size,
                 runtime_interest,
+            })
+            .await
+            .unwrap();
+
+        rx.await.unwrap()
+    }
+
+    /// Subscribes to the finality proofs (Grandpa justifications) of the chain.
+    ///
+    /// Every time the sync service finalizes blocks after verifying a finality proof, that proof
+    /// is sent on the returned channel as a Grandpa justification.
+    ///
+    /// If the channel is full, the notification is silently discarded. Contrary to
+    /// [`SyncService::subscribe_all`], the channel is **not** closed in that situation, as
+    /// finality proofs are independent from each other.
+    ///
+    /// Nothing is reported for blocks finalized before the subscription was created or as part of
+    /// a Grandpa warp sync; use [`SyncService::finality_proof`] for those. Parachains never
+    /// report anything, as their finality is derived from the relay chain.
+    pub async fn subscribe_finality_proofs(
+        &self,
+        buffer_size: usize,
+    ) -> async_channel::Receiver<FinalityProof> {
+        let (send_back, rx) = oneshot::channel();
+
+        self.to_background
+            .send(ToBackground::SubscribeFinalityProofs {
+                send_back,
+                buffer_size,
+            })
+            .await
+            .unwrap();
+
+        rx.await.unwrap()
+    }
+
+    /// Returns the finality proof (Grandpa justification) of the given block, if the sync service
+    /// happens to still have it.
+    ///
+    /// Only a small number of the most recently finalized blocks are covered, plus, for much
+    /// longer, the blocks that change the Grandpa authority set - including those covered by a
+    /// Grandpa warp sync, whose every fragment is such a block. `None` is returned for any other
+    /// block, even a finalized one, and for every block of a parachain.
+    ///
+    /// See [`SyncService::verified_finality_proof_from_block`] for obtaining the proof of a block
+    /// that isn't covered.
+    pub async fn finality_proof(&self, block_hash: &[u8; 32]) -> Option<FinalityProof> {
+        let (send_back, rx) = oneshot::channel();
+
+        self.to_background
+            .send(ToBackground::FinalityProof {
+                send_back,
+                block_hash: *block_hash,
+            })
+            .await
+            .unwrap();
+
+        rx.await.unwrap()
+    }
+
+    /// Verifies a finality proof that came back alongside a block downloaded from the network,
+    /// and keeps it around so that [`SyncService::finality_proof`] can serve it.
+    ///
+    /// Grandpa finalizes blocks in ranges, so a node only ever builds proofs for the blocks that
+    /// happened to be commit targets. A consumer that must prove a *specific* block final to a
+    /// third party has to get that proof elsewhere; full nodes keep the justifications of
+    /// authority-set-change blocks permanently and serve them alongside the block itself, at no
+    /// extra round trip.
+    ///
+    /// `block` is unverified data from a peer, so this checks that the header hashes to
+    /// `block_hash`, that the justification targets that same block, and that it is signed by the
+    /// authority set responsible for finalizing it. Returns `None` when that set is no longer
+    /// remembered: being unable to check a proof is treated as not having one.
+    pub async fn verified_finality_proof_from_block(
+        &self,
+        block_hash: &[u8; 32],
+        block: &codec::BlockData,
+    ) -> Option<FinalityProof> {
+        let scale_encoded_justification = block
+            .justifications
+            .as_ref()?
+            .iter()
+            .find(|justification| justification.engine_id == *b"FRNK")?
+            .justification
+            .clone();
+
+        // The header is self-verifying: hashing it must give back what was asked for.
+        let scale_encoded_header = block.header.as_ref()?;
+        if header::hash_from_scale_encoded_header(scale_encoded_header) != *block_hash {
+            return None;
+        }
+        let target_number = header::decode(scale_encoded_header, self.block_number_bytes)
+            .ok()?
+            .number;
+
+        // A peer could answer with a justification that is perfectly valid but proves some other
+        // block, which would say nothing about this one.
+        let decoded = finality::decode::decode_grandpa_justification(
+            &scale_encoded_justification,
+            self.block_number_bytes,
+        )
+        .ok()?;
+        if decoded.target_hash != block_hash || decoded.target_number != target_number {
+            return None;
+        }
+
+        let (authorities_set_id, authorities) =
+            self.grandpa_authority_set_for(target_number).await?;
+
+        let mut randomness_seed = [0u8; 32];
+        self.platform.fill_random_bytes(&mut randomness_seed);
+        if let Err(error) =
+            finality::verify::verify_justification(finality::verify::JustificationVerifyConfig {
+                justification: &scale_encoded_justification[..],
+                block_number_bytes: self.block_number_bytes,
+                authorities_set_id,
+                authorities_list: authorities.iter().map(|authority| &authority[..]),
+                randomness_seed,
+            })
+        {
+            log!(
+                &self.platform,
+                Debug,
+                "sync-service",
+                format!("Justification received alongside a block failed verification: {error}")
+            );
+            return None;
+        }
+
+        let proof = FinalityProof {
+            consensus_engine_id: *b"FRNK",
+            scale_encoded_justification,
+            target_hash: *block_hash,
+            target_number,
+        };
+
+        self.to_background
+            .send(ToBackground::RetainFinalityProof {
+                proof: proof.clone(),
+            })
+            .await
+            .unwrap();
+
+        Some(proof)
+    }
+
+    /// Returns the identifier and composition of the Grandpa authority set responsible for
+    /// finalizing the given block, if the sync service still remembers it.
+    async fn grandpa_authority_set_for(&self, block_number: u64) -> Option<(u64, Vec<[u8; 32]>)> {
+        let (send_back, rx) = oneshot::channel();
+
+        self.to_background
+            .send(ToBackground::GrandpaAuthoritySetFor {
+                send_back,
+                block_number,
             })
             .await
             .unwrap();
@@ -1373,6 +1529,30 @@ pub enum Notification {
     },
 }
 
+/// Proof that a block is finalized.
+///
+/// See [`SyncService::subscribe_finality_proofs`] and [`SyncService::finality_proof`].
+#[derive(Debug, Clone)]
+pub struct FinalityProof {
+    /// Consensus engine id the justification is meant for. Always `*b"FRNK"` (Grandpa) at the
+    /// moment, as Grandpa is the only finality algorithm that smoldot supports.
+    pub consensus_engine_id: [u8; 4],
+
+    /// SCALE-encoded Grandpa justification, verified against the authority set active at
+    /// [`FinalityProof::target_number`].
+    ///
+    /// When the verified proof was a Grandpa *commit*, which in steady state is the normal case,
+    /// this is an equivalent justification built from it by
+    /// [`smoldot::finality::encode::grandpa_commit_to_justification`].
+    pub scale_encoded_justification: Vec<u8>,
+
+    /// BLAKE2 hash of the header of the block that this proof finalizes.
+    pub target_hash: [u8; 32],
+
+    /// Height of the block that this proof finalizes.
+    pub target_number: u64,
+}
+
 /// Notification about a new block.
 ///
 /// See [`SyncService::subscribe_all`].
@@ -1426,4 +1606,21 @@ enum ToBackground {
     SerializeChainInformation {
         send_back: oneshot::Sender<Option<chain::chain_information::ValidChainInformation>>,
     },
+    /// See [`SyncService::subscribe_finality_proofs`].
+    SubscribeFinalityProofs {
+        send_back: oneshot::Sender<async_channel::Receiver<FinalityProof>>,
+        buffer_size: usize,
+    },
+    /// See [`SyncService::finality_proof`].
+    FinalityProof {
+        send_back: oneshot::Sender<Option<FinalityProof>>,
+        block_hash: [u8; 32],
+    },
+    /// Asks for the Grandpa authority set that finalized a given block.
+    GrandpaAuthoritySetFor {
+        send_back: oneshot::Sender<Option<(u64, Vec<[u8; 32]>)>>,
+        block_number: u64,
+    },
+    /// Caches a finality proof that the frontend has fetched and verified.
+    RetainFinalityProof { proof: FinalityProof },
 }

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -634,6 +634,32 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
                 ));
             }
 
+            WakeUpReason::ForegroundMessage(ToBackground::SubscribeFinalityProofs {
+                send_back,
+                ..
+            }) => {
+                // The finality of a parachain is derived from the relay chain rather than proven
+                // by a Grandpa justification. Return an already-closed channel.
+                let (_, rx) = async_channel::bounded(1);
+                let _ = send_back.send(rx);
+            }
+
+            WakeUpReason::ForegroundMessage(ToBackground::FinalityProof { send_back, .. }) => {
+                let _ = send_back.send(None);
+            }
+
+            WakeUpReason::ForegroundMessage(ToBackground::GrandpaAuthoritySetFor {
+                send_back,
+                ..
+            }) => {
+                // A parachain has no Grandpa authority set of its own.
+                let _ = send_back.send(None);
+            }
+
+            WakeUpReason::ForegroundMessage(ToBackground::RetainFinalityProof { .. }) => {
+                // No proof is ever produced for a parachain block, so there is none to keep.
+            }
+
             WakeUpReason::ForegroundClosed => {
                 return;
             }

--- a/light-base/src/sync_service/paraheads.rs
+++ b/light-base/src/sync_service/paraheads.rs
@@ -1138,6 +1138,43 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                 }
 
                 (
+                    WakeUpReason::ForegroundMessage(ToBackground::SubscribeFinalityProofs {
+                        send_back,
+                        ..
+                    }),
+                    _,
+                ) => {
+                    // The finality of a parachain is derived from the relay chain rather than
+                    // proven by a Grandpa justification. Return an already-closed channel.
+                    let (_, rx) = async_channel::bounded(1);
+                    let _ = send_back.send(rx);
+                }
+
+                (
+                    WakeUpReason::ForegroundMessage(ToBackground::FinalityProof {
+                        send_back, ..
+                    }),
+                    _,
+                ) => {
+                    let _ = send_back.send(None);
+                }
+
+                (
+                    WakeUpReason::ForegroundMessage(ToBackground::GrandpaAuthoritySetFor {
+                        send_back,
+                        ..
+                    }),
+                    _,
+                ) => {
+                    // A parachain has no Grandpa authority set of its own.
+                    let _ = send_back.send(None);
+                }
+
+                (WakeUpReason::ForegroundMessage(ToBackground::RetainFinalityProof { .. }), _) => {
+                    // No proof is ever produced for a parachain block, so there is none to keep.
+                }
+
+                (
                     WakeUpReason::ParaheadFetchFinished { .. }
                     | WakeUpReason::AdvanceSyncTree
                     | WakeUpReason::Notification(_)

--- a/light-base/src/sync_service/substrate_compat.rs
+++ b/light-base/src/sync_service/substrate_compat.rs
@@ -36,11 +36,11 @@ use futures_lite::FutureExt as _;
 use futures_util::{FutureExt as _, StreamExt as _, future, stream};
 use hashbrown::HashMap;
 use smoldot::{
-    chain, header,
+    chain, finality, header,
     informant::HashDisplay,
     libp2p,
     network::{self, codec},
-    sync::all,
+    sync::{all, all_forks},
 };
 
 /// Maximum wait for the first GrandpaNeighborPacket before falling back to AllForksOnly.
@@ -53,6 +53,54 @@ const MODE_DECISION_TIMEOUT: Duration = Duration::from_secs(30);
 /// Below warp sync minimum gap packets to observe before committing AllForksOnly. Avoids one lagging
 /// first peer locking us into the slow path when our local finalized is a stale checkpoint.
 const MODE_DECISION_MIN_PACKETS: usize = 2;
+
+/// Number of finality proofs of recently-finalized blocks kept in order to answer
+/// [`super::SyncService::finality_proof`].
+///
+/// Kept small: a justification weighs upwards of 100 bytes per authority, and the purpose is to
+/// serve the proof of a block a JSON-RPC client has just been told about, not historical ones.
+const RECENT_FINALITY_PROOFS_CACHE_SIZE: NonZero<usize> = match NonZero::<usize>::new(8) {
+    Some(v) => v,
+    None => unreachable!(),
+};
+
+/// Number of finality proofs of authority-set-change blocks kept in order to answer
+/// [`super::SyncService::finality_proof`].
+///
+/// Kept apart from [`RECENT_FINALITY_PROOFS_CACHE_SIZE`], and much larger, because such blocks
+/// occur only about once per session while a consumer that verifies Grandpa itself has to prove
+/// every set transition in order and cannot skip one.
+const MANDATORY_FINALITY_PROOFS_CACHE_SIZE: NonZero<usize> = match NonZero::<usize>::new(64) {
+    Some(v) => v,
+    None => unreachable!(),
+};
+
+/// Number of past Grandpa authority sets whose composition is kept, on top of the current one, in
+/// order to verify justifications fetched from the network. See
+/// [`super::SyncService::verified_finality_proof_from_block`].
+///
+/// One set lasts one session, so this bounds how far behind the chain a fetched justification can
+/// be and still be verifiable.
+const GRANDPA_AUTHORITY_SETS_HISTORY: usize = 16;
+
+/// One Grandpa authority set, and the range of blocks that it is responsible for finalizing.
+struct GrandpaAuthoritySet {
+    /// Identifier of the set. Part of the message that the authorities sign, and therefore
+    /// needed to verify a justification they produced.
+    set_id: u64,
+
+    /// ed25519 public keys of the authorities of the set.
+    authorities: Vec<[u8; 32]>,
+
+    /// Height of the first block that this set finalizes.
+    first_block: u64,
+
+    /// Height of the last block that this set finalizes, or `None` while this is the current set.
+    ///
+    /// The block that enacts a change of authorities is itself finalized by the outgoing set, so
+    /// this is that block's height rather than the one before it.
+    last_block: Option<u64>,
+}
 
 /// Starts a sync service background task to synchronize a chain (relay chain or not) that is
 /// built with Substrate.
@@ -125,6 +173,27 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
         .fuse(),
         pending_subscriptions: VecDeque::new(),
         all_notifications: Vec::<async_channel::Sender<Notification>>::new(),
+        block_number_bytes,
+        finality_proofs_subscriptions: Vec::new(),
+        recent_finality_proofs: lru::LruCache::with_hasher(
+            RECENT_FINALITY_PROOFS_CACHE_SIZE,
+            util::SipHasherBuild::new({
+                let mut seed = [0; 16];
+                platform.fill_random_bytes(&mut seed);
+                seed
+            }),
+        ),
+        mandatory_finality_proofs: lru::LruCache::with_hasher(
+            MANDATORY_FINALITY_PROOFS_CACHE_SIZE,
+            util::SipHasherBuild::new({
+                let mut seed = [0; 16];
+                platform.fill_random_bytes(&mut seed);
+                seed
+            }),
+        ),
+        // Seeded on the first finality-proof verification, when the chain information is known to
+        // be available.
+        grandpa_authority_sets: VecDeque::new(),
         log_target,
         from_network_service: None,
         network_service,
@@ -416,6 +485,12 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                     .proof_sender()
                     .map(|(_, (peer_id, _))| peer_id.clone());
 
+                // Grabbed before `perform` consumes the verifier and drops it. Only retained
+                // below, once the verification has succeeded.
+                let fragment_justification = verify
+                    .fragment()
+                    .map(|(_, justification)| justification.to_vec());
+
                 let (sync, result) = verify.perform({
                     let mut seed = [0; 32];
                     task.platform.fill_random_bytes(&mut seed);
@@ -438,6 +513,18 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                             verified_hash = HashDisplay(&fragment_hash),
                             verified_height = fragment_number
                         );
+
+                        // Not reported to the finality-proof subscribers: those follow finality
+                        // as it happens, and a warp sync leaps over most of the chain. A full
+                        // node likewise stores these justifications without notifying anybody.
+                        if let Some(scale_encoded_justification) = fragment_justification {
+                            task.retain_finality_proof(super::FinalityProof {
+                                consensus_engine_id: *b"FRNK",
+                                scale_encoded_justification,
+                                target_hash: fragment_hash,
+                                target_number: fragment_number,
+                            });
+                        }
                     }
                     Err(err) => {
                         log!(
@@ -568,6 +655,38 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
             WakeUpReason::SyncProcess(all::ProcessOne::VerifyFinalityProof(verify)) => {
                 // Finality proof to verify.
                 let sender = verify.sender().1.0.clone();
+                // Built before the verification, as it needs the headers of the blocks that the
+                // pre-commits target and `perform` consumes the state machine. Built for every
+                // proof, including the ones that turn out invalid and are thrown away below.
+                let proof_to_report = match verify.finality_proof() {
+                    all_forks::FinalityProofRef::GrandpaCommit(commit) => {
+                        match finality::encode::grandpa_commit_to_justification(
+                            commit,
+                            task.block_number_bytes,
+                            |hash| verify.non_finalized_block_header(hash).map(|h| h.to_vec()),
+                        ) {
+                            Ok(scale_encoded_justification) => {
+                                Some((*b"FRNK", scale_encoded_justification))
+                            }
+                            Err(error) => {
+                                log!(
+                                    &task.platform,
+                                    Warn,
+                                    &task.log_target,
+                                    format!(
+                                        "Failed to turn a Grandpa commit into a justification: \
+                                        {error}"
+                                    )
+                                );
+                                None
+                            }
+                        }
+                    }
+                    all_forks::FinalityProofRef::Justification {
+                        consensus_engine_id,
+                        scale_encoded_justification,
+                    } => Some((consensus_engine_id, scale_encoded_justification.to_vec())),
+                };
                 match verify.perform({
                     let mut seed = [0; 32];
                     task.platform.fill_random_bytes(&mut seed);
@@ -589,6 +708,43 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                             finalized_blocks = finalized_blocks_newest_to_oldest.len(),
                             sender
                         );
+
+                        // `finalized_blocks_newest_to_oldest` is never empty, and its first
+                        // element is the block that the proof targets.
+                        if let Some((consensus_engine_id, scale_encoded_justification)) =
+                            proof_to_report
+                        {
+                            let target = finalized_blocks_newest_to_oldest
+                                .first()
+                                .unwrap_or_else(|| unreachable!());
+                            task.on_verified_finality_proof(
+                                super::FinalityProof {
+                                    consensus_engine_id,
+                                    scale_encoded_justification,
+                                    target_hash: target.block_hash,
+                                    target_number: sync.finalized_block_number(),
+                                },
+                                header_changes_authority_set(
+                                    &target.header,
+                                    task.block_number_bytes,
+                                ),
+                            );
+                        }
+
+                        // Tracked so that a justification fetched from the network later can be
+                        // verified against the set that signed it. A set change can be anywhere
+                        // in the batch, not only at the proof's target.
+                        let enacted_at = finalized_blocks_newest_to_oldest
+                            .iter()
+                            .find(|block| {
+                                header_changes_authority_set(&block.header, task.block_number_bytes)
+                            })
+                            .and_then(|block| {
+                                header::decode(&block.header, task.block_number_bytes)
+                                    .ok()
+                                    .map(|header| header.number)
+                            });
+                        task.refresh_grandpa_authority_sets(&sync, enacted_at);
 
                         if updates_best_block {
                             task.network_up_to_date_best = false;
@@ -1118,6 +1274,43 @@ pub(super) async fn start_substrate_compatible_chain<TPlat: PlatformRef>(
                 let _ = send_back.send(out);
             }
 
+            WakeUpReason::ForegroundMessage(ToBackground::SubscribeFinalityProofs {
+                send_back,
+                buffer_size,
+            }) => {
+                // Frontend wants to be notified of the finality proofs that we verify.
+                let (tx, rx) = async_channel::bounded(cmp::max(buffer_size, 1));
+                task.finality_proofs_subscriptions.push(tx);
+                let _ = send_back.send(rx);
+            }
+
+            WakeUpReason::ForegroundMessage(ToBackground::FinalityProof {
+                send_back,
+                block_hash,
+            }) => {
+                // Frontend is querying the finality proof of a specific block.
+                let outcome = task
+                    .mandatory_finality_proofs
+                    .get(&block_hash)
+                    .or_else(|| task.recent_finality_proofs.get(&block_hash))
+                    .cloned();
+                let _ = send_back.send(outcome);
+            }
+
+            WakeUpReason::ForegroundMessage(ToBackground::GrandpaAuthoritySetFor {
+                send_back,
+                block_number,
+            }) => {
+                // Frontend needs the authority set that finalized a specific block, in order to
+                // verify a justification it has fetched from the network.
+                let _ = send_back.send(task.grandpa_authority_set_for(block_number));
+            }
+
+            WakeUpReason::ForegroundMessage(ToBackground::RetainFinalityProof { proof }) => {
+                // Frontend has fetched and verified a proof and wants it cached.
+                task.retain_finality_proof(proof);
+            }
+
             WakeUpReason::ForegroundMessage(ToBackground::SerializeChainInformation {
                 send_back,
             }) => {
@@ -1614,6 +1807,9 @@ struct Task<TPlat: PlatformRef> {
     /// Access to the platform's capabilities.
     platform: TPlat,
 
+    /// Number of bytes of the block number in the networking protocol.
+    block_number_bytes: usize,
+
     /// Main syncing state machine. Contains a list of peers, requests, and blocks, and manages
     /// everything about the non-finalized chain.
     ///
@@ -1657,6 +1853,22 @@ struct Task<TPlat: PlatformRef> {
     /// All event subscribers that are interested in events about the chain.
     all_notifications: Vec<async_channel::Sender<Notification>>,
 
+    /// All subscribers that are interested in the finality proofs that we verify.
+    /// See [`super::SyncService::subscribe_finality_proofs`].
+    finality_proofs_subscriptions: Vec<async_channel::Sender<super::FinalityProof>>,
+
+    /// Finality proofs of the most recently finalized blocks, keyed by the hash of the block
+    /// that they finalize. See [`RECENT_FINALITY_PROOFS_CACHE_SIZE`].
+    recent_finality_proofs: lru::LruCache<[u8; 32], super::FinalityProof, util::SipHasherBuild>,
+    /// Same, for the blocks that change the Grandpa authority set. Kept apart so that a slow
+    /// consumer can't lose them to ordinary churn. See
+    /// [`MANDATORY_FINALITY_PROOFS_CACHE_SIZE`].
+    mandatory_finality_proofs: lru::LruCache<[u8; 32], super::FinalityProof, util::SipHasherBuild>,
+
+    /// Composition of the current Grandpa authority set and of a bounded number of its
+    /// predecessors, oldest first. See [`GRANDPA_AUTHORITY_SETS_HISTORY`].
+    grandpa_authority_sets: VecDeque<GrandpaAuthoritySet>,
+
     /// Contains a `Delay` after which we print a warning about GrandPa warp sync taking a long
     /// time. Set to `Pending` after the warp sync has finished, so that future remains pending
     /// forever.
@@ -1674,6 +1886,27 @@ struct Task<TPlat: PlatformRef> {
     >,
 }
 
+/// Returns `true` if the given SCALE-encoded header schedules a change of the Grandpa authority
+/// set.
+///
+/// An undecodable header is reported as not changing the set. It has been verified by the time
+/// this is called, and being wrong this way only sends its proof to the smaller cache.
+fn header_changes_authority_set(scale_encoded_header: &[u8], block_number_bytes: usize) -> bool {
+    let Ok(header) = header::decode(scale_encoded_header, block_number_bytes) else {
+        return false;
+    };
+
+    header.digest.logs().any(|log| {
+        matches!(
+            log,
+            header::DigestItemRef::GrandpaConsensus(
+                header::GrandpaConsensusLogRef::ScheduledChange(_)
+                    | header::GrandpaConsensusLogRef::ForcedChange { .. }
+            )
+        )
+    })
+}
+
 enum RequestOutcome {
     Block(Result<Vec<codec::BlockData>, network_service::BlocksRequestError>),
     WarpSync(
@@ -1687,6 +1920,99 @@ enum RequestOutcome {
 }
 
 impl<TPlat: PlatformRef> Task<TPlat> {
+    /// Reports a locally-verified finality proof to the subscribers, and keeps it around so
+    /// that [`super::SyncService::finality_proof`] can serve it.
+    ///
+    /// `changes_authority_set` routes the proof to the longer-lived cache; see
+    /// [`MANDATORY_FINALITY_PROOFS_CACHE_SIZE`].
+    fn on_verified_finality_proof(
+        &mut self,
+        proof: super::FinalityProof,
+        changes_authority_set: bool,
+    ) {
+        // Contrary to `dispatch_all_subscribers`, a subscriber whose buffer is full is kept:
+        // proofs are independent, so missing one doesn't leave it inconsistent.
+        self.finality_proofs_subscriptions
+            .retain(|subscription| !subscription.is_closed());
+        for subscription in &self.finality_proofs_subscriptions {
+            let _ = subscription.try_send(proof.clone());
+        }
+
+        if changes_authority_set {
+            self.mandatory_finality_proofs.put(proof.target_hash, proof);
+        } else {
+            self.recent_finality_proofs.put(proof.target_hash, proof);
+        }
+    }
+
+    /// Records the composition of the current Grandpa authority set, closing the previous entry
+    /// if the set has changed.
+    ///
+    /// `enacted_at` is the height of the highest just-finalized block that enacts a change of
+    /// authorities, if any. That block is finalized by the outgoing set, so it is recorded as
+    /// that set's last one.
+    fn refresh_grandpa_authority_sets<TRq, TSrc, TBl>(
+        &mut self,
+        sync: &all::AllSync<TRq, TSrc, TBl>,
+        enacted_at: Option<u64>,
+    ) {
+        let chain_information = sync.as_chain_information();
+        let chain_information = chain_information.as_ref();
+        let chain::chain_information::ChainInformationFinalityRef::Grandpa {
+            after_finalized_block_authorities_set_id,
+            finalized_triggered_authorities,
+            ..
+        } = chain_information.finality
+        else {
+            return;
+        };
+
+        if self
+            .grandpa_authority_sets
+            .back()
+            .is_some_and(|set| set.set_id == after_finalized_block_authorities_set_id)
+        {
+            return;
+        }
+
+        // The set has changed, or this is the first call.
+        let finalized_number = chain_information.finalized_block_header.number;
+        let boundary = enacted_at.unwrap_or(finalized_number);
+        if let Some(previous) = self.grandpa_authority_sets.back_mut() {
+            previous.last_block = Some(boundary);
+        }
+        self.grandpa_authority_sets.push_back(GrandpaAuthoritySet {
+            set_id: after_finalized_block_authorities_set_id,
+            authorities: finalized_triggered_authorities
+                .iter()
+                .map(|authority| authority.public_key)
+                .collect(),
+            first_block: boundary.saturating_add(1),
+            last_block: None,
+        });
+        while self.grandpa_authority_sets.len() > GRANDPA_AUTHORITY_SETS_HISTORY {
+            self.grandpa_authority_sets.pop_front();
+        }
+    }
+
+    /// Returns the identifier and composition of the Grandpa authority set that is responsible
+    /// for finalizing the given block, if it is known.
+    fn grandpa_authority_set_for(&self, block_number: u64) -> Option<(u64, Vec<[u8; 32]>)> {
+        self.grandpa_authority_sets
+            .iter()
+            .find(|set| {
+                block_number >= set.first_block
+                    && set.last_block.is_none_or(|last| block_number <= last)
+            })
+            .map(|set| (set.set_id, set.authorities.clone()))
+    }
+
+    /// Keeps a finality proof of an authority-set-change block around for
+    /// [`super::SyncService::finality_proof`], without reporting it to the subscribers.
+    fn retain_finality_proof(&mut self, proof: super::FinalityProof) {
+        self.mandatory_finality_proofs.put(proof.target_hash, proof);
+    }
+
     /// Sends a notification to all the notification receivers.
     fn dispatch_all_subscribers(&mut self, notification: Notification) {
         // Elements in `all_notifications` are removed one by one and inserted back if the

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- Add `grandpa_subscribeJustifications` and `grandpa_unsubscribeJustifications` to the legacy JSON-RPC API. Every time the light client verifies a Grandpa finality proof, the corresponding SCALE-encoded Grandpa justification is sent to the subscribers. Finality proofs that were received as Grandpa *commit* messages, which is the normal case in steady state, are re-encoded as justifications, with the headers that link every pre-commit back to the finalized block added to the `votes_ancestries` field. Pre-commits that the light client can't link back to the finalized block are left out, as a verifier assigns them no voting weight anyway. ([#3288](https://github.com/paritytech/smoldot/issues/3288))
+- `chain_getBlock` now returns the Grandpa justification of the requested block instead of always returning `null`: either the one the light client verified itself while finalizing that block, or the one a full node serves alongside the block, verified locally against the authority set that signed it. ([#3288](https://github.com/paritytech/smoldot/issues/3288))
+
 ## 3.4.1 - 2026-08-13
 
 ### Fixed


### PR DESCRIPTION
Closes paritytech/smoldot#3288.
Unblocks paritytech/parity-bridges-common#3270 (light-client bridge relayers).

## Why

A bridge relayer submits a finalized source-chain header **plus its SCALE-encoded GRANDPA justification** to a bridge pallet on the target chain, which re-verifies GRANDPA on-chain.

smoldot verifies these proofs internally and then discards them, and exposes no JSON-RPC method that returns one: `grandpa_subscribeJustifications` was not implemented and `chain_getBlock` always returned `justifications: null`. A relayer running against a light client therefore has nothing to submit, so the light-client transport cannot be used.

## How

- Adds `grandpa_subscribeJustifications` / `grandpa_unsubscribeJustifications`, a live feed of every finality proof the light client verifies.
- `chain_getBlock` now returns the block's justification instead of always `null`: either the proof verified locally while finalizing that block, or the one a peer serves alongside the block, verified locally before it is returned.
- In steady state finality arrives as a gossiped GRANDPA *commit* rather than a justification, so verified commits are re-encoded into equivalent justifications.
- Proofs for authority-set-change blocks, including those from warp sync, are retained longer than ordinary ones, since a relayer must submit them in order and cannot skip them.

Both methods match the Substrate legacy API, so a relayer needs no smoldot-specific code path.
