### PR TITLE
statement-store: deliver statement subscriptions like a full node

### DIFF
--- a/e2e-tests/shared/statement_store_reception.js
+++ b/e2e-tests/shared/statement_store_reception.js
@@ -71,6 +71,25 @@ export default async function statementStoreReception(ctx) {
   }
   report("statement_subscribeStatement accepted", true, `subId=${subId}`);
 
+  // The first notification must be the empty initial batch, the only one with `remaining`.
+  const initialBatch = await rpc.readJsonRpcUntil(
+    para,
+    (msg) => {
+      if (msg.method !== "statement_statement") return undefined;
+      if (msg.params?.subscription !== subId) return undefined;
+      return msg.params.result;
+    },
+    Date.now() + 20_000,
+  );
+  const initialOk =
+    initialBatch?.event === "newStatements" &&
+    Array.isArray(initialBatch.data?.statements) &&
+    initialBatch.data.statements.length === 0 &&
+    initialBatch.data.remaining === 0;
+  const initialDetail = JSON.stringify(initialBatch);
+  report("initial batch: empty newStatements with remaining 0", initialOk, initialDetail);
+  if (!initialOk) throw new Error(`unexpected initial batch: ${initialDetail}`);
+
   // Block until Rust signals that smoldot is peered with both collators at
   // the statement-store level. The listen window below only makes sense
   // after that point: both peers push stmt_A during their initial sync.
@@ -119,12 +138,22 @@ export default async function statementStoreReception(ctx) {
     `other first=${firstOtherMs}ms count=${countOther}`;
   report("reception: stmt_A received exactly once, stmt_B never, no stray statements", ok, detail);
 
-  // Unsubscribe as a best-effort cleanup. Terminating the client implicitly
-  // removes the subscription; the test doesn't fail on this RPC round-trip
-  // since pending notifications may delay the response past our budget.
-  try {
-    rpc.sendRpc(para, "statement_unsubscribeStatement", [subId]);
-  } catch (_) {}
+  // `true` for an active subscription, `false` for one already gone or never issued.
+  const unsubscribe = (id) => rpc.sendRpcAndWait(para, "statement_unsubscribeStatement", [id]);
+  const unsubAnswers = [
+    await unsubscribe(subId),
+    await unsubscribe(subId),
+    await unsubscribe("never-issued"),
+  ];
+  const unsubOk =
+    unsubAnswers[0] === true && unsubAnswers[1] === false && unsubAnswers[2] === false;
+  const unsubDetail = `answers=${JSON.stringify(unsubAnswers)} expected=[true,false,false]`;
+  report(
+    "statement_unsubscribeStatement: true for the active subscription, false once gone or unknown",
+    unsubOk,
+    unsubDetail,
+  );
 
   if (!ok) throw new Error(`reception assertion failed: ${detail}`);
+  if (!unsubOk) throw new Error(`unsubscribe assertion failed: ${unsubDetail}`);
 }

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -467,7 +467,14 @@ define_methods! {
     /// Validate a SCALE-encoded statement and broadcast it to peers (light node has no local
     /// statement-store).
     statement_submit(encoded: HexString) -> StatementSubmitResult,
-    /// Subscribe to statements matching the given filter. Returns subscription ID.
+    /// Subscribe to statements matching the given filter. Returns the subscription ID.
+    ///
+    /// Notifications arrive on `statement_statement` in polkadot-sdk's `StatementEvent` format. A
+    /// full node first replays the matching statements of its store in batches that carry
+    /// `remaining`. A light client has no store, so the first notification is always an empty
+    /// batch with `remaining: 0`. Statements that peers already hold arrive later as live
+    /// notifications without `remaining`, if a peer re-sends them. A delivered statement passed
+    /// the expiry and proof checks of `statement_submit`. Signatures are not verified.
     statement_subscribeStatement(filter: TopicFilter) -> Cow<'a, str>,
     /// Unsubscribe from statement notifications.
     statement_unsubscribeStatement(subscription: String) -> bool,

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -850,10 +850,14 @@ pub(super) async fn run<TPlat: PlatformRef>(
                 me.statement_events_rx = Some(me.network_service.subscribe_statements().await);
             }
 
-            WakeUpReason::NetworkStatementsReceived(statements) => {
+            WakeUpReason::NetworkStatementsReceived(mut statements) => {
                 if me.statement_subscriptions.is_empty() {
                     continue;
                 }
+
+                let now = me.platform.now_from_unix_epoch();
+                statements
+                    .retain(|(_, statement)| super::statement::is_deliverable(statement, now));
 
                 // The reverse `topic` -> `subscription` index inside `statement_subscriptions`
                 // keeps this proportional to the number of subscriptions sharing a topic with the
@@ -3044,10 +3048,25 @@ pub(super) async fn run<TPlat: PlatformRef>(
                         let _ = me
                             .responses_tx
                             .send(
-                                methods::Response::statement_subscribeStatement(Cow::Owned(
-                                    subscription_id,
+                                methods::Response::statement_subscribeStatement(Cow::Borrowed(
+                                    &subscription_id,
                                 ))
                                 .to_json_response(request_id_json),
+                            )
+                            .await;
+
+                        // The initial batch is always empty, see `statement_subscribeStatement`.
+                        let _ = me
+                            .responses_tx
+                            .send(
+                                methods::ServerToClient::statement_statement {
+                                    subscription: Cow::Owned(subscription_id),
+                                    result: methods::StatementEvent::NewStatements {
+                                        statements: Vec::new(),
+                                        remaining: Some(0),
+                                    },
+                                }
+                                .to_json_request_object_parameters(None),
                             )
                             .await;
                     }

--- a/light-base/src/json_rpc_service/statement.rs
+++ b/light-base/src/json_rpc_service/statement.rs
@@ -136,7 +136,7 @@ where
         return Err(StatementSubmitError::InvalidEncoding);
     };
 
-    if now_from_unix_epoch.as_secs() >= statement.expiry >> 32 {
+    if is_expired(&statement, now_from_unix_epoch) {
         return Ok(StatementSubmitResult::Invalid(
             InvalidReason::AlreadyExpired,
         ));
@@ -163,6 +163,18 @@ where
     }
 
     Ok(StatementSubmitResult::New)
+}
+
+/// Whether a statement received from a peer may be delivered to subscriptions: the checks of
+/// `statement_submit` that need no store, expiry and presence of a proof.
+pub(super) fn is_deliverable(statement: &codec::Statement, now_from_unix_epoch: Duration) -> bool {
+    !is_expired(statement, now_from_unix_epoch) && statement.proof.is_some()
+}
+
+/// The most significant 32 bits of `expiry` hold a UNIX timestamp in seconds. A statement expiring
+/// exactly now is already expired, as in polkadot-sdk.
+fn is_expired(statement: &codec::Statement, now_from_unix_epoch: Duration) -> bool {
+    now_from_unix_epoch.as_secs() >= statement.expiry >> 32
 }
 
 pub(super) struct StatementSubscription {
@@ -505,6 +517,25 @@ mod tests {
             result,
             Ok(StatementSubmitResult::Invalid(InvalidReason::NoProof))
         );
+    }
+
+    fn decoded_statement(with_proof: bool, expiry: u64) -> codec::Statement {
+        codec::decode_statement(&encoded_statement(with_proof, expiry, None)).unwrap()
+    }
+
+    #[test]
+    fn is_deliverable_requires_proof_and_future_expiry() {
+        assert!(is_deliverable(&decoded_statement(true, FUTURE_EXPIRY), NOW));
+        assert!(!is_deliverable(
+            &decoded_statement(false, FUTURE_EXPIRY),
+            NOW
+        ));
+        assert!(!is_deliverable(&decoded_statement(true, 500 << 32), NOW));
+        // Expiring exactly now counts as expired, as in `validate_and_broadcast_statement`.
+        assert!(!is_deliverable(
+            &decoded_statement(true, NOW.as_secs() << 32),
+            NOW
+        ));
     }
 
     #[test]

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- `statement_subscribeStatement` sends an empty `newStatements` batch with `remaining: 0` right after the subscription ID, as a full node does when its store holds nothing matching, and drops gossiped statements that are expired or carry no proof before matching them against subscriptions.
+- `statement_subscribeStatement` sends an empty `newStatements` batch with `remaining: 0` right after the subscription ID, as a full node does when its store holds nothing matching, and drops gossiped statements that are expired or carry no proof before matching them against subscriptions. ([#3371](https://github.com/paritytech/smoldot/pull/3371))
 
 ## 3.5.0 - 2026-09-09
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- `statement_subscribeStatement` sends an empty `newStatements` batch with `remaining: 0` right after the subscription ID, as a full node does when its store holds nothing matching, and drops gossiped statements that are expired or carry no proof before matching them against subscriptions.
+
 ## 3.5.0 - 2026-09-09
 
 ### Changed


### PR DESCRIPTION
Part of #3349

Follow-up to https://github.com/paritytech/smoldot/pull/3344, which aligned `statement_submit` with polkadot-sdk. This PR does the same for the subscription side: what a client gets right after subscribing, which gossiped statements reach it, and what `statement_unsubscribeStatement` returns.

## Fixes

* **Sent the initial batch.** A full node first replays its store's matching statements in chunks carrying `remaining`, and an empty batch with `remaining: 0` when nothing matches. smoldot sent nothing, so a client waiting for the end of the replay hung. A light client's initial set is always empty, so it now sends `{ "statements": [], "remaining": 0 }` right after the subscription id. Live notifications keep omitting `remaining`.
* **Validated gossiped statements.** A full node only notifies subscriptions of statements its store accepted. smoldot forwarded every decodable statement, so a subscriber could receive an expired statement or one without a proof. Both are now dropped before topic matching, with the same expiry and proof checks that `statement_submit` runs, in the same order. Signatures stay unverified, as in #3344.
* **Documented the gap.** The `statement_subscribeStatement` doc comment says what replaces the replay and which checks a delivered statement passed.

## Behavior parity

| Behavior | Full node | smoldot | |
|---|---|---|---|
| `TopicFilter` validation | `-32602` | `-32602` | ✅ |
| Initial batch | store matches in chunks, then `remaining: 0` | `{ "statements": [], "remaining": 0 }` | ✅ nothing to replay |
| Delivered statements | passed `Store::submit` | passed the expiry and proof checks | signatures unverified, as in #3344 |
| Unsubscribe active id | `true` | `true` | ✅ |
| Unsubscribe same id again | `false` | `false` | ✅ |
| Unsubscribe unknown id | `false` | `false` | ✅ |

The `statement_store_reception` job pins two things: the first notification on the subscription must be the empty batch with `remaining: 0`, and `statement_unsubscribeStatement` answers `true` for the active subscription and `false` for the same id again and for an unknown id. The best-effort fire-and-forget unsubscribe at the end of the test body became the assertion.

## Breaking

* Every subscription receives one extra notification right after the subscription id.
* Expired statements and statements without a proof are no longer delivered.

